### PR TITLE
feat(admin): improve sidebar navigation with grouping

### DIFF
--- a/apps/web-client/src/modules/admin/components/layout/Sidebar.tsx
+++ b/apps/web-client/src/modules/admin/components/layout/Sidebar.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { usePathname } from 'next/navigation';
 import Link from 'next/link';
 import type { Route } from 'next';
-import { Menu, FileText, Play, Tv, Newspaper } from 'lucide-react';
+import { Menu, FileText, Play, Tv, Newspaper, LayoutDashboard, Plug } from 'lucide-react';
 import { cn } from '@/shared/utils';
 import { NavigationItem } from '../../types';
 import { Button } from '@/shared/ui/button';
@@ -18,8 +18,12 @@ interface SidebarProps {
   className?: string;
 }
 
-// Icon mapping for navigation items
+// Icon mapping for navigation items and groups
 const iconMap: Record<string, React.ReactNode> = {
+  // Groups
+  catalog: <LayoutDashboard className="h-4 w-4" />,
+  integrations: <Plug className="h-4 w-4" />,
+  // Items
   policies: <FileText className="h-4 w-4" />,
   runs: <Play className="h-4 w-4" />,
   providers: <Tv className="h-4 w-4" />,
@@ -28,20 +32,25 @@ const iconMap: Record<string, React.ReactNode> = {
 
 // Translation key mapping for navigation items
 const labelMap: Record<string, string> = {
+  // Groups
+  catalog: 'admin.navigation.catalog',
+  integrations: 'admin.navigation.integrations',
+  // Items
   policies: 'admin.navigation.policies',
   runs: 'admin.navigation.runs',
   providers: 'admin.navigation.providers',
   journal: 'admin.navigation.journal',
 };
 
-// Items that should have a separator before them (visual grouping)
-const separatorBefore = new Set(['journal']);
+// Standalone items that should have a separator before them
+const standaloneItems = new Set(['journal']);
 
 /**
  * Sidebar - Responsive navigation component for admin interface
  *
  * Features:
  * - Responsive: Sheet on mobile (< 768px), fixed panel on desktop
+ * - Grouped navigation with section headers
  * - Navigation items with Button variant="ghost"
  * - Active state based on current route
  * - Permissions-based visibility
@@ -76,20 +85,19 @@ export function Sidebar({ navigationItems, userPermissions = [], className }: Si
     (item: NavigationItem) => {
       const translationKey = labelMap[item.id];
       if (translationKey) {
-        // Use nested object access for translation keys like 'admin.navigation.policies'
         const keys = translationKey.split('.');
-        let value: any = dict;
+        let value: unknown = dict;
         for (const key of keys) {
-          value = value?.[key];
+          value = (value as Record<string, unknown>)?.[key];
         }
-        return value || item.label;
+        return (value as string) || item.label;
       }
       return item.label;
     },
     [dict],
   );
 
-  // Render navigation item
+  // Render a single navigation item (leaf node)
   const renderNavItem = React.useCallback(
     (item: NavigationItem) => {
       const active = isActive(item.href);
@@ -98,19 +106,20 @@ export function Sidebar({ navigationItems, userPermissions = [], className }: Si
 
       return (
         <Link
+          key={item.id}
           href={item.href as Route}
-          onClick={() => setIsMobileOpen(false)} // Close mobile menu on navigation
-          className="block mb-1"
+          onClick={() => setIsMobileOpen(false)}
+          className="block"
         >
           <Button
             variant="ghost"
             className={cn(
-              'w-full justify-start py-3',
+              'w-full justify-start py-2.5 h-auto',
               active && 'bg-secondary text-secondary-foreground',
             )}
           >
-            {icon && <span className="mr-2 h-4 w-4">{icon}</span>}
-            <span className="flex-1">{label}</span>
+            {icon && <span className="mr-2.5 h-4 w-4 opacity-70">{icon}</span>}
+            <span className="flex-1 text-left">{label}</span>
             {item.badge && (
               <Badge variant="default" className="ml-auto">
                 {item.badge}
@@ -123,38 +132,55 @@ export function Sidebar({ navigationItems, userPermissions = [], className }: Si
     [isActive, getTranslatedLabel],
   );
 
-  // Render navigation list
+  // Render navigation list with groups
   const renderNavigation = () => (
-    <nav className="space-y-2">
-      {visibleItems.map((item) => {
-        const needsSeparator = separatorBefore.has(item.id);
+    <nav className="space-y-1">
+      {visibleItems.map((item, index) => {
+        const isStandalone = standaloneItems.has(item.id);
+        const hasChildren = item.children && item.children.length > 0;
 
-        if (item.children && item.children.length > 0) {
-          // Render nested navigation (future enhancement)
+        // Standalone item with separator
+        if (isStandalone && !hasChildren) {
           return (
-            <div key={item.id} className="space-y-1">
-              {needsSeparator && <div className="my-3 border-t border-border" />}
-              <div className="px-3 py-2 text-sm font-medium text-muted-foreground">
-                {item.label}
+            <React.Fragment key={item.id}>
+              {index > 0 && <div className="my-4 border-t border-border" />}
+              {renderNavItem(item)}
+            </React.Fragment>
+          );
+        }
+
+        // Group with children
+        if (hasChildren) {
+          const icon = item.icon || iconMap[item.id];
+          const label = getTranslatedLabel(item);
+          const filteredChildren = item.children!.filter((child) => {
+            if (child.disabled) return false;
+            if (!child.permissions || child.permissions.length === 0) return true;
+            return child.permissions.some((permission) => userPermissions.includes(permission));
+          });
+
+          if (filteredChildren.length === 0) return null;
+
+          return (
+            <div key={item.id} className={cn('space-y-1', index > 0 && 'mt-5')}>
+              {/* Group header */}
+              <div className="flex items-center gap-2 px-3 py-2">
+                {icon && <span className="h-4 w-4 text-muted-foreground">{icon}</span>}
+                <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                  {label}
+                </span>
               </div>
-              <div className="space-y-1 pl-4">
-                {item.children
-                  .filter((child) => {
-                    if (child.disabled) return false;
-                    if (!child.permissions || child.permissions.length === 0) return true;
-                    return child.permissions.some((permission) =>
-                      userPermissions.includes(permission),
-                    );
-                  })
-                  .map(renderNavItem)}
+              {/* Group children */}
+              <div className="space-y-0.5 pl-2">
+                {filteredChildren.map((child) => renderNavItem(child))}
               </div>
             </div>
           );
         }
 
+        // Regular standalone item without separator
         return (
           <React.Fragment key={item.id}>
-            {needsSeparator && <div className="my-3 border-t border-border" />}
             {renderNavItem(item)}
           </React.Fragment>
         );

--- a/apps/web-client/src/modules/admin/components/layout/Sidebar.tsx
+++ b/apps/web-client/src/modules/admin/components/layout/Sidebar.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { usePathname } from 'next/navigation';
 import Link from 'next/link';
 import type { Route } from 'next';
-import { Menu, FileText, Play, Tv } from 'lucide-react';
+import { Menu, FileText, Play, Tv, Newspaper } from 'lucide-react';
 import { cn } from '@/shared/utils';
 import { NavigationItem } from '../../types';
 import { Button } from '@/shared/ui/button';
@@ -23,6 +23,7 @@ const iconMap: Record<string, React.ReactNode> = {
   policies: <FileText className="h-4 w-4" />,
   runs: <Play className="h-4 w-4" />,
   providers: <Tv className="h-4 w-4" />,
+  journal: <Newspaper className="h-4 w-4" />,
 };
 
 // Translation key mapping for navigation items
@@ -30,7 +31,11 @@ const labelMap: Record<string, string> = {
   policies: 'admin.navigation.policies',
   runs: 'admin.navigation.runs',
   providers: 'admin.navigation.providers',
+  journal: 'admin.navigation.journal',
 };
+
+// Items that should have a separator before them (visual grouping)
+const separatorBefore = new Set(['journal']);
 
 /**
  * Sidebar - Responsive navigation component for admin interface
@@ -93,7 +98,6 @@ export function Sidebar({ navigationItems, userPermissions = [], className }: Si
 
       return (
         <Link
-          key={item.id}
           href={item.href as Route}
           onClick={() => setIsMobileOpen(false)} // Close mobile menu on navigation
           className="block mb-1"
@@ -123,10 +127,13 @@ export function Sidebar({ navigationItems, userPermissions = [], className }: Si
   const renderNavigation = () => (
     <nav className="space-y-2">
       {visibleItems.map((item) => {
+        const needsSeparator = separatorBefore.has(item.id);
+
         if (item.children && item.children.length > 0) {
           // Render nested navigation (future enhancement)
           return (
             <div key={item.id} className="space-y-1">
+              {needsSeparator && <div className="my-3 border-t border-border" />}
               <div className="px-3 py-2 text-sm font-medium text-muted-foreground">
                 {item.label}
               </div>
@@ -145,7 +152,12 @@ export function Sidebar({ navigationItems, userPermissions = [], className }: Si
           );
         }
 
-        return renderNavItem(item);
+        return (
+          <React.Fragment key={item.id}>
+            {needsSeparator && <div className="my-3 border-t border-border" />}
+            {renderNavItem(item)}
+          </React.Fragment>
+        );
       })}
     </nav>
   );

--- a/apps/web-client/src/modules/admin/config.ts
+++ b/apps/web-client/src/modules/admin/config.ts
@@ -6,26 +6,40 @@ import { NavigationItem } from './types';
 
 export const ADMIN_NAVIGATION: NavigationItem[] = [
   {
-    id: 'policies',
-    label: 'Політики', // Fallback label, will be translated
-    href: '/admin/policies',
-    permissions: ['admin.policies.read'],
+    id: 'catalog',
+    label: 'Каталог',
+    href: '/admin/policies', // Default to first child
+    children: [
+      {
+        id: 'policies',
+        label: 'Політики',
+        href: '/admin/policies',
+        permissions: ['admin.policies.read'],
+      },
+      {
+        id: 'runs',
+        label: 'Запуски',
+        href: '/admin/runs',
+        permissions: ['admin.runs.read'],
+      },
+    ],
   },
   {
-    id: 'runs',
-    label: 'Запуски оцінювання', // Fallback label, will be translated
-    href: '/admin/runs',
-    permissions: ['admin.runs.read'],
-  },
-  {
-    id: 'providers',
-    label: 'Провайдери', // Fallback label, will be translated
-    href: '/admin/providers',
-    permissions: ['admin.providers.read'],
+    id: 'integrations',
+    label: 'Інтеграції',
+    href: '/admin/providers', // Default to first child
+    children: [
+      {
+        id: 'providers',
+        label: 'Провайдери',
+        href: '/admin/providers',
+        permissions: ['admin.providers.read'],
+      },
+    ],
   },
   {
     id: 'journal',
-    label: 'Журнал', // Fallback label, will be translated
+    label: 'Журнал',
     href: '/admin/journal',
     permissions: ['admin.journal.read'],
   },
@@ -35,10 +49,24 @@ export const ADMIN_NAVIGATION: NavigationItem[] = [
  * Get admin navigation filtered by user permissions
  */
 export function getAdminNavigation(userPermissions: string[] = []): NavigationItem[] {
-  return ADMIN_NAVIGATION.filter((item) => {
-    if (!item.permissions || item.permissions.length === 0) {
-      return true;
+  return ADMIN_NAVIGATION.map((item) => {
+    // Filter children by permissions
+    if (item.children && item.children.length > 0) {
+      const filteredChildren = item.children.filter((child) => {
+        if (!child.permissions || child.permissions.length === 0) return true;
+        return child.permissions.some((permission) => userPermissions.includes(permission));
+      });
+
+      // Only include group if it has visible children
+      if (filteredChildren.length === 0) return null;
+
+      return { ...item, children: filteredChildren };
     }
-    return item.permissions.some((permission) => userPermissions.includes(permission));
-  });
+
+    // Filter standalone items by permissions
+    if (!item.permissions || item.permissions.length === 0) return item;
+    if (item.permissions.some((permission) => userPermissions.includes(permission))) return item;
+
+    return null;
+  }).filter((item): item is NavigationItem => item !== null);
 }

--- a/apps/web-client/src/shared/i18n/locales/en.json
+++ b/apps/web-client/src/shared/i18n/locales/en.json
@@ -606,8 +606,10 @@
   "admin": {
     "navigation": {
       "title": "Navigation",
+      "catalog": "Catalog",
+      "integrations": "Integrations",
       "policies": "Policies",
-      "runs": "Evaluation Runs",
+      "runs": "Runs",
       "providers": "Providers",
       "journal": "Journal"
     },

--- a/apps/web-client/src/shared/i18n/locales/uk.json
+++ b/apps/web-client/src/shared/i18n/locales/uk.json
@@ -606,8 +606,10 @@
   "admin": {
     "navigation": {
       "title": "Навігація",
+      "catalog": "Каталог",
+      "integrations": "Інтеграції",
       "policies": "Політики",
-      "runs": "Запуски оцінювання",
+      "runs": "Запуски",
       "providers": "Провайдери",
       "journal": "Журнал"
     },


### PR DESCRIPTION
## Summary
- Add Newspaper icon for Journal in admin sidebar
- Implement grouped navigation with section headers (Catalog, Integrations)
- Add visual separator before standalone Journal item
- Add translations for new navigation groups

## Test plan
- [ ] Verify admin sidebar displays groups correctly
- [ ] Check that icons appear for all navigation items
- [ ] Confirm translations work in both UK and EN locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)