### PR TITLE
fix(trending): lower movie watchers threshold and cleanup stale ranks

### DIFF
--- a/apps/api/src/modules/catalog/domain/constants/catalog.constants.ts
+++ b/apps/api/src/modules/catalog/domain/constants/catalog.constants.ts
@@ -80,7 +80,7 @@ export const TRENDING_THRESHOLDS = {
   /** Minimum live watchers for shows to appear in trending (strong live signal) */
   MIN_WATCHERS_SHOWS: 10,
   /** Minimum live watchers for movies to appear in trending (weaker live signal) */
-  MIN_WATCHERS_MOVIES: 5,
+  MIN_WATCHERS_MOVIES: 2,
 } as const;
 
 /**

--- a/apps/api/src/modules/catalog/domain/repositories/media.repository.interface.ts
+++ b/apps/api/src/modules/catalog/domain/repositories/media.repository.interface.ts
@@ -239,6 +239,15 @@ export interface IMediaRepository {
   findSnapshotCandidates(options: { cursor?: string; limit: number }): Promise<SnapshotCandidate[]>;
 
   /**
+   * Clears trending_rank and trending_score for items not updated since `before`.
+   * Used to remove stale trending data after a fresh sync cycle completes.
+   *
+   * @param {Date} before - Cutoff date; items with trending_updated_at < before are cleared
+   * @returns {Promise<number>} Number of items cleared
+   */
+  clearStaleTrendingRanks(before: Date): Promise<number>;
+
+  /**
    * Finds homepage candidates with stale stats that need refresh.
    * Covers both Hero and Watching-Now sections.
    *

--- a/apps/api/src/modules/catalog/infrastructure/queries/shared/trending-conditions.builder.spec.ts
+++ b/apps/api/src/modules/catalog/infrastructure/queries/shared/trending-conditions.builder.spec.ts
@@ -79,8 +79,8 @@ describe('trending-conditions.builder', () => {
         const options: TrendingMovieConditionsOptions = { context: 'catalog' };
         const conditions = buildTrendingMovieConditions(mockDb, options);
 
-        // MIN_WATCHERS_MOVIES = 5
-        expect(TRENDING_THRESHOLDS.MIN_WATCHERS_MOVIES).toBe(5);
+        // MIN_WATCHERS_MOVIES = 2
+        expect(TRENDING_THRESHOLDS.MIN_WATCHERS_MOVIES).toBe(2);
         // Condition is always added (7th base condition)
         expect(conditions.length).toBeGreaterThanOrEqual(7);
       });

--- a/apps/api/src/modules/catalog/infrastructure/queries/trending-queries.property.spec.ts
+++ b/apps/api/src/modules/catalog/infrastructure/queries/trending-queries.property.spec.ts
@@ -562,8 +562,8 @@ describe('Trending Queries - Watchers Gate Property Tests', () => {
   });
 
   describe('Property: Threshold constants are correctly configured', () => {
-    it('movies threshold is 5', () => {
-      expect(TRENDING_THRESHOLDS.MIN_WATCHERS_MOVIES).toBe(5);
+    it('movies threshold is 2', () => {
+      expect(TRENDING_THRESHOLDS.MIN_WATCHERS_MOVIES).toBe(2);
     });
 
     it('shows threshold is 10', () => {

--- a/apps/api/src/modules/catalog/infrastructure/repositories/drizzle-media.repository.ts
+++ b/apps/api/src/modules/catalog/infrastructure/repositories/drizzle-media.repository.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 
-import { eq, inArray, sql, and, desc, gt, gte, isNull, isNotNull } from 'drizzle-orm';
+import { eq, inArray, sql, and, desc, gt, gte, lt, isNull, isNotNull } from 'drizzle-orm';
 import { type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 
 import { DB_CONSTRAINT } from '../../../../common/constants/database.constants';
@@ -988,5 +988,23 @@ export class DrizzleMediaRepository implements IMediaRepository {
         minQualityScore: options.minQualityScore,
       },
     );
+  }
+
+  async clearStaleTrendingRanks(before: Date): Promise<number> {
+    return withDbError('clear stale trending ranks', this.logger, async () => {
+      const result = await this.db
+        .update(schema.mediaItems)
+        .set({ trendingRank: null, trendingScore: 0 })
+        .where(
+          and(
+            isNotNull(schema.mediaItems.trendingRank),
+            lt(schema.mediaItems.trendingUpdatedAt, before),
+            isNull(schema.mediaItems.deletedAt),
+          ),
+        )
+        .returning({ id: schema.mediaItems.id });
+
+      return result.length;
+    });
   }
 }

--- a/apps/api/src/modules/ingestion/application/pipelines/trending.pipeline.spec.ts
+++ b/apps/api/src/modules/ingestion/application/pipelines/trending.pipeline.spec.ts
@@ -34,6 +34,7 @@ describe('TrendingPipeline', () => {
         .fn()
         .mockResolvedValue({ movies: 0, shows: 0, total: 0, hasMore: false }),
       syncHeroCandidatesStats: jest.fn().mockResolvedValue({ movies: 0, shows: 0, total: 0 }),
+      clearStaleTrendingRanks: jest.fn().mockResolvedValue(0),
     };
 
     const mockCatalogEvaluator = {
@@ -147,6 +148,20 @@ describe('TrendingPipeline', () => {
         since: expect.any(Date),
         limit: 200,
       });
+    });
+
+    it('should clear stale trending ranks when since is provided', async () => {
+      const since = new Date().toISOString();
+
+      await pipeline.processStats(since);
+
+      expect(trendingSyncService.clearStaleTrendingRanks).toHaveBeenCalledWith(expect.any(Date));
+    });
+
+    it('should not clear stale trending ranks when since is not provided', async () => {
+      await pipeline.processStats();
+
+      expect(trendingSyncService.clearStaleTrendingRanks).not.toHaveBeenCalled();
     });
 
     it('should run eligible trending backfill after stats sync', async () => {

--- a/apps/api/src/modules/ingestion/application/pipelines/trending.pipeline.ts
+++ b/apps/api/src/modules/ingestion/application/pipelines/trending.pipeline.ts
@@ -93,6 +93,12 @@ export class TrendingPipeline {
       `Syncing Trakt stats (since: ${sinceDate?.toISOString() || 'all'}, limit: ${limit || 'default'})...`,
     );
 
+    // Phase 0: Clear stale trending ranks from items not updated in this sync cycle
+    if (sinceDate) {
+      const cleared = await this.trendingSyncService.clearStaleTrendingRanks(sinceDate);
+      this.logger.log(`Phase 0 complete: cleared ${cleared} stale trending ranks`);
+    }
+
     // Phase 1: Sync stats for recently updated items (top trending from TMDB)
     const result = await this.trendingSyncService.syncTrendingStatsForUpdatedItems({
       since: sinceDate,

--- a/apps/api/src/modules/stats/application/services/trending-sync.service.ts
+++ b/apps/api/src/modules/stats/application/services/trending-sync.service.ts
@@ -52,6 +52,22 @@ export class TrendingSyncService {
   ) {}
 
   /**
+   * Clears trending_rank and trending_score for items not updated since `before`.
+   * Removes stale trending data from items that dropped out of TMDB trending.
+   *
+   * @param {Date} before - Cutoff date
+   * @returns {Promise<number>} Number of items cleared
+   */
+  async clearStaleTrendingRanks(before: Date): Promise<number> {
+    this.logger.log(`Clearing stale trending ranks (before: ${before.toISOString()})...`);
+
+    const cleared = await this.mediaRepository.clearStaleTrendingRanks(before);
+
+    this.logger.log(`Cleared ${cleared} stale trending ranks`);
+    return cleared;
+  }
+
+  /**
    * Syncs trending stats from Trakt API using batch operations.
    * Fetches current watchers count and trending rank for movies and shows,
    * then updates the media_stats table for items that exist in our database.


### PR DESCRIPTION
## Summary
- Lower `MIN_WATCHERS_MOVIES` from 5 to 2 — production analysis showed avg `watchers_count` of 2.9 for eligible movies, resulting in only 22 trending movies passing the gate
- Add Phase 0 cleanup in `TrendingPipeline.processStats()` to clear stale `trending_rank` for items that drop out of TMDB's top-100 between sync cycles (was causing 575 movies with rank vs 100 actual positions)

## Test plan
- [x] `trending.pipeline.spec.ts` — 15 tests pass (2 new for stale cleanup)
- [x] `trending-queries.property.spec.ts` — 20 tests pass (threshold assertion updated)
- [x] Lint, build, full test suite pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)