### PR TITLE
feat(catalog-policy): add localMaturityOverride for fresh content with local engagement

### DIFF
--- a/apps/api/src/modules/catalog-policy/application/utils/policy-input.mapper.ts
+++ b/apps/api/src/modules/catalog-policy/application/utils/policy-input.mapper.ts
@@ -35,6 +35,7 @@ export interface MediaItemRow {
   popularityScore: number | null;
   freshnessScore: number | null;
   ratingoScore: number | null;
+  watchersCount: number | null;
 }
 
 /**
@@ -58,6 +59,7 @@ export const POLICY_EVALUATION_SELECT_FIELDS = {
   popularityScore: schema.mediaStats.popularityScore,
   freshnessScore: schema.mediaStats.freshnessScore,
   ratingoScore: schema.mediaStats.ratingoScore,
+  watchersCount: schema.mediaStats.watchersCount,
 };
 
 const DEFAULT_CONTENT_CLASS: ContentClass = 'mainstream';
@@ -112,6 +114,7 @@ export function mapRowToPolicyEngineInput(
     },
     // Normalize scores from 0-100 (DB format) to 0-1 (policy engine format)
     // Policy engine expects normalized values for minQualityScoreNormalized comparisons
+    // watchersCount is NOT normalized - it's a raw count, not a score
     stats:
       row.qualityScore !== null
         ? {
@@ -124,6 +127,7 @@ export function mapRowToPolicyEngineInput(
               row.freshnessScore !== null ? row.freshnessScore / SCORE_NORMALIZATION_DIVISOR : null,
             ratingoScore:
               row.ratingoScore !== null ? row.ratingoScore / SCORE_NORMALIZATION_DIVISOR : null,
+            watchersCount: row.watchersCount,
           }
         : null,
   };

--- a/apps/api/src/modules/catalog-policy/domain/constants/evaluation.constants.ts
+++ b/apps/api/src/modules/catalog-policy/domain/constants/evaluation.constants.ts
@@ -102,6 +102,9 @@ export const EvaluationReason = {
   // Missing global signals (for breakout evaluation)
   MISSING_GLOBAL_SIGNALS: 'MISSING_GLOBAL_SIGNALS',
 
+  // Local maturity override (fresh content with strong local engagement)
+  ALLOWED_LOCAL_MATURITY: 'ALLOWED_LOCAL_MATURITY',
+
   // Success reasons (return ELIGIBLE)
   BREAKOUT_ALLOWED: 'BREAKOUT_ALLOWED',
   ALLOWED_COUNTRY: 'ALLOWED_COUNTRY',

--- a/apps/api/src/modules/catalog-policy/domain/gates/global-requirements.gate.spec.ts
+++ b/apps/api/src/modules/catalog-policy/domain/gates/global-requirements.gate.spec.ts
@@ -4,8 +4,13 @@ import {
   shouldApplyGlobalGate,
   hasAnyRating,
   checkGlobalRequirements,
+  checkLocalMaturityOverride,
 } from './global-requirements.gate';
-import type { GlobalRequirements, PolicyEngineInput } from '../types/policy.types';
+import type {
+  GlobalRequirements,
+  LocalMaturityOverride,
+  PolicyEngineInput,
+} from '../types/policy.types';
 
 describe('GlobalRequirementsGate', () => {
   const createMediaItem = (
@@ -226,6 +231,214 @@ describe('GlobalRequirementsGate', () => {
 
       expect(result.passes).toBe(false);
       expect(result.failedChecks).toHaveLength(3);
+    });
+
+    describe('localMaturityOverride', () => {
+      const overrideConfig: LocalMaturityOverride = {
+        minFreshnessScoreNormalized: 0.9,
+        minLocalWatchers: 30,
+      };
+
+      it('should apply override when votes fail but freshness and watchers pass', () => {
+        const input = createInput(
+          { voteCountImdb: 500, voteCountTrakt: 500 },
+          {
+            qualityScore: 0.7,
+            popularityScore: 0.5,
+            freshnessScore: 0.95,
+            ratingoScore: 70,
+            watchersCount: 50,
+          },
+        );
+        const requirements: GlobalRequirements = {
+          minVotesAnyOf: { sources: [VoteSource.IMDB, VoteSource.TRAKT], min: 1000 },
+          localMaturityOverride: overrideConfig,
+        };
+
+        const result = checkGlobalRequirements(input, requirements);
+
+        expect(result.passes).toBe(true);
+        expect(result.localMaturityOverrideApplied).toBe(true);
+        expect(result.failedChecks).toHaveLength(0);
+      });
+
+      it('should NOT apply override when freshness is below threshold', () => {
+        const input = createInput(
+          { voteCountImdb: 500 },
+          {
+            qualityScore: 0.7,
+            popularityScore: 0.5,
+            freshnessScore: 0.5, // Below 0.9 threshold
+            ratingoScore: 70,
+            watchersCount: 50,
+          },
+        );
+        const requirements: GlobalRequirements = {
+          minVotesAnyOf: { sources: [VoteSource.IMDB], min: 1000 },
+          localMaturityOverride: overrideConfig,
+        };
+
+        const result = checkGlobalRequirements(input, requirements);
+
+        expect(result.passes).toBe(false);
+        expect(result.localMaturityOverrideApplied).toBeFalsy();
+        expect(result.failedChecks).toContain(GlobalGateCheck.MIN_VOTES);
+      });
+
+      it('should NOT apply override when watchers are below threshold', () => {
+        const input = createInput(
+          { voteCountImdb: 500 },
+          {
+            qualityScore: 0.7,
+            popularityScore: 0.5,
+            freshnessScore: 0.95,
+            ratingoScore: 70,
+            watchersCount: 10, // Below 30 threshold
+          },
+        );
+        const requirements: GlobalRequirements = {
+          minVotesAnyOf: { sources: [VoteSource.IMDB], min: 1000 },
+          localMaturityOverride: overrideConfig,
+        };
+
+        const result = checkGlobalRequirements(input, requirements);
+
+        expect(result.passes).toBe(false);
+        expect(result.localMaturityOverrideApplied).toBeFalsy();
+        expect(result.failedChecks).toContain(GlobalGateCheck.MIN_VOTES);
+      });
+
+      it('should NOT apply override when watchersCount is null', () => {
+        const input = createInput(
+          { voteCountImdb: 500 },
+          {
+            qualityScore: 0.7,
+            popularityScore: 0.5,
+            freshnessScore: 0.95,
+            ratingoScore: 70,
+            watchersCount: null,
+          },
+        );
+        const requirements: GlobalRequirements = {
+          minVotesAnyOf: { sources: [VoteSource.IMDB], min: 1000 },
+          localMaturityOverride: overrideConfig,
+        };
+
+        const result = checkGlobalRequirements(input, requirements);
+
+        expect(result.passes).toBe(false);
+        expect(result.failedChecks).toContain(GlobalGateCheck.MIN_VOTES);
+      });
+
+      it('should NOT check override when votes pass', () => {
+        const input = createInput(
+          { voteCountImdb: 5000 }, // Above threshold
+          {
+            qualityScore: 0.7,
+            popularityScore: 0.5,
+            freshnessScore: 0.1, // Low freshness - wouldn't pass override
+            ratingoScore: 70,
+            watchersCount: 5, // Low watchers - wouldn't pass override
+          },
+        );
+        const requirements: GlobalRequirements = {
+          minVotesAnyOf: { sources: [VoteSource.IMDB], min: 1000 },
+          localMaturityOverride: overrideConfig,
+        };
+
+        const result = checkGlobalRequirements(input, requirements);
+
+        expect(result.passes).toBe(true);
+        expect(result.localMaturityOverrideApplied).toBeFalsy();
+      });
+    });
+  });
+
+  describe('checkLocalMaturityOverride', () => {
+    const override: LocalMaturityOverride = {
+      minFreshnessScoreNormalized: 0.9,
+      minLocalWatchers: 30,
+    };
+
+    it('should return true when both freshness and watchers meet thresholds', () => {
+      const input = createInput(
+        {},
+        {
+          qualityScore: 0.5,
+          popularityScore: 0.5,
+          freshnessScore: 0.95,
+          ratingoScore: 50,
+          watchersCount: 50,
+        },
+      );
+
+      expect(checkLocalMaturityOverride(input, override)).toBe(true);
+    });
+
+    it('should return false when freshness is below threshold', () => {
+      const input = createInput(
+        {},
+        {
+          qualityScore: 0.5,
+          popularityScore: 0.5,
+          freshnessScore: 0.8,
+          ratingoScore: 50,
+          watchersCount: 50,
+        },
+      );
+
+      expect(checkLocalMaturityOverride(input, override)).toBe(false);
+    });
+
+    it('should return false when watchers are below threshold', () => {
+      const input = createInput(
+        {},
+        {
+          qualityScore: 0.5,
+          popularityScore: 0.5,
+          freshnessScore: 0.95,
+          ratingoScore: 50,
+          watchersCount: 20,
+        },
+      );
+
+      expect(checkLocalMaturityOverride(input, override)).toBe(false);
+    });
+
+    it('should return false when stats is null', () => {
+      const input = createInput({}, null);
+
+      expect(checkLocalMaturityOverride(input, override)).toBe(false);
+    });
+
+    it('should return false when freshnessScore is null', () => {
+      const input = createInput(
+        {},
+        {
+          qualityScore: 0.5,
+          popularityScore: 0.5,
+          freshnessScore: null,
+          ratingoScore: 50,
+          watchersCount: 50,
+        },
+      );
+
+      expect(checkLocalMaturityOverride(input, override)).toBe(false);
+    });
+
+    it('should return true when values exactly meet thresholds', () => {
+      const input = createInput(
+        {},
+        {
+          qualityScore: 0.5,
+          popularityScore: 0.5,
+          freshnessScore: 0.9, // Exactly at threshold
+          ratingoScore: 50,
+          watchersCount: 30, // Exactly at threshold
+        },
+      );
+
+      expect(checkLocalMaturityOverride(input, override)).toBe(true);
     });
   });
 });

--- a/apps/api/src/modules/catalog-policy/domain/gates/global-requirements.gate.ts
+++ b/apps/api/src/modules/catalog-policy/domain/gates/global-requirements.gate.ts
@@ -11,6 +11,7 @@ import {
   VoteSource,
   GlobalGateCheck,
   type GlobalRequirements,
+  type LocalMaturityOverride,
   type PolicyEngineInput,
   type GlobalGateCheckType,
 } from '../types/policy.types';
@@ -37,6 +38,8 @@ export interface GlobalRequirementsResult {
   passes: boolean;
   /** List of checks that failed */
   failedChecks: GlobalGateCheckType[];
+  /** True if local maturity override was applied (fresh content with local engagement) */
+  localMaturityOverrideApplied?: boolean;
 }
 
 /**
@@ -92,8 +95,39 @@ export function hasAnyRating(
 }
 
 /**
+ * Checks if local maturity override requirements are met.
+ * Validates freshness and local watchers thresholds.
+ *
+ * @param input - Media item data and stats
+ * @param override - Local maturity override configuration
+ * @returns True if both freshness and watchers requirements are met
+ */
+export function checkLocalMaturityOverride(
+  input: PolicyEngineInput,
+  override: LocalMaturityOverride,
+): boolean {
+  const { freshnessScore, watchersCount } = input.stats ?? {};
+
+  // Both freshness and watchers must meet thresholds
+  const hasFreshness =
+    freshnessScore !== null &&
+    freshnessScore !== undefined &&
+    freshnessScore >= override.minFreshnessScoreNormalized;
+
+  const hasWatchers =
+    watchersCount !== null &&
+    watchersCount !== undefined &&
+    watchersCount >= override.minLocalWatchers;
+
+  return hasFreshness && hasWatchers;
+}
+
+/**
  * Checks if media meets global quality requirements.
  * All configured conditions are combined with AND logic.
+ *
+ * When minVotesAnyOf fails and localMaturityOverride is configured,
+ * the override provides an alternative path for fresh content with local engagement.
  *
  * @param input - Media item data and stats
  * @param requirements - Global requirements configuration
@@ -109,6 +143,7 @@ export function checkGlobalRequirements(
 
   const failedChecks: GlobalGateCheckType[] = [];
   const { mediaItem } = input;
+  let localMaturityOverrideApplied = false;
 
   // Check minQualityScoreNormalized (null/undefined = fail)
   if (requirements.minQualityScoreNormalized !== undefined) {
@@ -139,13 +174,24 @@ export function checkGlobalRequirements(
       const votes = source === VoteSource.IMDB ? mediaItem.voteCountImdb : mediaItem.voteCountTrakt;
       return votes !== null && votes !== undefined && votes >= min;
     });
+
     if (!hasEnoughVotes) {
-      failedChecks.push(GlobalGateCheck.MIN_VOTES);
+      // Try localMaturityOverride as alternative path
+      if (
+        requirements.localMaturityOverride &&
+        checkLocalMaturityOverride(input, requirements.localMaturityOverride)
+      ) {
+        // Override applied - don't fail the votes check
+        localMaturityOverrideApplied = true;
+      } else {
+        failedChecks.push(GlobalGateCheck.MIN_VOTES);
+      }
     }
   }
 
   return {
     passes: failedChecks.length === 0,
     failedChecks,
+    localMaturityOverrideApplied,
   };
 }

--- a/apps/api/src/modules/catalog-policy/domain/gates/index.ts
+++ b/apps/api/src/modules/catalog-policy/domain/gates/index.ts
@@ -27,6 +27,7 @@ export {
 // Global Requirements Gate
 export {
   checkGlobalRequirements,
+  checkLocalMaturityOverride,
   hasAnyRating,
   shouldApplyGlobalGate,
   type GlobalGateFailedCheck,

--- a/apps/api/src/modules/catalog-policy/domain/policy-engine.ts
+++ b/apps/api/src/modules/catalog-policy/domain/policy-engine.ts
@@ -115,6 +115,7 @@ export function evaluateEligibility(
   }
 
   // STEP 5: GLOBAL QUALITY GATE - CONTEXT AWARE
+  let localMaturityOverrideApplied = false;
   if (shouldApplyGlobalGate(policy.globalRequirements, context)) {
     const gateResult = checkGlobalRequirements(input, policy.globalRequirements);
     if (!gateResult.passes) {
@@ -125,19 +126,28 @@ export function evaluateEligibility(
         globalGateDetails: { failedChecks: gateResult.failedChecks },
       };
     }
+    localMaturityOverrideApplied = gateResult.localMaturityOverrideApplied ?? false;
   }
 
   // STEP 6: NEUTRAL/ALLOWED CHECKS with breakout opportunity
   const neutralResult = checkNeutral(mediaItem, policy);
 
   if (neutralResult.isNeutral) {
-    return handleNeutralContent(input, policy, neutralResult.reasons);
+    return handleNeutralContent(input, policy, neutralResult.reasons, localMaturityOverrideApplied);
   }
 
   // Content is in allowed lists
+  const reasons: EvaluationReasonType[] = [
+    EvaluationReason.ALLOWED_COUNTRY,
+    EvaluationReason.ALLOWED_LANGUAGE,
+  ];
+  if (localMaturityOverrideApplied) {
+    reasons.push(EvaluationReason.ALLOWED_LOCAL_MATURITY);
+  }
+
   return {
     status: EligibilityStatus.ELIGIBLE,
-    reasons: [EvaluationReason.ALLOWED_COUNTRY, EvaluationReason.ALLOWED_LANGUAGE],
+    reasons,
     breakoutRuleId: null,
   };
 }
@@ -214,19 +224,29 @@ function handleNeutralContent(
   input: PolicyEngineInput,
   policy: PolicyConfig,
   neutralReasons: EvaluationReasonType[],
+  localMaturityOverrideApplied = false,
 ): Evaluation {
   // First try RELAXED mode eligibility
   const relaxedResult = tryRelaxedModeEligibility(input.mediaItem, policy);
-  if (relaxedResult) return relaxedResult;
+  if (relaxedResult) {
+    if (localMaturityOverrideApplied) {
+      relaxedResult.reasons = [...relaxedResult.reasons, EvaluationReason.ALLOWED_LOCAL_MATURITY];
+    }
+    return relaxedResult;
+  }
 
   // Global gate has already passed at this point (checked in main flow).
   // Try breakout rules for neutral content.
   const breakoutRule = findMatchingBreakoutRule(input, policy);
 
   if (breakoutRule) {
+    const reasons: EvaluationReasonType[] = [EvaluationReason.BREAKOUT_ALLOWED];
+    if (localMaturityOverrideApplied) {
+      reasons.push(EvaluationReason.ALLOWED_LOCAL_MATURITY);
+    }
     return {
       status: EligibilityStatus.ELIGIBLE,
-      reasons: [EvaluationReason.BREAKOUT_ALLOWED],
+      reasons,
       breakoutRuleId: breakoutRule.id,
     };
   }
@@ -300,6 +320,8 @@ export function getReasonDescriptions(
     [EvaluationReason.NEUTRAL_LANGUAGE]: 'Content is in a neutral language (not in allowed list)',
     [EvaluationReason.MISSING_GLOBAL_SIGNALS]:
       'Content lacks required global signals (ratings, votes, providers)',
+    [EvaluationReason.ALLOWED_LOCAL_MATURITY]:
+      'Content passed via local maturity override (fresh content with strong platform engagement)',
     [EvaluationReason.BREAKOUT_ALLOWED]: 'Content meets breakout rule requirements',
     [EvaluationReason.ALLOWED_COUNTRY]: 'Content is from an allowed country',
     [EvaluationReason.ALLOWED_LANGUAGE]: 'Content is in an allowed language',

--- a/apps/api/src/modules/catalog-policy/domain/repositories/dry-run.repository.interface.ts
+++ b/apps/api/src/modules/catalog-policy/domain/repositories/dry-run.repository.interface.ts
@@ -31,6 +31,7 @@ export interface DryRunMediaItem {
   popularityScore: number | null;
   freshnessScore: number | null;
   ratingoScore: number | null;
+  watchersCount: number | null;
 }
 
 /**

--- a/apps/api/src/modules/catalog-policy/domain/types/policy.types.ts
+++ b/apps/api/src/modules/catalog-policy/domain/types/policy.types.ts
@@ -78,12 +78,40 @@ export const GlobalGateCheck = {
   MIN_QUALITY_SCORE: 'minQualityScoreNormalized',
   REQUIRE_RATINGS: 'requireAnyOfRatingsPresent',
   MIN_VOTES: 'minVotesAnyOf',
+  LOCAL_MATURITY_OVERRIDE: 'localMaturityOverride',
 } as const;
 
 /**
  * Global gate failed check type.
  */
 export type GlobalGateCheckType = (typeof GlobalGateCheck)[keyof typeof GlobalGateCheck];
+
+/**
+ * Local maturity override configuration.
+ * Alternative path for fresh content with strong local platform engagement.
+ *
+ * When minVotesAnyOf fails, content can still pass if:
+ * - Freshness score meets threshold (indicating new release)
+ * - Local watchers count meets threshold (indicating platform engagement)
+ *
+ * This allows new releases that users are watching to appear in trending
+ * before they accumulate external votes from IMDb/Trakt.
+ */
+export interface LocalMaturityOverride {
+  /**
+   * Minimum freshness score normalized (0-1).
+   * Higher values = stricter freshness requirement.
+   * Example: 0.90 = must be in top 10% freshest content.
+   */
+  minFreshnessScoreNormalized: number;
+
+  /**
+   * Minimum Ratingo platform watchers count.
+   * Validates local engagement signal.
+   * Example: 30 = at least 30 users actively watching on platform.
+   */
+  minLocalWatchers: number;
+}
 
 /**
  * Global quality gate requirements.
@@ -115,6 +143,13 @@ export interface GlobalRequirements {
    * Defaults to ['catalog', 'homepage', 'trending', 'search'].
    */
   appliesTo?: EvaluationContext[];
+
+  /**
+   * Alternative path for fresh content with local engagement.
+   * Applied only when minVotesAnyOf check fails.
+   * Allows new releases with strong platform signals to bypass vote requirements.
+   */
+  localMaturityOverride?: LocalMaturityOverride;
 }
 
 /**
@@ -357,6 +392,11 @@ export interface PolicyEngineInput {
     popularityScore: number | null;
     freshnessScore: number | null;
     ratingoScore: number | null;
+    /**
+     * Current live watchers count from Ratingo platform.
+     * Used for localMaturityOverride gate checks.
+     */
+    watchersCount?: number | null;
   } | null;
 }
 

--- a/apps/api/src/modules/catalog-policy/domain/validation/policy.schema.spec.ts
+++ b/apps/api/src/modules/catalog-policy/domain/validation/policy.schema.spec.ts
@@ -281,6 +281,90 @@ describe('Policy Schema Validation', () => {
     });
   });
 
+  describe('localMaturityOverride validation', () => {
+    it('should accept valid localMaturityOverride', () => {
+      const policy = createValidPolicy({
+        globalRequirements: {
+          minVotesAnyOf: { sources: ['imdb', 'trakt'], min: 1000 },
+          localMaturityOverride: {
+            minFreshnessScoreNormalized: 0.9,
+            minLocalWatchers: 30,
+          },
+        },
+      });
+
+      const result = validatePolicyOrThrow(policy);
+      expect(result.globalRequirements?.localMaturityOverride).toBeDefined();
+      expect(result.globalRequirements?.localMaturityOverride?.minFreshnessScoreNormalized).toBe(
+        0.9,
+      );
+      expect(result.globalRequirements?.localMaturityOverride?.minLocalWatchers).toBe(30);
+    });
+
+    it('should accept globalRequirements without localMaturityOverride', () => {
+      const policy = createValidPolicy({
+        globalRequirements: {
+          minVotesAnyOf: { sources: ['imdb'], min: 1000 },
+        },
+      });
+
+      const result = validatePolicyOrThrow(policy);
+      expect(result.globalRequirements?.localMaturityOverride).toBeUndefined();
+    });
+
+    it('should reject localMaturityOverride with minFreshnessScoreNormalized > 1', () => {
+      const policy = createValidPolicy({
+        globalRequirements: {
+          localMaturityOverride: {
+            minFreshnessScoreNormalized: 1.5,
+            minLocalWatchers: 30,
+          },
+        },
+      });
+
+      expect(() => validatePolicyOrThrow(policy)).toThrow();
+    });
+
+    it('should reject localMaturityOverride with minFreshnessScoreNormalized < 0', () => {
+      const policy = createValidPolicy({
+        globalRequirements: {
+          localMaturityOverride: {
+            minFreshnessScoreNormalized: -0.1,
+            minLocalWatchers: 30,
+          },
+        },
+      });
+
+      expect(() => validatePolicyOrThrow(policy)).toThrow();
+    });
+
+    it('should reject localMaturityOverride with negative minLocalWatchers', () => {
+      const policy = createValidPolicy({
+        globalRequirements: {
+          localMaturityOverride: {
+            minFreshnessScoreNormalized: 0.9,
+            minLocalWatchers: -10,
+          },
+        },
+      });
+
+      expect(() => validatePolicyOrThrow(policy)).toThrow();
+    });
+
+    it('should reject localMaturityOverride with missing required fields', () => {
+      const policy = createValidPolicy({
+        globalRequirements: {
+          localMaturityOverride: {
+            minFreshnessScoreNormalized: 0.9,
+            // missing minLocalWatchers
+          } as any,
+        },
+      });
+
+      expect(() => validatePolicyOrThrow(policy)).toThrow();
+    });
+  });
+
   describe('isPolicyConfig', () => {
     it('should return true for valid policy', () => {
       const policy = createValidPolicy();

--- a/apps/api/src/modules/catalog-policy/domain/validation/policy.schema.ts
+++ b/apps/api/src/modules/catalog-policy/domain/validation/policy.schema.ts
@@ -39,6 +39,12 @@ const BreakoutRuleSchema = z.object({
   }),
 });
 
+/** Local maturity override schema. */
+const LocalMaturityOverrideSchema = z.object({
+  minFreshnessScoreNormalized: z.number().min(0).max(1),
+  minLocalWatchers: z.number().int().min(0),
+});
+
 /** Global quality gate requirements schema. */
 const GlobalRequirementsSchema = z.object({
   minQualityScoreNormalized: z.number().min(0).max(1).optional(),
@@ -50,6 +56,7 @@ const GlobalRequirementsSchema = z.object({
     })
     .optional(),
   appliesTo: z.array(z.enum(VALID_CONTEXTS)).optional(),
+  localMaturityOverride: LocalMaturityOverrideSchema.optional(),
 });
 
 /** Context-specific display requirements schema. */

--- a/apps/api/src/modules/catalog-policy/infrastructure/repositories/dry-run.repository.ts
+++ b/apps/api/src/modules/catalog-policy/infrastructure/repositories/dry-run.repository.ts
@@ -37,6 +37,7 @@ const DRY_RUN_SELECT_FIELDS = {
   popularityScore: schema.mediaStats.popularityScore,
   freshnessScore: schema.mediaStats.freshnessScore,
   ratingoScore: schema.mediaStats.ratingoScore,
+  watchersCount: schema.mediaStats.watchersCount,
 };
 
 @Injectable()
@@ -64,7 +65,8 @@ export class DryRunRepository implements IDryRunRepository {
         ms.quality_score as "qualityScore",
         ms.popularity_score as "popularityScore",
         ms.freshness_score as "freshnessScore",
-        ms.ratingo_score as "ratingoScore"
+        ms.ratingo_score as "ratingoScore",
+        ms.watchers_count as "watchersCount"
       FROM media_items mi TABLESAMPLE BERNOULLI(${samplePercent})
       LEFT JOIN media_stats ms ON mi.id = ms.media_item_id
       WHERE mi.deleted_at IS NULL

--- a/apps/api/src/modules/catalog-policy/presentation/dto/global-requirements.dto.ts
+++ b/apps/api/src/modules/catalog-policy/presentation/dto/global-requirements.dto.ts
@@ -65,6 +65,38 @@ export class MinVotesAnyOfDto {
 }
 
 /**
+ * Local maturity override configuration DTO.
+ * Alternative path for fresh content with strong local platform engagement.
+ */
+export class LocalMaturityOverrideDto {
+  @ApiPropertyOptional({
+    description:
+      'Minimum freshness score normalized (0-1). ' +
+      'Higher values = stricter freshness requirement. ' +
+      'Example: 0.90 = must be in top 10% freshest content.',
+    example: 0.9,
+    minimum: 0,
+    maximum: 1,
+  })
+  @IsNumber()
+  @Min(0)
+  @Max(1)
+  minFreshnessScoreNormalized: number;
+
+  @ApiPropertyOptional({
+    description:
+      'Minimum Ratingo platform watchers count. ' +
+      'Validates local engagement signal. ' +
+      'Example: 30 = at least 30 users actively watching on platform.',
+    example: 30,
+    minimum: 0,
+  })
+  @IsInt()
+  @Min(0)
+  minLocalWatchers: number;
+}
+
+/**
  * Global requirements DTO for API validation.
  * Defines minimum quality thresholds for all content.
  */
@@ -116,4 +148,16 @@ export class GlobalRequirementsDto {
   @IsArray()
   @IsIn(EVALUATION_CONTEXTS, { each: true })
   appliesTo?: EvaluationContext[];
+
+  @ApiPropertyOptional({
+    description:
+      'Alternative path for fresh content with local engagement. ' +
+      'Applied only when minVotesAnyOf check fails. ' +
+      'Allows new releases with strong platform signals to bypass vote requirements.',
+    type: LocalMaturityOverrideDto,
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => LocalMaturityOverrideDto)
+  localMaturityOverride?: LocalMaturityOverrideDto;
 }

--- a/apps/api/test/catalog-policy/policy-engine-business-logic.e2e-spec.ts
+++ b/apps/api/test/catalog-policy/policy-engine-business-logic.e2e-spec.ts
@@ -35,6 +35,7 @@ function createMediaItem(overrides: Partial<DryRunMediaItem> = {}): DryRunMediaI
     popularityScore: 60,
     freshnessScore: 50,
     ratingoScore: 70,
+    watchersCount: null,
     ...overrides,
   };
 }
@@ -181,6 +182,63 @@ const MISSING_METADATA = createMediaItem({
   voteCountImdb: 50000,
   qualityScore: 70,
   ratingoScore: 65,
+});
+
+// Local Maturity Override test items - fresh content with local engagement
+const FRESH_WITH_WATCHERS = createMediaItem({
+  id: 'fresh-with-watchers',
+  title: 'Knight of the Seven Kingdoms',
+  originCountries: ['US'],
+  originalLanguage: 'en',
+  contentClass: 'mainstream',
+  voteCountImdb: 500, // Low - fails minVotesAnyOf
+  voteCountTrakt: 367, // Low - fails minVotesAnyOf
+  qualityScore: 80,
+  freshnessScore: 95, // High freshness (0.95 normalized)
+  watchersCount: 69, // Strong local engagement
+  ratingoScore: 75,
+});
+
+const FRESH_LOW_WATCHERS = createMediaItem({
+  id: 'fresh-low-watchers',
+  title: 'New Show Low Engagement',
+  originCountries: ['US'],
+  originalLanguage: 'en',
+  contentClass: 'mainstream',
+  voteCountImdb: 500, // Low
+  voteCountTrakt: 300, // Low
+  qualityScore: 70,
+  freshnessScore: 95, // High freshness
+  watchersCount: 10, // Too few watchers
+  ratingoScore: 65,
+});
+
+const OLD_WITH_WATCHERS = createMediaItem({
+  id: 'old-with-watchers',
+  title: 'Old Show With Engagement',
+  originCountries: ['US'],
+  originalLanguage: 'en',
+  contentClass: 'mainstream',
+  voteCountImdb: 500, // Low
+  voteCountTrakt: 400, // Low
+  qualityScore: 75,
+  freshnessScore: 30, // Low freshness - old content
+  watchersCount: 100, // High watchers
+  ratingoScore: 70,
+});
+
+const HIGH_VOTES_LOW_FRESHNESS = createMediaItem({
+  id: 'high-votes-low-freshness',
+  title: 'Established Hit',
+  originCountries: ['US'],
+  originalLanguage: 'en',
+  contentClass: 'mainstream',
+  voteCountImdb: 100000, // High - passes minVotesAnyOf
+  voteCountTrakt: 50000, // High
+  qualityScore: 85,
+  freshnessScore: 20, // Low freshness
+  watchersCount: 5, // Low watchers - doesn't matter since votes pass
+  ratingoScore: 80,
 });
 
 // ============================================================================
@@ -877,6 +935,153 @@ describe('Policy Engine Business Logic (e2e)', () => {
       const breakdown = res.body.data.summary.reasonBreakdown;
       expect(breakdown).toBeDefined();
       expect(Array.isArray(breakdown)).toBe(true);
+    });
+  });
+
+  // ==========================================================================
+  // Local Maturity Override (Fresh Content with Local Engagement)
+  // ==========================================================================
+
+  describe('Local Maturity Override', () => {
+    const localMaturityPolicy = createTestPolicy({
+      allowedCountries: ['US', 'UA'],
+      blockedCountries: ['RU'],
+      allowedLanguages: ['en', 'uk'],
+      blockedLanguages: ['ru'],
+      globalRequirements: {
+        appliesTo: ['catalog'],
+        minVotesAnyOf: {
+          min: 1000, // Requires 1000 votes from IMDb or Trakt
+          sources: ['imdb', 'trakt'],
+        },
+        localMaturityOverride: {
+          minFreshnessScoreNormalized: 0.9, // 90% freshness (score >= 90)
+          minLocalWatchers: 30, // At least 30 Ratingo users watching
+        },
+      },
+    });
+
+    it('should allow fresh content with local engagement despite low votes', async () => {
+      ctx.dryRunRepo.setItems([FRESH_WITH_WATCHERS]);
+
+      const res = await ctx
+        .post('/dry-run', {
+          policy: localMaturityPolicy,
+          options: { mode: 'sample', limit: 10 },
+        })
+        .expect(200);
+
+      const item = res.body.data.items[0];
+      expect(item.proposedStatus).toBe('eligible');
+      expect(item.reasons).toContain('ALLOWED_LOCAL_MATURITY');
+    });
+
+    it('should reject fresh content with insufficient local watchers', async () => {
+      ctx.dryRunRepo.setItems([FRESH_LOW_WATCHERS]);
+
+      const res = await ctx
+        .post('/dry-run', {
+          policy: localMaturityPolicy,
+          options: { mode: 'sample', limit: 10 },
+        })
+        .expect(200);
+
+      const item = res.body.data.items[0];
+      expect(item.proposedStatus).toBe('ineligible');
+      expect(item.reasons).toContain('MISSING_GLOBAL_SIGNALS');
+    });
+
+    it('should reject old content with local watchers (freshness too low)', async () => {
+      ctx.dryRunRepo.setItems([OLD_WITH_WATCHERS]);
+
+      const res = await ctx
+        .post('/dry-run', {
+          policy: localMaturityPolicy,
+          options: { mode: 'sample', limit: 10 },
+        })
+        .expect(200);
+
+      const item = res.body.data.items[0];
+      expect(item.proposedStatus).toBe('ineligible');
+      expect(item.reasons).toContain('MISSING_GLOBAL_SIGNALS');
+    });
+
+    it('should allow content with high votes regardless of freshness/watchers', async () => {
+      ctx.dryRunRepo.setItems([HIGH_VOTES_LOW_FRESHNESS]);
+
+      const res = await ctx
+        .post('/dry-run', {
+          policy: localMaturityPolicy,
+          options: { mode: 'sample', limit: 10 },
+        })
+        .expect(200);
+
+      const item = res.body.data.items[0];
+      expect(item.proposedStatus).toBe('eligible');
+      // Should NOT have ALLOWED_LOCAL_MATURITY since votes passed directly
+      expect(item.reasons).not.toContain('ALLOWED_LOCAL_MATURITY');
+    });
+
+    it('should work correctly with mixed items', async () => {
+      ctx.dryRunRepo.setItems([
+        FRESH_WITH_WATCHERS, // Should pass via local maturity
+        FRESH_LOW_WATCHERS, // Should fail - low watchers
+        OLD_WITH_WATCHERS, // Should fail - low freshness
+        HIGH_VOTES_LOW_FRESHNESS, // Should pass via votes
+      ]);
+
+      const res = await ctx
+        .post('/dry-run', {
+          policy: localMaturityPolicy,
+          options: { mode: 'sample', limit: 10 },
+        })
+        .expect(200);
+
+      const items = res.body.data.items;
+
+      const freshWithWatchers = items.find((i: any) => i.mediaItemId === 'fresh-with-watchers');
+      const freshLowWatchers = items.find((i: any) => i.mediaItemId === 'fresh-low-watchers');
+      const oldWithWatchers = items.find((i: any) => i.mediaItemId === 'old-with-watchers');
+      const highVotes = items.find((i: any) => i.mediaItemId === 'high-votes-low-freshness');
+
+      expect(freshWithWatchers.proposedStatus).toBe('eligible');
+      expect(freshLowWatchers.proposedStatus).toBe('ineligible');
+      expect(oldWithWatchers.proposedStatus).toBe('ineligible');
+      expect(highVotes.proposedStatus).toBe('eligible');
+
+      // Summary should show 2 eligible, 2 ineligible
+      expect(res.body.data.summary.eligible).toBe(2);
+      expect(res.body.data.summary.ineligible).toBe(2);
+    });
+
+    it('should NOT apply local maturity override when not configured', async () => {
+      ctx.dryRunRepo.setItems([FRESH_WITH_WATCHERS]);
+
+      const policyWithoutOverride = createTestPolicy({
+        allowedCountries: ['US'],
+        blockedCountries: ['RU'],
+        allowedLanguages: ['en'],
+        blockedLanguages: ['ru'],
+        globalRequirements: {
+          appliesTo: ['catalog'],
+          minVotesAnyOf: {
+            min: 1000,
+            sources: ['imdb', 'trakt'],
+          },
+          // No localMaturityOverride configured
+        },
+      });
+
+      const res = await ctx
+        .post('/dry-run', {
+          policy: policyWithoutOverride,
+          options: { mode: 'sample', limit: 10 },
+        })
+        .expect(200);
+
+      const item = res.body.data.items[0];
+      expect(item.proposedStatus).toBe('ineligible');
+      expect(item.reasons).toContain('MISSING_GLOBAL_SIGNALS');
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds `localMaturityOverride` - an alternative path for fresh content with strong local platform engagement to bypass the `minVotesAnyOf` requirement.

**Problem:** New releases like "Лицар Сімох Королівств" weren't appearing in trending because they don't have 1000+ votes on IMDb/Trakt yet, despite having active Ratingo users watching.

**Solution:** Allow content to pass global requirements if it meets freshness AND local engagement thresholds.

## Changes

- Added `LocalMaturityOverride` type to domain
- Added `ALLOWED_LOCAL_MATURITY` evaluation reason
- Added `checkLocalMaturityOverride()` gate function
- Added `watchersCount` to policy engine input
- Updated DTOs with validation
- Added comprehensive tests (unit + e2e)

## Configuration

```json
{
  "globalRequirements": {
    "minVotesAnyOf": { "sources": ["imdb", "trakt"], "min": 1000 },
    "localMaturityOverride": {
      "minFreshnessScoreNormalized": 0.90,
      "minLocalWatchers": 30
    }
  }
}
```

## Test plan

- [x] Unit tests for `checkLocalMaturityOverride()` gate (12 tests)
- [x] Schema validation tests (6 tests)
- [x] E2E tests for localMaturityOverride scenarios (6 tests)
- [x] Manual dry-run verification - "Лицар Сімох Королівств" now gets `ALLOWED_LOCAL_MATURITY`
- [x] Policy v3 created and promoted with feature enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)