### PR TITLE
perf(db): replace N+1 loops with batch INSERT operations

### DIFF
--- a/apps/api/src/modules/catalog/infrastructure/repositories/drizzle-show.repository.ts
+++ b/apps/api/src/modules/catalog/infrastructure/repositories/drizzle-show.repository.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 
-import { eq } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import { type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 
 import { MediaType } from '../../../../common/enums/media-type.enum';
@@ -102,7 +102,8 @@ export class DrizzleShowRepository implements IShowRepository {
   }
 
   /**
-   * Upserts episodes for a season.
+   * Upserts episodes for a season using batch INSERT.
+   * Uses single INSERT with ON CONFLICT DO UPDATE for better performance.
    */
   private async upsertEpisodes(
     drizzleTx: ReturnType<typeof toDrizzleTx>,
@@ -112,15 +113,23 @@ export class DrizzleShowRepository implements IShowRepository {
   ): Promise<void> {
     if (!episodes?.length) return;
 
-    for (const ep of episodes) {
-      await drizzleTx
-        .insert(schema.episodes)
-        .values(PersistenceMapper.toEpisodeInsert(seasonId, showId, ep))
-        .onConflictDoUpdate({
-          target: [schema.episodes.seasonId, schema.episodes.number],
-          set: PersistenceMapper.toEpisodeUpdate(ep),
-        });
-    }
+    const values = episodes.map((ep) => PersistenceMapper.toEpisodeInsert(seasonId, showId, ep));
+
+    await drizzleTx
+      .insert(schema.episodes)
+      .values(values)
+      .onConflictDoUpdate({
+        target: [schema.episodes.seasonId, schema.episodes.number],
+        set: {
+          tmdbId: sql`excluded.tmdb_id`,
+          title: sql`excluded.title`,
+          overview: sql`excluded.overview`,
+          airDate: sql`excluded.air_date`,
+          runtime: sql`excluded.runtime`,
+          stillPath: sql`excluded.still_path`,
+          voteAverage: sql`excluded.vote_average`,
+        },
+      });
   }
 
   /**

--- a/apps/api/src/modules/ingestion/domain/repositories/snapshots.repository.interface.ts
+++ b/apps/api/src/modules/ingestion/domain/repositories/snapshots.repository.interface.ts
@@ -39,6 +39,15 @@ export interface ISnapshotsRepository {
    * @returns {Promise<void>} Nothing
    */
   upsertSnapshot(data: SnapshotUpsertData): Promise<void>;
+
+  /**
+   * Bulk upserts watcher snapshots using a single INSERT statement.
+   * More efficient than multiple individual upserts.
+   *
+   * @param {SnapshotUpsertData[]} data - Array of snapshot data to upsert
+   * @returns {Promise<void>} Nothing
+   */
+  bulkUpsertSnapshots(data: SnapshotUpsertData[]): Promise<void>;
 }
 
 /**

--- a/apps/api/src/modules/ingestion/infrastructure/repositories/snapshots.repository.ts
+++ b/apps/api/src/modules/ingestion/infrastructure/repositories/snapshots.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable, Inject } from '@nestjs/common';
 
-import { eq } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import { type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 
 import { DATABASE_CONNECTION } from '../../../../database/database.module';
@@ -61,6 +61,34 @@ export class SnapshotsRepository implements ISnapshotsRepository {
         ],
         set: {
           totalWatchers: data.totalWatchers,
+        },
+      });
+  }
+
+  /**
+   * @inheritdoc
+   */
+  async bulkUpsertSnapshots(data: SnapshotUpsertData[]): Promise<void> {
+    if (data.length === 0) return;
+
+    const values = data.map((d) => ({
+      mediaItemId: d.mediaItemId,
+      snapshotDate: d.snapshotDate,
+      totalWatchers: d.totalWatchers,
+      region: d.region,
+    }));
+
+    await this.db
+      .insert(schema.mediaWatchersSnapshots)
+      .values(values)
+      .onConflictDoUpdate({
+        target: [
+          schema.mediaWatchersSnapshots.mediaItemId,
+          schema.mediaWatchersSnapshots.snapshotDate,
+          schema.mediaWatchersSnapshots.region,
+        ],
+        set: {
+          totalWatchers: sql`excluded.total_watchers`,
         },
       });
   }

--- a/apps/api/src/modules/stats/infrastructure/repositories/drizzle-stats.repository.spec.ts
+++ b/apps/api/src/modules/stats/infrastructure/repositories/drizzle-stats.repository.spec.ts
@@ -72,7 +72,7 @@ describe('DrizzleStatsRepository', () => {
   });
 
   describe('bulkUpsert', () => {
-    it('should upsert multiple stats', async () => {
+    it('should upsert multiple stats in a single batch', async () => {
       const mockDb = createMockDb();
 
       const module: TestingModule = await Test.createTestingModule({
@@ -87,7 +87,8 @@ describe('DrizzleStatsRepository', () => {
       ];
       await repository.bulkUpsert(stats);
 
-      expect(mockDb.insert).toHaveBeenCalledTimes(2);
+      // Should use single batch INSERT instead of N individual inserts
+      expect(mockDb.insert).toHaveBeenCalledTimes(1);
     });
 
     it('should return early if array is empty', async () => {

--- a/apps/api/src/modules/stats/infrastructure/repositories/drizzle-stats.repository.ts
+++ b/apps/api/src/modules/stats/infrastructure/repositories/drizzle-stats.repository.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 
-import { eq } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import { type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 
 import { withDbError } from '@/common/utils/db-error.utils';
@@ -68,35 +68,35 @@ export class DrizzleStatsRepository implements IStatsRepository {
       'bulk upsert stats',
       this.logger,
       async () => {
-        // Process each stat individually to ensure correct values on conflict
-        for (const stat of stats) {
-          await this.db
-            .insert(schema.mediaStats)
-            .values({
-              mediaItemId: stat.mediaItemId,
-              watchersCount: stat.watchersCount,
-              trendingRank: stat.trendingRank,
-              popularity24h: stat.popularity24h,
-              ratingoScore: stat.ratingoScore,
-              qualityScore: stat.qualityScore,
-              popularityScore: stat.popularityScore,
-              freshnessScore: stat.freshnessScore,
-              updatedAt: new Date(),
-            })
-            .onConflictDoUpdate({
-              target: schema.mediaStats.mediaItemId,
-              set: {
-                watchersCount: stat.watchersCount,
-                trendingRank: stat.trendingRank,
-                popularity24h: stat.popularity24h,
-                ratingoScore: stat.ratingoScore,
-                qualityScore: stat.qualityScore,
-                popularityScore: stat.popularityScore,
-                freshnessScore: stat.freshnessScore,
-                updatedAt: new Date(),
-              },
-            });
-        }
+        const now = new Date();
+        const values = stats.map((stat) => ({
+          mediaItemId: stat.mediaItemId,
+          watchersCount: stat.watchersCount,
+          trendingRank: stat.trendingRank,
+          popularity24h: stat.popularity24h,
+          ratingoScore: stat.ratingoScore,
+          qualityScore: stat.qualityScore,
+          popularityScore: stat.popularityScore,
+          freshnessScore: stat.freshnessScore,
+          updatedAt: now,
+        }));
+
+        await this.db
+          .insert(schema.mediaStats)
+          .values(values)
+          .onConflictDoUpdate({
+            target: schema.mediaStats.mediaItemId,
+            set: {
+              watchersCount: sql`excluded.watchers_count`,
+              trendingRank: sql`excluded.trending_rank`,
+              popularity24h: sql`excluded.popularity_24h`,
+              ratingoScore: sql`excluded.ratingo_score`,
+              qualityScore: sql`excluded.quality_score`,
+              popularityScore: sql`excluded.popularity_score`,
+              freshnessScore: sql`excluded.freshness_score`,
+              updatedAt: sql`excluded.updated_at`,
+            },
+          });
       },
       { count: stats.length },
     );


### PR DESCRIPTION
## Summary
- Replace episodes N+1 INSERT loop with single batch INSERT (~32k → ~200 queries per trending sync)
- Replace stats bulkUpsert N+1 loop with single batch INSERT (~400 → 1 query)
- Add `bulkUpsertSnapshots()` method for future optimizations

## Problem
PostgreSQL checkpoint storms observed during trending sync:
- Checkpoint write times: 212s and 134s
- ~2125 dirty buffers (17MB) being flushed
- Root cause: N+1 INSERT patterns in episodes, stats, and snapshots

## Solution
Replace `for...of` loops with individual INSERT statements with single batch INSERT using `excluded.*` syntax for ON CONFLICT DO UPDATE.

## Expected Impact
| Operation | Before | After | Reduction |
|-----------|--------|-------|-----------|
| Episodes per sync | ~32,000 INSERT | ~200 batch | 99.4% |
| Stats sync | ~400 INSERT | 1 batch | 99.8% |
| WAL pressure | ~15 MB/sync | ~2-3 MB/sync | ~80% |
| Checkpoint time | 212s | ~30-50s (expected) | ~75% |

## Test plan
- [x] Lint passes
- [x] Unit tests pass (updated stats test to expect single batch call)
- [x] Build compiles successfully
- [ ] Monitor checkpoint logs after next trending sync (every 4 hours)

🤖 Generated with [Claude Code](https://claude.com/claude-code)