### PR TITLE
fix(reviews): review disappears after page refresh

### DIFF
--- a/apps/web-client/src/modules/reviews/components/reviews-section.tsx
+++ b/apps/web-client/src/modules/reviews/components/reviews-section.tsx
@@ -5,6 +5,7 @@ import { MessageSquare, ChevronDown } from 'lucide-react';
 import { toast } from 'sonner';
 import {
   useReviews,
+  useMyReview,
   useCreateReview,
   useVoteReview,
   useUnvoteReview,
@@ -68,8 +69,8 @@ export function ReviewsSection({ mediaItemId, className, initialData }: ReviewsS
   const totalReviews = reviewsData?.meta?.total ?? 0;
   const hasMore = reviews.length < totalReviews;
 
-  // Check if current user already has a review in the list
-  const userHasReview = user ? reviews.some((r) => r.author.id === user.id) : false;
+  const { data: myReview } = useMyReview(mediaItemId, { enabled: isAuthenticated });
+  const userHasReview = !!myReview;
   // Show form to guests too (they'll see login modal on submit)
   const showForm = !userHasReview && !isLoadingReviews;
 


### PR DESCRIPTION
## Summary
- Fixed a bug where the user's review disappeared after page refresh due to stale cached data
- Root cause: two caching layers (Next.js server 60s + TanStack Query 2min staleTime) served stale reviews list that didn't include the newly created review
- Fix: use the existing `useMyReview` hook (authenticated `GET /me/reviews/media/:id`) to detect if the user already has a review, instead of scanning the cached public reviews list

## Test plan
- [ ] Submit a review on a show/movie page
- [ ] Refresh the page immediately — review should still be visible, form should be hidden
- [ ] Verify "already reviewed" toast no longer appears on refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)