### PR TITLE
fix(import): prioritize imports and fix search isImported flag

### DIFF
--- a/apps/api/src/common/infrastructure/bullmq/job-status-mapper.spec.ts
+++ b/apps/api/src/common/infrastructure/bullmq/job-status-mapper.spec.ts
@@ -1,0 +1,27 @@
+import { JOB_STATUS } from '@/common/enums/job-status.enum';
+
+import { mapBullStateToJobStatus } from './job-status-mapper';
+
+describe('mapBullStateToJobStatus', () => {
+  it.each([
+    ['waiting', JOB_STATUS.QUEUED],
+    ['prioritized', JOB_STATUS.QUEUED],
+    ['delayed', JOB_STATUS.QUEUED],
+    ['paused', JOB_STATUS.QUEUED],
+    ['active', JOB_STATUS.PROCESSING],
+    ['completed', JOB_STATUS.READY],
+    ['failed', JOB_STATUS.FAILED],
+    ['stalled', JOB_STATUS.FAILED],
+  ])('should map "%s" to %s', (state, expected) => {
+    expect(mapBullStateToJobStatus(state)).toBe(expected);
+  });
+
+  it('should infer READY for unknown state with finishedOn', () => {
+    expect(mapBullStateToJobStatus('unknown-state', Date.now())).toBe(JOB_STATUS.READY);
+  });
+
+  it('should infer FAILED for unknown state without finishedOn', () => {
+    expect(mapBullStateToJobStatus('unknown-state')).toBe(JOB_STATUS.FAILED);
+    expect(mapBullStateToJobStatus('unknown-state', null)).toBe(JOB_STATUS.FAILED);
+  });
+});

--- a/apps/api/src/common/infrastructure/bullmq/job-status-mapper.ts
+++ b/apps/api/src/common/infrastructure/bullmq/job-status-mapper.ts
@@ -6,6 +6,7 @@ import { JOB_STATUS, type JobStatus } from '@/common/enums/job-status.enum';
  */
 const BULL_STATE_TO_JOB_STATUS: Record<string, JobStatus> = {
   waiting: JOB_STATUS.QUEUED,
+  prioritized: JOB_STATUS.QUEUED,
   delayed: JOB_STATUS.QUEUED,
   active: JOB_STATUS.PROCESSING,
   completed: JOB_STATUS.READY,

--- a/apps/api/src/modules/catalog/application/services/catalog-search.service.spec.ts
+++ b/apps/api/src/modules/catalog/application/services/catalog-search.service.spec.ts
@@ -51,6 +51,7 @@ describe('CatalogSearchService', () => {
   beforeEach(async () => {
     mediaRepository = {
       search: jest.fn().mockResolvedValue([]),
+      findManyByTmdbIds: jest.fn().mockResolvedValue([]),
     };
 
     const mockMetadataPort: jest.Mocked<IMediaMetadataPort> = {
@@ -111,6 +112,7 @@ describe('CatalogSearchService', () => {
         title: 'TMDB Movie',
         posterPath: '/tmdb.jpg',
         year: 2024,
+        isImported: false,
       }),
     );
   });
@@ -129,6 +131,17 @@ describe('CatalogSearchService', () => {
 
     const duplicate = result.tmdb.find((m) => m.tmdbId === 100);
     expect(duplicate).toBeUndefined();
+  });
+
+  it('should mark TMDB results as imported when they exist in DB', async () => {
+    metadataPort.searchMulti.mockResolvedValue([mockTmdbMovie]);
+    mediaRepository.findManyByTmdbIds.mockResolvedValue([{ id: 'uuid-2', tmdbId: 200 }]);
+
+    const result = await service.search('movie');
+
+    expect(result.tmdb).toHaveLength(1);
+    expect(result.tmdb[0].isImported).toBe(true);
+    expect(mediaRepository.findManyByTmdbIds).toHaveBeenCalledWith([200]);
   });
 
   it('should handle errors gracefully and return empty results', async () => {

--- a/apps/api/src/modules/catalog/application/services/catalog-search.service.ts
+++ b/apps/api/src/modules/catalog/application/services/catalog-search.service.ts
@@ -60,19 +60,28 @@ export class CatalogSearchService {
         rating: r.rating || 0,
       }));
 
-      const tmdb: TmdbSearchResultItem[] = tmdbResults
+      const filteredTmdb = tmdbResults
         .filter((r) => !localTmdbIds.has(r.externalIds.tmdbId))
-        .slice(0, SEARCH_CONFIG.RESULTS_LIMIT)
-        .map((r) => ({
-          source: SEARCH_SOURCE.TMDB,
-          type: r.type,
-          tmdbId: r.externalIds.tmdbId,
-          title: r.title,
-          originalTitle: r.originalTitle,
-          year: r.releaseDate ? new Date(r.releaseDate).getFullYear() || null : null,
-          posterPath: r.posterPath,
-          rating: r.rating || 0,
-        }));
+        .slice(0, SEARCH_CONFIG.RESULTS_LIMIT);
+
+      // Batch-check which TMDB results are already imported in our DB
+      const tmdbIdsToCheck = filteredTmdb.map((r) => r.externalIds.tmdbId);
+      const importedItems = tmdbIdsToCheck.length
+        ? await this.mediaRepository.findManyByTmdbIds(tmdbIdsToCheck)
+        : [];
+      const importedTmdbIds = new Set(importedItems.map((item) => item.tmdbId));
+
+      const tmdb: TmdbSearchResultItem[] = filteredTmdb.map((r) => ({
+        source: SEARCH_SOURCE.TMDB,
+        type: r.type,
+        tmdbId: r.externalIds.tmdbId,
+        title: r.title,
+        originalTitle: r.originalTitle,
+        year: r.releaseDate ? new Date(r.releaseDate).getFullYear() || null : null,
+        posterPath: r.posterPath,
+        rating: r.rating || 0,
+        isImported: importedTmdbIds.has(r.externalIds.tmdbId),
+      }));
 
       return { query, local, tmdb };
     } catch (error) {

--- a/apps/api/src/modules/catalog/domain/types/search.types.ts
+++ b/apps/api/src/modules/catalog/domain/types/search.types.ts
@@ -38,6 +38,7 @@ export interface LocalSearchResultItem extends BaseSearchResultItem {
  */
 export interface TmdbSearchResultItem extends BaseSearchResultItem {
   source: typeof SEARCH_SOURCE.TMDB;
+  isImported: boolean;
 }
 
 /**

--- a/apps/api/src/modules/catalog/infrastructure/adapters/bullmq-import-job.adapter.spec.ts
+++ b/apps/api/src/modules/catalog/infrastructure/adapters/bullmq-import-job.adapter.spec.ts
@@ -37,7 +37,7 @@ describe('BullMQImportJobAdapter', () => {
       expect(queue.add).toHaveBeenCalledWith(
         IngestionJob.SYNC_MOVIE,
         { tmdbId: 123 },
-        { jobId: 'sync-movie_123' },
+        { jobId: 'sync-movie_123', priority: 1 },
       );
       expect(result.jobId).toBe('sync-movie_123');
     });
@@ -50,7 +50,7 @@ describe('BullMQImportJobAdapter', () => {
       expect(queue.add).toHaveBeenCalledWith(
         IngestionJob.SYNC_SHOW,
         { tmdbId: 456 },
-        { jobId: 'sync-show_456' },
+        { jobId: 'sync-show_456', priority: 1 },
       );
       expect(result.jobId).toBe('sync-show_456');
     });

--- a/apps/api/src/modules/catalog/infrastructure/adapters/bullmq-import-job.adapter.ts
+++ b/apps/api/src/modules/catalog/infrastructure/adapters/bullmq-import-job.adapter.ts
@@ -17,6 +17,9 @@ const MEDIA_TYPE_TO_JOB: Record<MediaType, IngestionJob> = {
   [MediaType.SHOW]: IngestionJob.SYNC_SHOW,
 };
 
+/** User-triggered imports jump ahead of batch sync jobs in the queue. */
+const IMPORT_JOB_PRIORITY = 1;
+
 /**
  * BullMQ implementation of IImportJobPort.
  * Encapsulates all BullMQ-specific logic for import job operations.
@@ -31,7 +34,7 @@ export class BullMQImportJobAdapter implements IImportJobPort {
   async queueImport(tmdbId: number, type: MediaType): Promise<QueuedJob> {
     const jobName = MEDIA_TYPE_TO_JOB[type];
     const jobId = this.buildJobId(jobName, tmdbId);
-    const job = await this.queue.add(jobName, { tmdbId }, { jobId });
+    const job = await this.queue.add(jobName, { tmdbId }, { jobId, priority: IMPORT_JOB_PRIORITY });
     return { jobId: job.id! };
   }
 

--- a/apps/api/src/modules/catalog/presentation/controllers/catalog.search.controller.spec.ts
+++ b/apps/api/src/modules/catalog/presentation/controllers/catalog.search.controller.spec.ts
@@ -61,6 +61,7 @@ describe('CatalogSearchController', () => {
             year: 2003,
             posterPath: '/poster2.jpg',
             rating: 7.0,
+            isImported: false,
           },
         ],
       };

--- a/apps/api/src/modules/catalog/presentation/mappers/search.mapper.spec.ts
+++ b/apps/api/src/modules/catalog/presentation/mappers/search.mapper.spec.ts
@@ -79,6 +79,7 @@ describe('SearchMapper', () => {
         year: 2011,
         posterPath: '/got.jpg',
         rating: 9.3,
+        isImported: false,
       };
 
       const input: HybridSearchResult = {
@@ -162,6 +163,7 @@ describe('SearchMapper', () => {
             year: 2008,
             posterPath: '/batman2.jpg',
             rating: 9.0,
+            isImported: false,
           },
         ],
       };

--- a/apps/api/src/modules/catalog/presentation/mappers/search.mapper.ts
+++ b/apps/api/src/modules/catalog/presentation/mappers/search.mapper.ts
@@ -46,7 +46,7 @@ export class SearchMapper {
       year: item.year,
       poster: ImageMapper.toPoster(item.posterPath),
       rating: item.rating,
-      isImported: false,
+      isImported: item.isImported,
     };
   }
 }


### PR DESCRIPTION
## Summary
- Add `priority: 1` to user-triggered import jobs so they jump ahead of batch trending sync jobs in the shared ingestion queue (was causing multi-minute delays)
- Add `prioritized` BullMQ state to job-status-mapper (priority jobs use this state instead of `waiting`, which was incorrectly falling back to `FAILED`)
- Resolve `isImported` for TMDB search results via batch DB lookup instead of hardcoding `false` — items already in DB now correctly show `isImported: true`

## Test plan
- [x] 3234 tests pass (including 10 new mapper tests + 1 new search service test)
- [x] E2E verified: import completes in ~2s instead of minutes
- [x] E2E verified: search returns `isImported: true` for imported TMDB results

🤖 Generated with [Claude Code](https://claude.com/claude-code)