### PR TITLE
fix(web-client): reduce CDN stale-while-revalidate from 1 year to 1 hour

### DIFF
--- a/apps/web-client/next.config.js
+++ b/apps/web-client/next.config.js
@@ -2,6 +2,13 @@
 const nextConfig = {
   reactStrictMode: true,
   typedRoutes: true,
+  expireTime: 3600,
+  experimental: {
+    staleTimes: {
+      dynamic: 60,
+      static: 300,
+    },
+  },
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## Summary

- CDN was serving stale content for up to **1 year** (`stale-while-revalidate=31535940`)
- Home page showed outdated trending data even though `revalidate = 60` was set
- Root cause: Next.js default `stale-while-revalidate` is ~1 year

## Changes

| Config | Before | After |
|--------|--------|-------|
| CDN `stale-while-revalidate` | 365 days | **1 hour** (`expireTime: 3600`) |
| Client router cache (dynamic) | 0s | 60s |
| Client router cache (static) | 5 min | 5 min |

## Expected headers after deploy

```
cache-control: s-maxage=60, stale-while-revalidate=3600
```

## Test plan

- [x] All backend tests pass (2557)
- [x] All frontend tests pass (292)
- [x] Lint passes
- [ ] Verify cache headers after deploy

🤖 Generated with [Claude Code](https://claude.ai/code)