### PR TITLE
feat(stats): add community average rating to detail pages

### DIFF
--- a/apps/api/drizzle_v2/0014_happy_genesis.sql
+++ b/apps/api/drizzle_v2/0014_happy_genesis.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "media_stats" ADD COLUMN "community_average_rating" double precision;--> statement-breakpoint
+ALTER TABLE "media_stats" ADD COLUMN "community_rating_count" integer DEFAULT 0;

--- a/apps/api/drizzle_v2/meta/0014_snapshot.json
+++ b/apps/api/drizzle_v2/meta/0014_snapshot.json
@@ -1,0 +1,4763 @@
+{
+  "id": "81ec50aa-e354-4367-9d1b-eee4bccef143",
+  "prevId": "81ecdf7d-e482-4255-9598-05cb5d86bce2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.catalog_evaluation_runs": {
+      "name": "catalog_evaluation_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "evaluation_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counters": {
+          "name": "counters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"processed\":0,\"eligible\":0,\"ineligible\":0,\"review\":0,\"reasonBreakdown\":{}}'::jsonb"
+        },
+        "target_policy_id": {
+          "name": "target_policy_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_policy_version": {
+          "name": "target_policy_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "baseline_policy_version": {
+          "name": "baseline_policy_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_ready_snapshot": {
+          "name": "total_ready_snapshot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "snapshot_cutoff": {
+          "name": "snapshot_cutoff",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed": {
+          "name": "processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "eligible": {
+          "name": "eligible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "ineligible": {
+          "name": "ineligible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "pending": {
+          "name": "pending",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "errors": {
+          "name": "errors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "error_sample": {
+          "name": "error_sample",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promoted_by": {
+          "name": "promoted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_eval_runs_policy_version_idx": {
+          "name": "catalog_eval_runs_policy_version_idx",
+          "columns": [
+            {
+              "expression": "policy_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_eval_runs_status_idx": {
+          "name": "catalog_eval_runs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_eval_runs_target_policy_idx": {
+          "name": "catalog_eval_runs_target_policy_idx",
+          "columns": [
+            {
+              "expression": "target_policy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "catalog_evaluation_runs_target_policy_id_catalog_policies_id_fk": {
+          "name": "catalog_evaluation_runs_target_policy_id_catalog_policies_id_fk",
+          "tableFrom": "catalog_evaluation_runs",
+          "tableTo": "catalog_policies",
+          "columnsFrom": [
+            "target_policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_policies": {
+      "name": "catalog_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_policies_version_idx": {
+          "name": "catalog_policies_version_idx",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_policies_active_idx": {
+          "name": "catalog_policies_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"catalog_policies\".\"is_active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.episodes": {
+      "name": "episodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "show_id": {
+          "name": "show_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "air_date": {
+          "name": "air_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "still_path": {
+          "name": "still_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vote_average": {
+          "name": "vote_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "episodes_season_number_uniq": {
+          "name": "episodes_season_number_uniq",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "episodes_season_idx": {
+          "name": "episodes_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "episodes_air_date_idx": {
+          "name": "episodes_air_date_idx",
+          "columns": [
+            {
+              "expression": "air_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "episodes_show_idx": {
+          "name": "episodes_show_idx",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "episodes_show_air_date_idx": {
+          "name": "episodes_show_air_date_idx",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "air_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "episodes_show_air_date_number_idx": {
+          "name": "episodes_show_air_date_number_idx",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "air_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "episodes_season_id_seasons_id_fk": {
+          "name": "episodes_season_id_seasons_id_fk",
+          "tableFrom": "episodes",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "episodes_show_id_shows_id_fk": {
+          "name": "episodes_show_id_shows_id_fk",
+          "tableFrom": "episodes",
+          "tableTo": "shows",
+          "columnsFrom": [
+            "show_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.genres": {
+      "name": "genres",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "genres_tmdb_id_unique": {
+          "name": "genres_tmdb_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tmdb_id"
+          ]
+        },
+        "genres_slug_unique": {
+          "name": "genres_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_posts": {
+      "name": "journal_posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_html": {
+          "name": "body_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "post_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured_image_url": {
+          "name": "featured_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_title": {
+          "name": "meta_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_journal_posts_type": {
+          "name": "idx_journal_posts_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_journal_posts_context": {
+          "name": "idx_journal_posts_context",
+          "columns": [
+            {
+              "expression": "context_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"journal_posts\".\"context_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_journal_posts_published": {
+          "name": "idx_journal_posts_published",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"journal_posts\".\"is_draft\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "journal_posts_author_id_users_id_fk": {
+          "name": "journal_posts_author_id_users_id_fk",
+          "tableFrom": "journal_posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "journal_posts_slug_unique": {
+          "name": "journal_posts_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_catalog_evaluations": {
+      "name": "media_catalog_evaluations",
+      "schema": "",
+      "columns": {
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "eligibility_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reasons": {
+          "name": "reasons",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "relevance_score": {
+          "name": "relevance_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakout_rule_id": {
+          "name": "breakout_rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluated_at": {
+          "name": "evaluated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "evaluation_context",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'catalog'"
+        }
+      },
+      "indexes": {
+        "media_catalog_eval_status_idx": {
+          "name": "media_catalog_eval_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_catalog_eval_status_relevance_idx": {
+          "name": "media_catalog_eval_status_relevance_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relevance_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_catalog_eval_policy_version_idx": {
+          "name": "media_catalog_eval_policy_version_idx",
+          "columns": [
+            {
+              "expression": "policy_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_catalog_eval_run_id_idx": {
+          "name": "media_catalog_eval_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_catalog_eval_context_idx": {
+          "name": "media_catalog_eval_context_idx",
+          "columns": [
+            {
+              "expression": "context",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_catalog_eval_context_status_idx": {
+          "name": "media_catalog_eval_context_status_idx",
+          "columns": [
+            {
+              "expression": "context",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relevance_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_catalog_evaluations_media_item_id_media_items_id_fk": {
+          "name": "media_catalog_evaluations_media_item_id_media_items_id_fk",
+          "tableFrom": "media_catalog_evaluations",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_catalog_evaluations_run_id_catalog_evaluation_runs_id_fk": {
+          "name": "media_catalog_evaluations_run_id_catalog_evaluation_runs_id_fk",
+          "tableFrom": "media_catalog_evaluations",
+          "tableTo": "catalog_evaluation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_catalog_evaluations_media_item_id_policy_version_context_pk": {
+          "name": "media_catalog_evaluations_media_item_id_policy_version_context_pk",
+          "columns": [
+            "media_item_id",
+            "policy_version",
+            "context"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_genres": {
+      "name": "media_genres",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "media_genres_uniq": {
+          "name": "media_genres_uniq",
+          "columns": [
+            {
+              "expression": "media_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_genres_genre_idx": {
+          "name": "media_genres_genre_idx",
+          "columns": [
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_genres_media_item_id_media_items_id_fk": {
+          "name": "media_genres_media_item_id_media_items_id_fk",
+          "tableFrom": "media_genres",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_genres_genre_id_genres_id_fk": {
+          "name": "media_genres_genre_id_genres_id_fk",
+          "tableFrom": "media_genres",
+          "tableTo": "genres",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_items": {
+      "name": "media_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "media_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imdb_id": {
+          "name": "imdb_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_title": {
+          "name": "original_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backdrop_path": {
+          "name": "backdrop_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "videos": {
+          "name": "videos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "credits": {
+          "name": "credits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"cast\":[],\"crew\":[]}'::jsonb"
+        },
+        "watch_providers_raw": {
+          "name": "watch_providers_raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "trending_score": {
+          "name": "trending_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "trending_rank": {
+          "name": "trending_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trending_updated_at": {
+          "name": "trending_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "popularity": {
+          "name": "popularity",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "rating": {
+          "name": "rating",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "rating_imdb": {
+          "name": "rating_imdb",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vote_count_imdb": {
+          "name": "vote_count_imdb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_metacritic": {
+          "name": "rating_metacritic",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_rotten_tomatoes": {
+          "name": "rating_rotten_tomatoes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_trakt": {
+          "name": "rating_trakt",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vote_count_trakt": {
+          "name": "vote_count_trakt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_countries": {
+          "name": "origin_countries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "original_language": {
+          "name": "original_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingestion_status": {
+          "name": "ingestion_status",
+          "type": "ingestion_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ready'"
+        },
+        "content_class": {
+          "name": "content_class",
+          "type": "content_class",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mainstream'"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(original_title, '') || ' ' || coalesce(overview, ''))",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "media_type_tmdb_idx": {
+          "name": "media_type_tmdb_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tmdb_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_imdb_idx": {
+          "name": "media_imdb_idx",
+          "columns": [
+            {
+              "expression": "imdb_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_trending_idx": {
+          "name": "media_trending_idx",
+          "columns": [
+            {
+              "expression": "trending_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_trending_rank_idx": {
+          "name": "media_trending_rank_idx",
+          "columns": [
+            {
+              "expression": "trending_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_popularity_idx": {
+          "name": "media_popularity_idx",
+          "columns": [
+            {
+              "expression": "popularity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_release_date_idx": {
+          "name": "media_release_date_idx",
+          "columns": [
+            {
+              "expression": "release_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_type_slug_idx": {
+          "name": "media_type_slug_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_slug_idx": {
+          "name": "media_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_active_idx": {
+          "name": "media_active_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"media_items\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_search_idx": {
+          "name": "media_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_content_class_idx": {
+          "name": "media_content_class_idx",
+          "columns": [
+            {
+              "expression": "content_class",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_stats": {
+      "name": "media_stats",
+      "schema": "",
+      "columns": {
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watchers_count": {
+          "name": "watchers_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "total_watchers": {
+          "name": "total_watchers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "trending_rank": {
+          "name": "trending_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "popularity_24h": {
+          "name": "popularity_24h",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ratingo_score": {
+          "name": "ratingo_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "popularity_score": {
+          "name": "popularity_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "freshness_score": {
+          "name": "freshness_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "community_average_rating": {
+          "name": "community_average_rating",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "community_rating_count": {
+          "name": "community_rating_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_stats_ratingo_score_idx": {
+          "name": "media_stats_ratingo_score_idx",
+          "columns": [
+            {
+              "expression": "ratingo_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_stats_watchers_idx": {
+          "name": "media_stats_watchers_idx",
+          "columns": [
+            {
+              "expression": "watchers_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_stats_media_item_id_media_items_id_fk": {
+          "name": "media_stats_media_item_id_media_items_id_fk",
+          "tableFrom": "media_stats",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_watch_offers": {
+      "name": "media_watch_offers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distribution_channel": {
+          "name": "distribution_channel",
+          "type": "distribution_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'direct'"
+        },
+        "offer_type": {
+          "name": "offer_type",
+          "type": "offer_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tmdb_provider_id": {
+          "name": "tmdb_provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_watch_offers_media_idx": {
+          "name": "media_watch_offers_media_idx",
+          "columns": [
+            {
+              "expression": "media_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_watch_offers_provider_idx": {
+          "name": "media_watch_offers_provider_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_watch_offers_offer_type_idx": {
+          "name": "media_watch_offers_offer_type_idx",
+          "columns": [
+            {
+              "expression": "offer_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_watch_offers_region_idx": {
+          "name": "media_watch_offers_region_idx",
+          "columns": [
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_watch_offers_provider_offer_idx": {
+          "name": "media_watch_offers_provider_offer_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "offer_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_watch_offers_tmdb_idx": {
+          "name": "media_watch_offers_tmdb_idx",
+          "columns": [
+            {
+              "expression": "tmdb_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_watch_offers_media_item_id_media_items_id_fk": {
+          "name": "media_watch_offers_media_item_id_media_items_id_fk",
+          "tableFrom": "media_watch_offers",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_watch_offers_provider_id_provider_registry_id_fk": {
+          "name": "media_watch_offers_provider_id_provider_registry_id_fk",
+          "tableFrom": "media_watch_offers",
+          "tableTo": "provider_registry",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "media_watch_offers_variant_id_provider_variants_id_fk": {
+          "name": "media_watch_offers_variant_id_provider_variants_id_fk",
+          "tableFrom": "media_watch_offers",
+          "tableTo": "provider_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_watchers_snapshots": {
+      "name": "media_watchers_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_watchers": {
+          "name": "total_watchers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'global'"
+        }
+      },
+      "indexes": {
+        "media_watchers_media_date_region_uniq": {
+          "name": "media_watchers_media_date_region_uniq",
+          "columns": [
+            {
+              "expression": "media_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "snapshot_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_watchers_date_idx": {
+          "name": "media_watchers_date_idx",
+          "columns": [
+            {
+              "expression": "snapshot_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_watchers_snapshots_media_item_id_media_items_id_fk": {
+          "name": "media_watchers_snapshots_media_item_id_media_items_id_fk",
+          "tableFrom": "media_watchers_snapshots",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.movies": {
+      "name": "movies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "budget": {
+          "name": "budget",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revenue": {
+          "name": "revenue",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theatrical_release_date": {
+          "name": "theatrical_release_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "digital_release_date": {
+          "name": "digital_release_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_now_playing": {
+          "name": "is_now_playing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "releases": {
+          "name": "releases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "movies_now_playing_idx": {
+          "name": "movies_now_playing_idx",
+          "columns": [
+            {
+              "expression": "is_now_playing",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"movies\".\"is_now_playing\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "movies_theatrical_idx": {
+          "name": "movies_theatrical_idx",
+          "columns": [
+            {
+              "expression": "theatrical_release_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "movies_digital_idx": {
+          "name": "movies_digital_idx",
+          "columns": [
+            {
+              "expression": "digital_release_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "movies_media_item_idx": {
+          "name": "movies_media_item_idx",
+          "columns": [
+            {
+              "expression": "media_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "movies_media_item_id_media_items_id_fk": {
+          "name": "movies_media_item_id_media_items_id_fk",
+          "tableFrom": "movies",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "movies_media_item_id_unique": {
+          "name": "movies_media_item_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "media_item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_exchange_codes": {
+      "name": "oauth_exchange_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_exchange_codes_hash_idx": {
+          "name": "oauth_exchange_codes_hash_idx",
+          "columns": [
+            {
+              "expression": "code_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_exchange_codes_expires_idx": {
+          "name": "oauth_exchange_codes_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_exchange_codes_user_id_users_id_fk": {
+          "name": "oauth_exchange_codes_user_id_users_id_fk",
+          "tableFrom": "oauth_exchange_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_mappings": {
+      "name": "provider_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tmdb_provider_id": {
+          "name": "tmdb_provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distribution_channel": {
+          "name": "distribution_channel",
+          "type": "distribution_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'direct'"
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provider_mappings_tmdb_region_uniq": {
+          "name": "provider_mappings_tmdb_region_uniq",
+          "columns": [
+            {
+              "expression": "tmdb_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_mappings_tmdb_idx": {
+          "name": "provider_mappings_tmdb_idx",
+          "columns": [
+            {
+              "expression": "tmdb_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_mappings_provider_id_provider_registry_id_fk": {
+          "name": "provider_mappings_provider_id_provider_registry_id_fk",
+          "tableFrom": "provider_mappings",
+          "tableTo": "provider_registry",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "provider_mappings_variant_id_provider_variants_id_fk": {
+          "name": "provider_mappings_variant_id_provider_variants_id_fk",
+          "tableFrom": "provider_mappings",
+          "tableTo": "provider_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_registry": {
+      "name": "provider_registry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_group": {
+          "name": "brand_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_path": {
+          "name": "logo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 100
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_unmapped": {
+      "name": "provider_unmapped",
+      "schema": "",
+      "columns": {
+        "tmdb_provider_id": {
+          "name": "tmdb_provider_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_seen_name": {
+          "name": "last_seen_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_names": {
+          "name": "sample_names",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "seen_count": {
+          "name": "seen_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "sample_regions": {
+          "name": "sample_regions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_variants": {
+      "name": "provider_variants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_label": {
+          "name": "display_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_ads_tier": {
+          "name": "is_ads_tier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_premium_tier": {
+          "name": "is_premium_tier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provider_variants_provider_idx": {
+          "name": "provider_variants_provider_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_variants_provider_id_provider_registry_id_fk": {
+          "name": "provider_variants_provider_id_provider_registry_id_fk",
+          "tableFrom": "provider_variants",
+          "tableTo": "provider_registry",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_user_idx": {
+          "name": "refresh_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_expires_idx": {
+          "name": "refresh_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_replies": {
+      "name": "review_replies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_reply_id": {
+          "name": "parent_reply_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_username": {
+          "name": "reply_to_username",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar(280)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_replies_review_idx": {
+          "name": "review_replies_review_idx",
+          "columns": [
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_replies_parent_idx": {
+          "name": "review_replies_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_reply_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_replies_review_id_reviews_id_fk": {
+          "name": "review_replies_review_id_reviews_id_fk",
+          "tableFrom": "review_replies",
+          "tableTo": "reviews",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_replies_user_id_users_id_fk": {
+          "name": "review_replies_user_id_users_id_fk",
+          "tableFrom": "review_replies",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_reports": {
+      "name": "review_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "review_report_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "review_report_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "moderator_id": {
+          "name": "moderator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderator_notes": {
+          "name": "moderator_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_reports_reporter_review_uniq": {
+          "name": "review_reports_reporter_review_uniq",
+          "columns": [
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_reports_status_idx": {
+          "name": "review_reports_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_reports_review_id_reviews_id_fk": {
+          "name": "review_reports_review_id_reviews_id_fk",
+          "tableFrom": "review_reports",
+          "tableTo": "reviews",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_reports_reporter_id_users_id_fk": {
+          "name": "review_reports_reporter_id_users_id_fk",
+          "tableFrom": "review_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_reports_moderator_id_users_id_fk": {
+          "name": "review_reports_moderator_id_users_id_fk",
+          "tableFrom": "review_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "moderator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_votes": {
+      "name": "review_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "review_vote_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_votes_user_review_uniq": {
+          "name": "review_votes_user_review_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_votes_review_idx": {
+          "name": "review_votes_review_idx",
+          "columns": [
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_votes_review_id_reviews_id_fk": {
+          "name": "review_votes_review_id_reviews_id_fk",
+          "tableFrom": "review_votes",
+          "tableTo": "reviews",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_votes_user_id_users_id_fk": {
+          "name": "review_votes_user_id_users_id_fk",
+          "tableFrom": "review_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar(280)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_spoiler": {
+          "name": "has_spoiler",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "likes_count": {
+          "name": "likes_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dislikes_count": {
+          "name": "dislikes_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "replies_count": {
+          "name": "replies_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "reviews_user_media_uniq": {
+          "name": "reviews_user_media_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"reviews\".\"is_deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_media_idx": {
+          "name": "reviews_media_idx",
+          "columns": [
+            {
+              "expression": "media_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_user_idx": {
+          "name": "reviews_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviews_user_id_users_id_fk": {
+          "name": "reviews_user_id_users_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reviews_media_item_id_media_items_id_fk": {
+          "name": "reviews_media_item_id_media_items_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seasons": {
+      "name": "seasons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "show_id": {
+          "name": "show_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "air_date": {
+          "name": "air_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "episode_count": {
+          "name": "episode_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "seasons_show_number_uniq": {
+          "name": "seasons_show_number_uniq",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "seasons_show_idx": {
+          "name": "seasons_show_idx",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "seasons_show_id_shows_id_fk": {
+          "name": "seasons_show_id_shows_id_fk",
+          "tableFrom": "seasons",
+          "tableTo": "shows",
+          "columnsFrom": [
+            "show_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shows": {
+      "name": "shows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_seasons": {
+          "name": "total_seasons",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_episodes": {
+          "name": "total_episodes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_air_date": {
+          "name": "last_air_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_air_date": {
+          "name": "next_air_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drop_off_analysis": {
+          "name": "drop_off_analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "shows_media_item_idx": {
+          "name": "shows_media_item_idx",
+          "columns": [
+            {
+              "expression": "media_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shows_media_item_id_media_items_id_fk": {
+          "name": "shows_media_item_id_media_items_id_fk",
+          "tableFrom": "shows",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "shows_media_item_id_unique": {
+          "name": "shows_media_item_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "media_item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_episode_progress": {
+      "name": "user_episode_progress",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "episode_id": {
+          "name": "episode_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "watched_at": {
+          "name": "watched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_episode_progress_user_idx": {
+          "name": "user_episode_progress_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_episode_progress_episode_idx": {
+          "name": "user_episode_progress_episode_idx",
+          "columns": [
+            {
+              "expression": "episode_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_episode_progress_user_id_users_id_fk": {
+          "name": "user_episode_progress_user_id_users_id_fk",
+          "tableFrom": "user_episode_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_episode_progress_episode_id_episodes_id_fk": {
+          "name": "user_episode_progress_episode_id_episodes_id_fk",
+          "tableFrom": "user_episode_progress",
+          "tableTo": "episodes",
+          "columnsFrom": [
+            "episode_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_episode_progress_user_id_episode_id_pk": {
+          "name": "user_episode_progress_user_id_episode_id_pk",
+          "columns": [
+            "user_id",
+            "episode_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_media_actions": {
+      "name": "user_media_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_key": {
+          "name": "reason_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_media_actions_user_idx": {
+          "name": "user_media_actions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_media_actions_media_idx": {
+          "name": "user_media_actions_media_idx",
+          "columns": [
+            {
+              "expression": "media_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_media_actions_action_idx": {
+          "name": "user_media_actions_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_media_actions_created_at_idx": {
+          "name": "user_media_actions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_media_actions_user_id_users_id_fk": {
+          "name": "user_media_actions_user_id_users_id_fk",
+          "tableFrom": "user_media_actions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_media_actions_media_item_id_media_items_id_fk": {
+          "name": "user_media_actions_media_item_id_media_items_id_fk",
+          "tableFrom": "user_media_actions",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_media_state": {
+      "name": "user_media_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "user_media_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_media_state_user_media_uniq": {
+          "name": "user_media_state_user_media_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_media_state_user_idx": {
+          "name": "user_media_state_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_media_state_media_idx": {
+          "name": "user_media_state_media_idx",
+          "columns": [
+            {
+              "expression": "media_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_media_state_user_id_users_id_fk": {
+          "name": "user_media_state_user_id_users_id_fk",
+          "tableFrom": "user_media_state",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_media_state_media_item_id_media_items_id_fk": {
+          "name": "user_media_state_media_item_id_media_items_id_fk",
+          "tableFrom": "user_media_state",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notifications": {
+      "name": "user_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "subscription_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_notifications_user_idx": {
+          "name": "user_notifications_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_notifications_user_unread_idx": {
+          "name": "user_notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_notifications_created_at_idx": {
+          "name": "user_notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_notifications_dedup_idx": {
+          "name": "user_notifications_dedup_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payload",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_notifications_user_id_users_id_fk": {
+          "name": "user_notifications_user_id_users_id_fk",
+          "tableFrom": "user_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_notifications_media_item_id_media_items_id_fk": {
+          "name": "user_notifications_media_item_id_media_items_id_fk",
+          "tableFrom": "user_notifications",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_notifications_subscription_id_user_subscriptions_id_fk": {
+          "name": "user_notifications_subscription_id_user_subscriptions_id_fk",
+          "tableFrom": "user_notifications",
+          "tableTo": "user_subscriptions",
+          "columnsFrom": [
+            "subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_saved_items": {
+      "name": "user_saved_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list": {
+          "name": "list",
+          "type": "saved_item_list",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_key": {
+          "name": "reason_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_saved_items_user_media_list_uniq": {
+          "name": "user_saved_items_user_media_list_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "list",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_saved_items_user_idx": {
+          "name": "user_saved_items_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_saved_items_user_list_idx": {
+          "name": "user_saved_items_user_list_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "list",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_saved_items_user_id_users_id_fk": {
+          "name": "user_saved_items_user_id_users_id_fk",
+          "tableFrom": "user_saved_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_saved_items_media_item_id_media_items_id_fk": {
+          "name": "user_saved_items_media_item_id_media_items_id_fk",
+          "tableFrom": "user_saved_items",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_subscriptions": {
+      "name": "user_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "subscription_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'push'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_notified_at": {
+          "name": "last_notified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_notified_episode_key": {
+          "name": "last_notified_episode_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_notified_season_number": {
+          "name": "last_notified_season_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_subscriptions_user_media_trigger_channel_uniq": {
+          "name": "user_subscriptions_user_media_trigger_channel_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_subscriptions_user_idx": {
+          "name": "user_subscriptions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_subscriptions_user_active_idx": {
+          "name": "user_subscriptions_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_subscriptions_trigger_idx": {
+          "name": "user_subscriptions_trigger_idx",
+          "columns": [
+            {
+              "expression": "trigger",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_subscriptions_user_id_users_id_fk": {
+          "name": "user_subscriptions_user_id_users_id_fk",
+          "tableFrom": "user_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_subscriptions_media_item_id_media_items_id_fk": {
+          "name": "user_subscriptions_media_item_id_media_items_id_fk",
+          "tableFrom": "user_subscriptions",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_id": {
+          "name": "google_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_language": {
+          "name": "preferred_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_region": {
+          "name": "preferred_region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_profile_public": {
+          "name": "is_profile_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "show_watch_history": {
+          "name": "show_watch_history",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "show_ratings": {
+          "name": "show_ratings",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "allow_followers": {
+          "name": "allow_followers",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "users_google_id_unique": {
+          "name": "users_google_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.content_class": {
+      "name": "content_class",
+      "schema": "public",
+      "values": [
+        "mainstream",
+        "anime",
+        "documentary",
+        "reality",
+        "kids"
+      ]
+    },
+    "public.distribution_channel": {
+      "name": "distribution_channel",
+      "schema": "public",
+      "values": [
+        "direct",
+        "amazon_channel",
+        "apple_tv_channel"
+      ]
+    },
+    "public.eligibility_status": {
+      "name": "eligibility_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "eligible",
+        "ineligible",
+        "review"
+      ]
+    },
+    "public.evaluation_context": {
+      "name": "evaluation_context",
+      "schema": "public",
+      "values": [
+        "catalog",
+        "trending",
+        "homepage",
+        "now_playing",
+        "new_digital",
+        "search"
+      ]
+    },
+    "public.evaluation_run_status": {
+      "name": "evaluation_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "prepared",
+        "failed",
+        "cancelled",
+        "promoted",
+        "pending",
+        "completed",
+        "success"
+      ]
+    },
+    "public.ingestion_status": {
+      "name": "ingestion_status",
+      "schema": "public",
+      "values": [
+        "importing",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.media_type": {
+      "name": "media_type",
+      "schema": "public",
+      "values": [
+        "movie",
+        "show"
+      ]
+    },
+    "public.offer_type": {
+      "name": "offer_type",
+      "schema": "public",
+      "values": [
+        "flatrate",
+        "rent",
+        "buy",
+        "ads",
+        "free"
+      ]
+    },
+    "public.post_type": {
+      "name": "post_type",
+      "schema": "public",
+      "values": [
+        "update",
+        "explanation",
+        "fix",
+        "roadmap"
+      ]
+    },
+    "public.review_report_reason": {
+      "name": "review_report_reason",
+      "schema": "public",
+      "values": [
+        "spam",
+        "harassment",
+        "hate_speech",
+        "misinformation",
+        "spoiler_unmarked",
+        "other"
+      ]
+    },
+    "public.review_report_status": {
+      "name": "review_report_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "reviewed",
+        "dismissed",
+        "actioned"
+      ]
+    },
+    "public.review_vote_type": {
+      "name": "review_vote_type",
+      "schema": "public",
+      "values": [
+        "like",
+        "dislike"
+      ]
+    },
+    "public.saved_item_list": {
+      "name": "saved_item_list",
+      "schema": "public",
+      "values": [
+        "for_later",
+        "considering"
+      ]
+    },
+    "public.subscription_trigger": {
+      "name": "subscription_trigger",
+      "schema": "public",
+      "values": [
+        "release",
+        "new_season",
+        "new_episode",
+        "on_streaming",
+        "status_changed"
+      ]
+    },
+    "public.user_media_status": {
+      "name": "user_media_status",
+      "schema": "public",
+      "values": [
+        "watching",
+        "completed",
+        "planned",
+        "dropped",
+        "paused"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle_v2/meta/_journal.json
+++ b/apps/api/drizzle_v2/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1768930461185,
       "tag": "0013_pale_manta",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1770710139694,
+      "tag": "0014_happy_genesis",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/common/dtos/ratingo-stats.dto.ts
+++ b/apps/api/src/common/dtos/ratingo-stats.dto.ts
@@ -44,4 +44,20 @@ export class RatingoStatsDto {
     nullable: true,
   })
   totalWatchers?: number | null;
+
+  @ApiProperty({
+    example: 78.5,
+    description: 'Community average rating (0-100 scale)',
+    required: false,
+    nullable: true,
+  })
+  communityAverageRating?: number | null;
+
+  @ApiProperty({
+    example: 1240,
+    description: 'Number of community ratings',
+    required: false,
+    nullable: true,
+  })
+  communityRatingCount?: number | null;
 }

--- a/apps/api/src/common/types/media.types.ts
+++ b/apps/api/src/common/types/media.types.ts
@@ -36,4 +36,6 @@ export interface RatingoStats {
   popularityScore: number | null;
   liveWatchers: number | null;
   totalWatchers: number | null;
+  communityAverageRating?: number | null;
+  communityRatingCount?: number | null;
 }

--- a/apps/api/src/database/schema.ts
+++ b/apps/api/src/database/schema.ts
@@ -218,6 +218,10 @@ export const mediaStats = pgTable(
     popularityScore: doublePrecision('popularity_score'), // Popularity-based component
     freshnessScore: doublePrecision('freshness_score'), // Time-based component
 
+    // Community ratings (aggregated from user_media_state)
+    communityAverageRating: doublePrecision('community_average_rating'),
+    communityRatingCount: integer('community_rating_count').default(0),
+
     // Timestamps
     updatedAt: timestamp('updated_at').defaultNow().notNull(),
   },

--- a/apps/api/src/modules/catalog/domain/types/common.types.ts
+++ b/apps/api/src/modules/catalog/domain/types/common.types.ts
@@ -47,6 +47,8 @@ export interface RatingoStats {
   popularityScore: number | null;
   liveWatchers: number | null;
   totalWatchers: number | null;
+  communityAverageRating: number | null;
+  communityRatingCount: number | null;
 }
 
 /**

--- a/apps/api/src/modules/catalog/infrastructure/queries/shared/movie-details-select-fields.spec.ts
+++ b/apps/api/src/modules/catalog/infrastructure/queries/shared/movie-details-select-fields.spec.ts
@@ -44,14 +44,16 @@ describe('MOVIE_DETAILS_SELECT_FIELDS', () => {
         'popularityScore',
         'watchersCount',
         'totalWatchers',
+        'communityAverageRating',
+        'communityRatingCount',
       ];
 
       expect(selectFieldKeys).toEqual(expectedKeys.sort());
     });
 
-    it('should have exactly 32 fields', () => {
+    it('should have exactly 34 fields', () => {
       const fieldCount = Object.keys(MOVIE_DETAILS_SELECT_FIELDS).length;
-      expect(fieldCount).toBe(32);
+      expect(fieldCount).toBe(34);
     });
   });
 
@@ -117,6 +119,8 @@ describe('MOVIE_DETAILS_SELECT_FIELDS', () => {
         'popularityScore',
         'watchersCount',
         'totalWatchers',
+        'communityAverageRating',
+        'communityRatingCount',
       ];
 
       statsFields.forEach((field) => {

--- a/apps/api/src/modules/catalog/infrastructure/queries/shared/movie-details-select-fields.ts
+++ b/apps/api/src/modules/catalog/infrastructure/queries/shared/movie-details-select-fields.ts
@@ -51,6 +51,8 @@ export const MOVIE_DETAILS_SELECT_FIELDS = {
   popularityScore: schema.mediaStats.popularityScore,
   watchersCount: schema.mediaStats.watchersCount,
   totalWatchers: schema.mediaStats.totalWatchers,
+  communityAverageRating: schema.mediaStats.communityAverageRating,
+  communityRatingCount: schema.mediaStats.communityRatingCount,
 } as const;
 
 /**

--- a/apps/api/src/modules/catalog/infrastructure/queries/shared/movie-details.mapper.spec.ts
+++ b/apps/api/src/modules/catalog/infrastructure/queries/shared/movie-details.mapper.spec.ts
@@ -62,6 +62,8 @@ describe('movie-details.mapper', () => {
     popularityScore: 0.9,
     watchersCount: 100,
     totalWatchers: 500,
+    communityAverageRating: 78.5,
+    communityRatingCount: 42,
     ...overrides,
   });
 
@@ -105,6 +107,8 @@ describe('movie-details.mapper', () => {
         popularityScore: 0.9,
         liveWatchers: 100,
         totalWatchers: 500,
+        communityAverageRating: 78.5,
+        communityRatingCount: 42,
       });
     });
 
@@ -115,6 +119,8 @@ describe('movie-details.mapper', () => {
         popularityScore: null,
         watchersCount: null,
         totalWatchers: null,
+        communityAverageRating: null,
+        communityRatingCount: null,
       });
       const result = mapRatingoStats(row);
 
@@ -124,6 +130,8 @@ describe('movie-details.mapper', () => {
         popularityScore: null,
         liveWatchers: null,
         totalWatchers: null,
+        communityAverageRating: null,
+        communityRatingCount: null,
       });
     });
   });

--- a/apps/api/src/modules/catalog/infrastructure/queries/shared/movie-details.mapper.ts
+++ b/apps/api/src/modules/catalog/infrastructure/queries/shared/movie-details.mapper.ts
@@ -53,6 +53,8 @@ export interface MovieDetailsQueryRow {
   popularityScore: number | null;
   watchersCount: number | null;
   totalWatchers: number | null;
+  communityAverageRating: number | null;
+  communityRatingCount: number | null;
 }
 
 /**
@@ -78,6 +80,8 @@ export function mapRatingoStats(row: MovieDetailsQueryRow) {
     popularityScore: row.popularityScore,
     liveWatchers: row.watchersCount,
     totalWatchers: row.totalWatchers,
+    communityAverageRating: row.communityAverageRating,
+    communityRatingCount: row.communityRatingCount,
   };
 }
 

--- a/apps/api/src/modules/catalog/infrastructure/queries/shared/movie-result.mapper.spec.ts
+++ b/apps/api/src/modules/catalog/infrastructure/queries/shared/movie-result.mapper.spec.ts
@@ -68,6 +68,8 @@ describe('MovieResultMapper', () => {
         popularityScore: 70,
         liveWatchers: 1000,
         totalWatchers: 50000,
+        communityAverageRating: null,
+        communityRatingCount: null,
       });
     });
 

--- a/apps/api/src/modules/catalog/infrastructure/queries/shared/movie-result.mapper.ts
+++ b/apps/api/src/modules/catalog/infrastructure/queries/shared/movie-result.mapper.ts
@@ -40,6 +40,8 @@ export class MovieResultMapper {
         popularityScore: row.popularityScore,
         liveWatchers: row.watchersCount,
         totalWatchers: row.totalWatchers,
+        communityAverageRating: null,
+        communityRatingCount: null,
       },
       externalRatings: {
         tmdb: { rating: row.rating, voteCount: row.voteCount },

--- a/apps/api/src/modules/catalog/infrastructure/queries/shared/show-details-select-fields.spec.ts
+++ b/apps/api/src/modules/catalog/infrastructure/queries/shared/show-details-select-fields.spec.ts
@@ -3,10 +3,10 @@ import { SHOW_DETAILS_SELECT_FIELDS } from './show-details-select-fields';
 
 describe('SHOW_DETAILS_SELECT_FIELDS', () => {
   describe('Field count validation', () => {
-    it('should have exactly 32 fields', () => {
+    it('should have exactly 34 fields', () => {
       const fieldCount = Object.keys(SHOW_DETAILS_SELECT_FIELDS).length;
-      // 15 core + 6 external ratings + 6 show-specific + 5 stats = 32
-      expect(fieldCount).toBe(32);
+      // 15 core + 6 external ratings + 6 show-specific + 7 stats = 34
+      expect(fieldCount).toBe(34);
     });
   });
 
@@ -68,16 +68,18 @@ describe('SHOW_DETAILS_SELECT_FIELDS', () => {
       }
     });
 
-    it('should include all stats fields (5)', () => {
+    it('should include all stats fields (7)', () => {
       const statsFields: (keyof typeof SHOW_DETAILS_SELECT_FIELDS)[] = [
         'ratingoScore',
         'qualityScore',
         'popularityScore',
         'watchersCount',
         'totalWatchers',
+        'communityAverageRating',
+        'communityRatingCount',
       ];
 
-      expect(statsFields).toHaveLength(5);
+      expect(statsFields).toHaveLength(7);
       for (const field of statsFields) {
         expect(SHOW_DETAILS_SELECT_FIELDS).toHaveProperty(field);
       }
@@ -129,6 +131,8 @@ describe('SHOW_DETAILS_SELECT_FIELDS', () => {
         'popularityScore',
         'watchersCount',
         'totalWatchers',
+        'communityAverageRating',
+        'communityRatingCount',
       ];
 
       expect(selectFieldKeys.sort()).toEqual(expectedKeys.sort());

--- a/apps/api/src/modules/catalog/infrastructure/queries/shared/show-details-select-fields.ts
+++ b/apps/api/src/modules/catalog/infrastructure/queries/shared/show-details-select-fields.ts
@@ -45,7 +45,7 @@ export const SHOW_DETAILS_SELECT_FIELDS = {
   nextAirDate: schema.shows.nextAirDate,
   showId: schema.shows.id,
 
-  // Stats (5)
+  // Stats (7)
   ratingoScore: schema.mediaStats.ratingoScore,
   qualityScore: schema.mediaStats.qualityScore,
   popularityScore: schema.mediaStats.popularityScore,

--- a/apps/api/src/modules/catalog/infrastructure/queries/shared/show-details-select-fields.ts
+++ b/apps/api/src/modules/catalog/infrastructure/queries/shared/show-details-select-fields.ts
@@ -51,6 +51,8 @@ export const SHOW_DETAILS_SELECT_FIELDS = {
   popularityScore: schema.mediaStats.popularityScore,
   watchersCount: schema.mediaStats.watchersCount,
   totalWatchers: schema.mediaStats.totalWatchers,
+  communityAverageRating: schema.mediaStats.communityAverageRating,
+  communityRatingCount: schema.mediaStats.communityRatingCount,
 } as const;
 
 /**

--- a/apps/api/src/modules/catalog/infrastructure/queries/shared/show-details.mapper.spec.ts
+++ b/apps/api/src/modules/catalog/infrastructure/queries/shared/show-details.mapper.spec.ts
@@ -65,6 +65,8 @@ describe('show-details.mapper', () => {
     popularityScore: 85,
     watchersCount: 500,
     totalWatchers: 10000,
+    communityAverageRating: 75.2,
+    communityRatingCount: 123,
     ...overrides,
   });
 
@@ -144,6 +146,8 @@ describe('show-details.mapper', () => {
         popularityScore: 85,
         liveWatchers: 500,
         totalWatchers: 10000,
+        communityAverageRating: 75.2,
+        communityRatingCount: 123,
       });
     });
 
@@ -279,6 +283,8 @@ describe('show-details.mapper', () => {
         popularityScore: null,
         watchersCount: null,
         totalWatchers: null,
+        communityAverageRating: null,
+        communityRatingCount: null,
       });
 
       const result = mapShowDetails(row, mockGenres, mockSeasons, mockWatchOffers);
@@ -289,6 +295,8 @@ describe('show-details.mapper', () => {
         popularityScore: null,
         liveWatchers: null,
         totalWatchers: null,
+        communityAverageRating: null,
+        communityRatingCount: null,
       });
     });
 
@@ -347,6 +355,8 @@ describe('show-details.mapper', () => {
         popularityScore: null,
         watchersCount: null,
         totalWatchers: null,
+        communityAverageRating: null,
+        communityRatingCount: null,
       };
 
       expect(mockRow.id).toBe('test-id');

--- a/apps/api/src/modules/catalog/infrastructure/queries/shared/show-details.mapper.ts
+++ b/apps/api/src/modules/catalog/infrastructure/queries/shared/show-details.mapper.ts
@@ -50,12 +50,14 @@ export interface ShowDetailsQueryRow {
   nextAirDate: Date | null;
   showId: string;
 
-  // Stats (5)
+  // Stats (7)
   ratingoScore: number | null;
   qualityScore: number | null;
   popularityScore: number | null;
   watchersCount: number | null;
   totalWatchers: number | null;
+  communityAverageRating: number | null;
+  communityRatingCount: number | null;
 }
 
 /**
@@ -81,6 +83,8 @@ function mapRatingoStats(row: ShowDetailsQueryRow) {
     popularityScore: row.popularityScore,
     liveWatchers: row.watchersCount,
     totalWatchers: row.totalWatchers,
+    communityAverageRating: row.communityAverageRating,
+    communityRatingCount: row.communityRatingCount,
   };
 }
 

--- a/apps/api/src/modules/catalog/infrastructure/queries/shared/show-details.mapper.ts
+++ b/apps/api/src/modules/catalog/infrastructure/queries/shared/show-details.mapper.ts
@@ -14,7 +14,7 @@ import {
 
 /**
  * Raw row type from show details query.
- * Explicit types for all 32 fields to ensure type safety.
+ * Explicit types for all 34 fields to ensure type safety.
  */
 export interface ShowDetailsQueryRow {
   // Core media item fields (15)

--- a/apps/api/src/modules/catalog/infrastructure/queries/shared/show-result.mapper.spec.ts
+++ b/apps/api/src/modules/catalog/infrastructure/queries/shared/show-result.mapper.spec.ts
@@ -189,6 +189,8 @@ describe('ShowResultMapper', () => {
         popularityScore: 85,
         liveWatchers: 500,
         totalWatchers: 10000,
+        communityAverageRating: null,
+        communityRatingCount: null,
       });
     });
 
@@ -337,6 +339,8 @@ describe('ShowResultMapper', () => {
         popularityScore: null,
         liveWatchers: null,
         totalWatchers: null,
+        communityAverageRating: null,
+        communityRatingCount: null,
       });
     });
   });

--- a/apps/api/src/modules/catalog/infrastructure/queries/shared/show-result.mapper.ts
+++ b/apps/api/src/modules/catalog/infrastructure/queries/shared/show-result.mapper.ts
@@ -81,6 +81,8 @@ export class ShowResultMapper {
         popularityScore: row.popularity_score,
         liveWatchers: row.watchers_count,
         totalWatchers: row.total_watchers,
+        communityAverageRating: null,
+        communityRatingCount: null,
       },
       externalRatings: {
         tmdb: { rating: row.rating, voteCount: row.vote_count },

--- a/apps/api/src/modules/stats/application/listeners/community-rating-changed.listener.spec.ts
+++ b/apps/api/src/modules/stats/application/listeners/community-rating-changed.listener.spec.ts
@@ -1,0 +1,64 @@
+import { Test } from '@nestjs/testing';
+
+import { UserMediaRatingChangedEvent } from '../../../user-media/domain/events/user-media-rating-changed.event';
+import { CommunityRatingService } from '../services/community-rating.service';
+
+import { CommunityRatingChangedListener } from './community-rating-changed.listener';
+
+describe('CommunityRatingChangedListener', () => {
+  let listener: CommunityRatingChangedListener;
+  let communityRatingService: jest.Mocked<CommunityRatingService>;
+
+  beforeEach(async () => {
+    const mockCommunityRatingService = {
+      recalculateForMediaItem: jest.fn(),
+      reconcileAll: jest.fn(),
+    };
+
+    const module = await Test.createTestingModule({
+      providers: [
+        CommunityRatingChangedListener,
+        { provide: CommunityRatingService, useValue: mockCommunityRatingService },
+      ],
+    }).compile();
+
+    listener = module.get(CommunityRatingChangedListener);
+    communityRatingService = module.get(CommunityRatingService);
+  });
+
+  describe('handleRatingChanged', () => {
+    it('should call recalculateForMediaItem with correct mediaItemId', async () => {
+      const event = new UserMediaRatingChangedEvent('user-1', 'media-1', 85);
+      communityRatingService.recalculateForMediaItem.mockResolvedValue();
+
+      await listener.handleRatingChanged(event);
+
+      expect(communityRatingService.recalculateForMediaItem).toHaveBeenCalledWith('media-1');
+    });
+
+    it('should call recalculateForMediaItem when rating is cleared (null)', async () => {
+      const event = new UserMediaRatingChangedEvent('user-1', 'media-1', null);
+      communityRatingService.recalculateForMediaItem.mockResolvedValue();
+
+      await listener.handleRatingChanged(event);
+
+      expect(communityRatingService.recalculateForMediaItem).toHaveBeenCalledWith('media-1');
+    });
+
+    it('should not throw when recalculation fails', async () => {
+      const event = new UserMediaRatingChangedEvent('user-1', 'media-1', 75);
+      communityRatingService.recalculateForMediaItem.mockRejectedValue(
+        new Error('DB connection failed'),
+      );
+
+      await expect(listener.handleRatingChanged(event)).resolves.not.toThrow();
+    });
+
+    it('should not throw when recalculation fails with non-Error', async () => {
+      const event = new UserMediaRatingChangedEvent('user-1', 'media-1', 75);
+      communityRatingService.recalculateForMediaItem.mockRejectedValue('string error');
+
+      await expect(listener.handleRatingChanged(event)).resolves.not.toThrow();
+    });
+  });
+});

--- a/apps/api/src/modules/stats/application/listeners/community-rating-changed.listener.ts
+++ b/apps/api/src/modules/stats/application/listeners/community-rating-changed.listener.ts
@@ -1,0 +1,34 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+
+import { UserMediaRatingChangedEvent } from '../../../user-media/domain/events/user-media-rating-changed.event';
+import { CommunityRatingService } from '../services/community-rating.service';
+
+/**
+ * Listens for user rating changes and triggers community average recalculation.
+ *
+ * When a user rates (or clears their rating) via presets,
+ * UserMediaRatingChangedEvent is emitted. This listener recalculates
+ * the community average for the affected media item.
+ *
+ * Errors are caught and logged to prevent event handler failures
+ * from propagating to the caller.
+ */
+@Injectable()
+export class CommunityRatingChangedListener {
+  private readonly logger = new Logger(CommunityRatingChangedListener.name);
+
+  constructor(private readonly communityRatingService: CommunityRatingService) {}
+
+  @OnEvent(UserMediaRatingChangedEvent.eventName)
+  async handleRatingChanged(event: UserMediaRatingChangedEvent): Promise<void> {
+    try {
+      await this.communityRatingService.recalculateForMediaItem(event.mediaItemId);
+    } catch (error) {
+      this.logger.warn(
+        `Failed to recalculate community rating: media=${event.mediaItemId}`,
+        error instanceof Error ? error.message : error,
+      );
+    }
+  }
+}

--- a/apps/api/src/modules/stats/application/services/community-rating.service.spec.ts
+++ b/apps/api/src/modules/stats/application/services/community-rating.service.spec.ts
@@ -20,6 +20,7 @@ describe('CommunityRatingService', () => {
     const mockAggregationPort: jest.Mocked<ICommunityRatingAggregationPort> = {
       aggregateForMediaItem: jest.fn(),
       aggregateAll: jest.fn(),
+      findMediaItemIdsWithCommunityRatings: jest.fn().mockResolvedValue([]),
     };
 
     const mockStatsRepository: jest.Mocked<IStatsRepository> = {
@@ -108,7 +109,7 @@ describe('CommunityRatingService', () => {
 
       const result = await service.reconcileAll();
 
-      expect(result).toEqual({ updated: 0 });
+      expect(result).toEqual({ updated: 0, reset: 0 });
       expect(statsRepository.bulkUpsert).not.toHaveBeenCalled();
     });
 
@@ -119,10 +120,15 @@ describe('CommunityRatingService', () => {
         ['media-3', { averageRating: 92, ratingCount: 100 }],
       ]);
       aggregationPort.aggregateAll.mockResolvedValue(aggregations);
+      aggregationPort.findMediaItemIdsWithCommunityRatings.mockResolvedValue([
+        'media-1',
+        'media-2',
+        'media-3',
+      ]);
 
       const result = await service.reconcileAll();
 
-      expect(result).toEqual({ updated: 3 });
+      expect(result).toEqual({ updated: 3, reset: 0 });
       expect(statsRepository.bulkUpsert).toHaveBeenCalledWith([
         { mediaItemId: 'media-1', communityAverageRating: 85.56, communityRatingCount: 20 },
         { mediaItemId: 'media-2', communityAverageRating: 60.12, communityRatingCount: 5 },
@@ -133,12 +139,41 @@ describe('CommunityRatingService', () => {
     it('should round averages to 2 decimal places in bulk', async () => {
       const aggregations = new Map([['media-1', { averageRating: 33.3333333, ratingCount: 3 }]]);
       aggregationPort.aggregateAll.mockResolvedValue(aggregations);
+      aggregationPort.findMediaItemIdsWithCommunityRatings.mockResolvedValue(['media-1']);
 
       await service.reconcileAll();
 
       expect(statsRepository.bulkUpsert).toHaveBeenCalledWith([
         { mediaItemId: 'media-1', communityAverageRating: 33.33, communityRatingCount: 3 },
       ]);
+    });
+
+    it('should reset stale community ratings for items with no remaining user ratings', async () => {
+      const aggregations = new Map([['media-1', { averageRating: 80, ratingCount: 5 }]]);
+      aggregationPort.aggregateAll.mockResolvedValue(aggregations);
+      aggregationPort.findMediaItemIdsWithCommunityRatings.mockResolvedValue([
+        'media-1',
+        'media-stale-1',
+        'media-stale-2',
+      ]);
+
+      const result = await service.reconcileAll();
+
+      expect(result).toEqual({ updated: 1, reset: 2 });
+      expect(statsRepository.updateCommunityRating).toHaveBeenCalledWith('media-stale-1', 0, 0);
+      expect(statsRepository.updateCommunityRating).toHaveBeenCalledWith('media-stale-2', 0, 0);
+      expect(statsRepository.updateCommunityRating).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not reset any ratings when all existing items have fresh ratings', async () => {
+      const aggregations = new Map([['media-1', { averageRating: 70, ratingCount: 3 }]]);
+      aggregationPort.aggregateAll.mockResolvedValue(aggregations);
+      aggregationPort.findMediaItemIdsWithCommunityRatings.mockResolvedValue(['media-1']);
+
+      const result = await service.reconcileAll();
+
+      expect(result).toEqual({ updated: 1, reset: 0 });
+      expect(statsRepository.updateCommunityRating).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/modules/stats/application/services/community-rating.service.spec.ts
+++ b/apps/api/src/modules/stats/application/services/community-rating.service.spec.ts
@@ -1,0 +1,144 @@
+import { Test } from '@nestjs/testing';
+
+import {
+  COMMUNITY_RATING_AGGREGATION_PORT,
+  type ICommunityRatingAggregationPort,
+} from '../../domain/ports/community-rating-aggregation.port';
+import {
+  STATS_REPOSITORY,
+  type IStatsRepository,
+} from '../../domain/repositories/stats.repository.interface';
+
+import { CommunityRatingService } from './community-rating.service';
+
+describe('CommunityRatingService', () => {
+  let service: CommunityRatingService;
+  let aggregationPort: jest.Mocked<ICommunityRatingAggregationPort>;
+  let statsRepository: jest.Mocked<IStatsRepository>;
+
+  beforeEach(async () => {
+    const mockAggregationPort: jest.Mocked<ICommunityRatingAggregationPort> = {
+      aggregateForMediaItem: jest.fn(),
+      aggregateAll: jest.fn(),
+    };
+
+    const mockStatsRepository: jest.Mocked<IStatsRepository> = {
+      upsert: jest.fn(),
+      bulkUpsert: jest.fn(),
+      findByMediaItemId: jest.fn(),
+      findByTmdbId: jest.fn(),
+      updateTotalWatchers: jest.fn(),
+      updateWatchersCount: jest.fn(),
+      updateCommunityRating: jest.fn(),
+    };
+
+    const module = await Test.createTestingModule({
+      providers: [
+        CommunityRatingService,
+        { provide: COMMUNITY_RATING_AGGREGATION_PORT, useValue: mockAggregationPort },
+        { provide: STATS_REPOSITORY, useValue: mockStatsRepository },
+      ],
+    }).compile();
+
+    service = module.get(CommunityRatingService);
+    aggregationPort = module.get(COMMUNITY_RATING_AGGREGATION_PORT);
+    statsRepository = module.get(STATS_REPOSITORY);
+  });
+
+  describe('recalculateForMediaItem', () => {
+    const mediaItemId = 'media-123';
+
+    it('should update community rating when ratings exist', async () => {
+      aggregationPort.aggregateForMediaItem.mockResolvedValue({
+        averageRating: 75.333,
+        ratingCount: 10,
+      });
+
+      await service.recalculateForMediaItem(mediaItemId);
+
+      expect(aggregationPort.aggregateForMediaItem).toHaveBeenCalledWith(mediaItemId);
+      expect(statsRepository.updateCommunityRating).toHaveBeenCalledWith(mediaItemId, 75.33, 10);
+    });
+
+    it('should reset to zero when no ratings exist (null result)', async () => {
+      aggregationPort.aggregateForMediaItem.mockResolvedValue(null);
+
+      await service.recalculateForMediaItem(mediaItemId);
+
+      expect(statsRepository.updateCommunityRating).toHaveBeenCalledWith(mediaItemId, 0, 0);
+    });
+
+    it('should reset to zero when rating count is 0', async () => {
+      aggregationPort.aggregateForMediaItem.mockResolvedValue({
+        averageRating: 0,
+        ratingCount: 0,
+      });
+
+      await service.recalculateForMediaItem(mediaItemId);
+
+      expect(statsRepository.updateCommunityRating).toHaveBeenCalledWith(mediaItemId, 0, 0);
+    });
+
+    it('should round average rating to 2 decimal places', async () => {
+      aggregationPort.aggregateForMediaItem.mockResolvedValue({
+        averageRating: 82.6666666667,
+        ratingCount: 3,
+      });
+
+      await service.recalculateForMediaItem(mediaItemId);
+
+      expect(statsRepository.updateCommunityRating).toHaveBeenCalledWith(mediaItemId, 82.67, 3);
+    });
+
+    it('should handle exact integer averages', async () => {
+      aggregationPort.aggregateForMediaItem.mockResolvedValue({
+        averageRating: 80,
+        ratingCount: 5,
+      });
+
+      await service.recalculateForMediaItem(mediaItemId);
+
+      expect(statsRepository.updateCommunityRating).toHaveBeenCalledWith(mediaItemId, 80, 5);
+    });
+  });
+
+  describe('reconcileAll', () => {
+    it('should return updated count of zero for empty aggregation map', async () => {
+      aggregationPort.aggregateAll.mockResolvedValue(new Map());
+
+      const result = await service.reconcileAll();
+
+      expect(result).toEqual({ updated: 0 });
+      expect(statsRepository.bulkUpsert).not.toHaveBeenCalled();
+    });
+
+    it('should bulk upsert aggregations for multiple items', async () => {
+      const aggregations = new Map([
+        ['media-1', { averageRating: 85.555, ratingCount: 20 }],
+        ['media-2', { averageRating: 60.123, ratingCount: 5 }],
+        ['media-3', { averageRating: 92, ratingCount: 100 }],
+      ]);
+      aggregationPort.aggregateAll.mockResolvedValue(aggregations);
+
+      const result = await service.reconcileAll();
+
+      expect(result).toEqual({ updated: 3 });
+      expect(statsRepository.bulkUpsert).toHaveBeenCalledWith([
+        { mediaItemId: 'media-1', communityAverageRating: 85.56, communityRatingCount: 20 },
+        { mediaItemId: 'media-2', communityAverageRating: 60.12, communityRatingCount: 5 },
+        { mediaItemId: 'media-3', communityAverageRating: 92, communityRatingCount: 100 },
+      ]);
+    });
+
+    it('should round averages to 2 decimal places in bulk', async () => {
+      const aggregations = new Map([['media-1', { averageRating: 33.3333333, ratingCount: 3 }]]);
+      aggregationPort.aggregateAll.mockResolvedValue(aggregations);
+
+      await service.reconcileAll();
+
+      expect(statsRepository.bulkUpsert).toHaveBeenCalledWith([
+        { mediaItemId: 'media-1', communityAverageRating: 33.33, communityRatingCount: 3 },
+      ]);
+    });
+  });
+});

--- a/apps/api/src/modules/stats/application/services/community-rating.service.spec.ts
+++ b/apps/api/src/modules/stats/application/services/community-rating.service.spec.ts
@@ -160,9 +160,10 @@ describe('CommunityRatingService', () => {
       const result = await service.reconcileAll();
 
       expect(result).toEqual({ updated: 1, reset: 2 });
-      expect(statsRepository.updateCommunityRating).toHaveBeenCalledWith('media-stale-1', 0, 0);
-      expect(statsRepository.updateCommunityRating).toHaveBeenCalledWith('media-stale-2', 0, 0);
-      expect(statsRepository.updateCommunityRating).toHaveBeenCalledTimes(2);
+      expect(statsRepository.bulkUpsert).toHaveBeenCalledWith([
+        { mediaItemId: 'media-stale-1', communityAverageRating: 0, communityRatingCount: 0 },
+        { mediaItemId: 'media-stale-2', communityAverageRating: 0, communityRatingCount: 0 },
+      ]);
     });
 
     it('should not reset any ratings when all existing items have fresh ratings', async () => {
@@ -173,7 +174,8 @@ describe('CommunityRatingService', () => {
       const result = await service.reconcileAll();
 
       expect(result).toEqual({ updated: 1, reset: 0 });
-      expect(statsRepository.updateCommunityRating).not.toHaveBeenCalled();
+      // bulkUpsert called only once (for fresh items), no second call for stale resets
+      expect(statsRepository.bulkUpsert).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/apps/api/src/modules/stats/application/services/community-rating.service.ts
+++ b/apps/api/src/modules/stats/application/services/community-rating.service.ts
@@ -55,11 +55,12 @@ export class CommunityRatingService {
 
   /**
    * Reconciles community ratings for all media items that have user ratings.
+   * Also resets stale ratings for items whose ratings were all deleted.
    * Intended for periodic batch reconciliation via background job.
    *
-   * @returns Object with the number of items updated
+   * @returns Object with the number of items updated and reset
    */
-  async reconcileAll(): Promise<{ updated: number }> {
+  async reconcileAll(): Promise<{ updated: number; reset: number }> {
     const allAggregations = await this.aggregationPort.aggregateAll();
 
     const stats = Array.from(allAggregations.entries()).map(([mediaItemId, agg]) => ({
@@ -72,7 +73,20 @@ export class CommunityRatingService {
       await this.statsRepository.bulkUpsert(stats);
     }
 
+    // Reset stale community ratings for items that no longer have any user ratings
+    const existingIds = await this.aggregationPort.findMediaItemIdsWithCommunityRatings();
+    const freshIds = new Set(allAggregations.keys());
+    const staleIds = existingIds.filter((id) => !freshIds.has(id));
+
+    for (const id of staleIds) {
+      await this.statsRepository.updateCommunityRating(id, 0, 0);
+    }
+
+    if (staleIds.length > 0) {
+      this.logger.log(`Reset stale community ratings for ${staleIds.length} media items`);
+    }
+
     this.logger.log(`Reconciled community ratings for ${stats.length} media items`);
-    return { updated: stats.length };
+    return { updated: stats.length, reset: staleIds.length };
   }
 }

--- a/apps/api/src/modules/stats/application/services/community-rating.service.ts
+++ b/apps/api/src/modules/stats/application/services/community-rating.service.ts
@@ -78,11 +78,14 @@ export class CommunityRatingService {
     const freshIds = new Set(allAggregations.keys());
     const staleIds = existingIds.filter((id) => !freshIds.has(id));
 
-    for (const id of staleIds) {
-      await this.statsRepository.updateCommunityRating(id, 0, 0);
-    }
-
     if (staleIds.length > 0) {
+      await this.statsRepository.bulkUpsert(
+        staleIds.map((mediaItemId) => ({
+          mediaItemId,
+          communityAverageRating: 0,
+          communityRatingCount: 0,
+        })),
+      );
       this.logger.log(`Reset stale community ratings for ${staleIds.length} media items`);
     }
 

--- a/apps/api/src/modules/stats/application/services/community-rating.service.ts
+++ b/apps/api/src/modules/stats/application/services/community-rating.service.ts
@@ -1,0 +1,78 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+
+import {
+  COMMUNITY_RATING_AGGREGATION_PORT,
+  type ICommunityRatingAggregationPort,
+} from '../../domain/ports/community-rating-aggregation.port';
+import {
+  STATS_REPOSITORY,
+  type IStatsRepository,
+} from '../../domain/repositories/stats.repository.interface';
+
+/** Multiplier for rounding to 2 decimal places. */
+const ROUNDING_PRECISION = 100;
+
+/** Rounds a number to 2 decimal places. */
+function roundToTwoDecimals(value: number): number {
+  return Math.round(value * ROUNDING_PRECISION) / ROUNDING_PRECISION;
+}
+
+/**
+ * Service responsible for recalculating community average ratings.
+ * Aggregates user ratings from user_media_state and persists to media_stats.
+ */
+@Injectable()
+export class CommunityRatingService {
+  private readonly logger = new Logger(CommunityRatingService.name);
+
+  constructor(
+    @Inject(COMMUNITY_RATING_AGGREGATION_PORT)
+    private readonly aggregationPort: ICommunityRatingAggregationPort,
+    @Inject(STATS_REPOSITORY)
+    private readonly statsRepository: IStatsRepository,
+  ) {}
+
+  /**
+   * Recalculates the community average rating for a single media item.
+   * Resets to 0 if no ratings exist.
+   *
+   * @param mediaItemId - Internal UUID of the media item
+   */
+  async recalculateForMediaItem(mediaItemId: string): Promise<void> {
+    const agg = await this.aggregationPort.aggregateForMediaItem(mediaItemId);
+
+    if (!agg || agg.ratingCount === 0) {
+      await this.statsRepository.updateCommunityRating(mediaItemId, 0, 0);
+      return;
+    }
+
+    await this.statsRepository.updateCommunityRating(
+      mediaItemId,
+      roundToTwoDecimals(agg.averageRating),
+      agg.ratingCount,
+    );
+  }
+
+  /**
+   * Reconciles community ratings for all media items that have user ratings.
+   * Intended for periodic batch reconciliation via background job.
+   *
+   * @returns Object with the number of items updated
+   */
+  async reconcileAll(): Promise<{ updated: number }> {
+    const allAggregations = await this.aggregationPort.aggregateAll();
+
+    const stats = Array.from(allAggregations.entries()).map(([mediaItemId, agg]) => ({
+      mediaItemId,
+      communityAverageRating: roundToTwoDecimals(agg.averageRating),
+      communityRatingCount: agg.ratingCount,
+    }));
+
+    if (stats.length > 0) {
+      await this.statsRepository.bulkUpsert(stats);
+    }
+
+    this.logger.log(`Reconciled community ratings for ${stats.length} media items`);
+    return { updated: stats.length };
+  }
+}

--- a/apps/api/src/modules/stats/application/services/index.ts
+++ b/apps/api/src/modules/stats/application/services/index.ts
@@ -1,3 +1,4 @@
+export { CommunityRatingService } from './community-rating.service';
 export { DropOffService } from './drop-off.service';
 export { ScoreRecalculationService } from './score-recalculation.service';
 export { StatsBackfillService } from './stats-backfill.service';

--- a/apps/api/src/modules/stats/application/workers/stats.worker.spec.ts
+++ b/apps/api/src/modules/stats/application/workers/stats.worker.spec.ts
@@ -82,7 +82,7 @@ describe('StatsWorker', () => {
     });
 
     it('should process RECONCILE_COMMUNITY_RATINGS job', async () => {
-      communityRatingService.reconcileAll.mockResolvedValue({ updated: 10 });
+      communityRatingService.reconcileAll.mockResolvedValue({ updated: 10, reset: 0 });
       const job = { name: STATS_JOBS.RECONCILE_COMMUNITY_RATINGS, data: {}, id: '8' } as Job;
       await worker.process(job);
       expect(communityRatingService.reconcileAll).toHaveBeenCalled();

--- a/apps/api/src/modules/stats/application/workers/stats.worker.spec.ts
+++ b/apps/api/src/modules/stats/application/workers/stats.worker.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { StatsWorker } from './stats.worker';
+import { CommunityRatingService } from '../services/community-rating.service';
 import { DropOffService, StatsBackfillService, TrendingSyncService } from '../services';
 import { STATS_JOBS } from '../../stats.constants';
 import { Job } from 'bullmq';
@@ -9,6 +10,7 @@ describe('StatsWorker', () => {
   let trendingSyncService: any;
   let statsBackfillService: any;
   let dropOffService: any;
+  let communityRatingService: any;
 
   beforeEach(async () => {
     trendingSyncService = {
@@ -24,12 +26,18 @@ describe('StatsWorker', () => {
       analyzeAllShows: jest.fn(),
     };
 
+    communityRatingService = {
+      recalculateForMediaItem: jest.fn(),
+      reconcileAll: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         StatsWorker,
         { provide: TrendingSyncService, useValue: trendingSyncService },
         { provide: StatsBackfillService, useValue: statsBackfillService },
         { provide: DropOffService, useValue: dropOffService },
+        { provide: CommunityRatingService, useValue: communityRatingService },
       ],
     }).compile();
 
@@ -71,6 +79,13 @@ describe('StatsWorker', () => {
       const job = { name: STATS_JOBS.ANALYZE_DROP_OFF, data: {}, id: '5' } as Job;
       await worker.process(job);
       expect(dropOffService.analyzeAllShows).toHaveBeenCalledWith(50);
+    });
+
+    it('should process RECONCILE_COMMUNITY_RATINGS job', async () => {
+      communityRatingService.reconcileAll.mockResolvedValue({ updated: 10 });
+      const job = { name: STATS_JOBS.RECONCILE_COMMUNITY_RATINGS, data: {}, id: '8' } as Job;
+      await worker.process(job);
+      expect(communityRatingService.reconcileAll).toHaveBeenCalled();
     });
 
     it('should log warning for unknown job type', async () => {

--- a/apps/api/src/modules/stats/application/workers/stats.worker.ts
+++ b/apps/api/src/modules/stats/application/workers/stats.worker.ts
@@ -7,6 +7,7 @@ import { DEFAULT_BATCH_SIZE, MAX_PAGE_SIZE } from '../../../../common/constants'
 import { WORKER_CONFIG } from '../../../../config/queue.config';
 import { STATS_QUEUE, STATS_JOBS } from '../../stats.constants';
 import { DropOffService, StatsBackfillService, TrendingSyncService } from '../services';
+import { CommunityRatingService } from '../services/community-rating.service';
 
 /**
  * Background worker for processing stats-related jobs.
@@ -25,6 +26,7 @@ export class StatsWorker extends WorkerHost {
     private readonly trendingSyncService: TrendingSyncService,
     private readonly statsBackfillService: StatsBackfillService,
     private readonly dropOffService: DropOffService,
+    private readonly communityRatingService: CommunityRatingService,
   ) {
     super();
   }
@@ -63,6 +65,10 @@ export class StatsWorker extends WorkerHost {
 
         case STATS_JOBS.BACKFILL_WATCHERS_CHUNK:
           await this.processBackfillChunk(job);
+          break;
+
+        case STATS_JOBS.RECONCILE_COMMUNITY_RATINGS:
+          await this.communityRatingService.reconcileAll();
           break;
 
         default:

--- a/apps/api/src/modules/stats/domain/constants/community-rating.constants.spec.ts
+++ b/apps/api/src/modules/stats/domain/constants/community-rating.constants.spec.ts
@@ -1,0 +1,10 @@
+import { COMMUNITY_RATING_MIN_THRESHOLD } from './community-rating.constants';
+
+describe('community-rating.constants', () => {
+  describe('COMMUNITY_RATING_MIN_THRESHOLD', () => {
+    it('should be a positive integer', () => {
+      expect(COMMUNITY_RATING_MIN_THRESHOLD).toBeGreaterThan(0);
+      expect(Number.isInteger(COMMUNITY_RATING_MIN_THRESHOLD)).toBe(true);
+    });
+  });
+});

--- a/apps/api/src/modules/stats/domain/constants/community-rating.constants.ts
+++ b/apps/api/src/modules/stats/domain/constants/community-rating.constants.ts
@@ -1,2 +1,2 @@
 /** Minimum number of community ratings before displaying the average. */
-export const COMMUNITY_RATING_MIN_THRESHOLD = 5;
+export const COMMUNITY_RATING_MIN_THRESHOLD = 2;

--- a/apps/api/src/modules/stats/domain/constants/community-rating.constants.ts
+++ b/apps/api/src/modules/stats/domain/constants/community-rating.constants.ts
@@ -1,0 +1,2 @@
+/** Minimum number of community ratings before displaying the average. */
+export const COMMUNITY_RATING_MIN_THRESHOLD = 5;

--- a/apps/api/src/modules/stats/domain/ports/community-rating-aggregation.port.ts
+++ b/apps/api/src/modules/stats/domain/ports/community-rating-aggregation.port.ts
@@ -1,0 +1,30 @@
+export const COMMUNITY_RATING_AGGREGATION_PORT = Symbol('COMMUNITY_RATING_AGGREGATION_PORT');
+
+/**
+ * Aggregated community rating data for a single media item.
+ */
+export interface CommunityRatingAggregation {
+  averageRating: number;
+  ratingCount: number;
+}
+
+/**
+ * Port for aggregating community ratings from user rating data.
+ * Infrastructure layer implements this to query the actual data source.
+ */
+export interface ICommunityRatingAggregationPort {
+  /**
+   * Aggregates ratings for a single media item.
+   *
+   * @param mediaItemId - Internal UUID of the media item
+   * @returns Aggregation result or null if no ratings exist
+   */
+  aggregateForMediaItem(mediaItemId: string): Promise<CommunityRatingAggregation | null>;
+
+  /**
+   * Aggregates ratings for all media items that have at least one rating.
+   *
+   * @returns Map of mediaItemId to aggregation result
+   */
+  aggregateAll(): Promise<Map<string, CommunityRatingAggregation>>;
+}

--- a/apps/api/src/modules/stats/domain/ports/community-rating-aggregation.port.ts
+++ b/apps/api/src/modules/stats/domain/ports/community-rating-aggregation.port.ts
@@ -27,4 +27,12 @@ export interface ICommunityRatingAggregationPort {
    * @returns Map of mediaItemId to aggregation result
    */
   aggregateAll(): Promise<Map<string, CommunityRatingAggregation>>;
+
+  /**
+   * Returns IDs of media items that currently have non-zero community ratings in media_stats.
+   * Used to detect stale ratings that should be reset during reconciliation.
+   *
+   * @returns Array of media item UUIDs
+   */
+  findMediaItemIdsWithCommunityRatings(): Promise<string[]>;
 }

--- a/apps/api/src/modules/stats/domain/repositories/stats.repository.interface.ts
+++ b/apps/api/src/modules/stats/domain/repositories/stats.repository.interface.ts
@@ -24,6 +24,10 @@ export interface MediaStatsData {
   popularityScore?: number;
   /** Freshness/recency component score (0-1) */
   freshnessScore?: number;
+  /** Community average rating (0-100 scale, aggregated from user ratings) */
+  communityAverageRating?: number;
+  /** Number of community ratings */
+  communityRatingCount?: number;
 }
 
 /**
@@ -86,4 +90,19 @@ export interface IStatsRepository {
    * @returns {Promise<void>} Nothing
    */
   updateWatchersCount(mediaItemId: string, watchersCount: number): Promise<void>;
+
+  /**
+   * Upserts community rating fields for a media item.
+   * Creates the stats row if it doesn't exist.
+   *
+   * @param {string} mediaItemId - Internal UUID of the media item
+   * @param {number} averageRating - The community average rating (0-100)
+   * @param {number} ratingCount - The number of community ratings
+   * @returns {Promise<void>} Nothing
+   */
+  updateCommunityRating(
+    mediaItemId: string,
+    averageRating: number,
+    ratingCount: number,
+  ): Promise<void>;
 }

--- a/apps/api/src/modules/stats/infrastructure/queries/community-rating-aggregation.query.spec.ts
+++ b/apps/api/src/modules/stats/infrastructure/queries/community-rating-aggregation.query.spec.ts
@@ -1,0 +1,263 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CommunityRatingAggregationQuery } from './community-rating-aggregation.query';
+import { DATABASE_CONNECTION } from '../../../../database/database.module';
+import { DatabaseException } from '../../../../common/exceptions';
+
+describe('CommunityRatingAggregationQuery', () => {
+  let query: CommunityRatingAggregationQuery;
+
+  const createMockDb = (options: { resolveWith?: any; rejectWith?: Error } = {}) => {
+    // Create a thenable object that resolves/rejects when awaited
+    const createThenable = () => {
+      const thenable: any = {};
+
+      // All chain methods return the same thenable
+      const chainMethods = [
+        'from',
+        'where',
+        'limit',
+        'innerJoin',
+        'values',
+        'onConflictDoUpdate',
+        'groupBy',
+      ];
+      chainMethods.forEach((method) => {
+        thenable[method] = jest.fn().mockReturnValue(thenable);
+      });
+
+      // Make it thenable (awaitable)
+      if (options.rejectWith) {
+        thenable.then = function (onFulfilled: any, onRejected: any) {
+          return Promise.reject(options.rejectWith).then(onFulfilled, onRejected);
+        };
+      } else {
+        thenable.then = function (onFulfilled: any, onRejected: any) {
+          return Promise.resolve(options.resolveWith ?? []).then(onFulfilled, onRejected);
+        };
+      }
+
+      return thenable;
+    };
+
+    const thenable = createThenable();
+
+    // Root db methods that start the chain
+    return {
+      select: jest.fn().mockReturnValue(thenable),
+      insert: jest.fn().mockReturnValue(thenable),
+    };
+  };
+
+  describe('aggregateForMediaItem', () => {
+    it('should return aggregation when ratings exist', async () => {
+      const mockResult = [{ averageRating: 4.2, ratingCount: 15 }];
+      const mockDb = createMockDb({ resolveWith: mockResult });
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          CommunityRatingAggregationQuery,
+          { provide: DATABASE_CONNECTION, useValue: mockDb },
+        ],
+      }).compile();
+
+      query = module.get<CommunityRatingAggregationQuery>(CommunityRatingAggregationQuery);
+
+      const result = await query.aggregateForMediaItem('media-1');
+
+      expect(result).toEqual({ averageRating: 4.2, ratingCount: 15 });
+      expect(mockDb.select).toHaveBeenCalled();
+    });
+
+    it('should return null when no ratings (empty result)', async () => {
+      const mockDb = createMockDb({ resolveWith: [] });
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          CommunityRatingAggregationQuery,
+          { provide: DATABASE_CONNECTION, useValue: mockDb },
+        ],
+      }).compile();
+
+      query = module.get<CommunityRatingAggregationQuery>(CommunityRatingAggregationQuery);
+
+      const result = await query.aggregateForMediaItem('non-existent');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when ratingCount is 0', async () => {
+      const mockResult = [{ averageRating: null, ratingCount: 0 }];
+      const mockDb = createMockDb({ resolveWith: mockResult });
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          CommunityRatingAggregationQuery,
+          { provide: DATABASE_CONNECTION, useValue: mockDb },
+        ],
+      }).compile();
+
+      query = module.get<CommunityRatingAggregationQuery>(CommunityRatingAggregationQuery);
+
+      const result = await query.aggregateForMediaItem('media-no-ratings');
+
+      expect(result).toBeNull();
+    });
+
+    it('should throw DatabaseException on DB error', async () => {
+      const mockDb = createMockDb({ rejectWith: new Error('DB Error') });
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          CommunityRatingAggregationQuery,
+          { provide: DATABASE_CONNECTION, useValue: mockDb },
+        ],
+      }).compile();
+
+      query = module.get<CommunityRatingAggregationQuery>(CommunityRatingAggregationQuery);
+
+      await expect(query.aggregateForMediaItem('media-1')).rejects.toThrow(DatabaseException);
+    });
+  });
+
+  describe('aggregateAll', () => {
+    it('should return Map with multiple items', async () => {
+      const mockRows = [
+        { mediaItemId: 'media-1', averageRating: 4.5, ratingCount: 10 },
+        { mediaItemId: 'media-2', averageRating: 3.8, ratingCount: 25 },
+        { mediaItemId: 'media-3', averageRating: 2.1, ratingCount: 3 },
+      ];
+      const mockDb = createMockDb({ resolveWith: mockRows });
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          CommunityRatingAggregationQuery,
+          { provide: DATABASE_CONNECTION, useValue: mockDb },
+        ],
+      }).compile();
+
+      query = module.get<CommunityRatingAggregationQuery>(CommunityRatingAggregationQuery);
+
+      const result = await query.aggregateAll();
+
+      expect(result).toBeInstanceOf(Map);
+      expect(result.size).toBe(3);
+      expect(result.get('media-1')).toEqual({ averageRating: 4.5, ratingCount: 10 });
+      expect(result.get('media-2')).toEqual({ averageRating: 3.8, ratingCount: 25 });
+      expect(result.get('media-3')).toEqual({ averageRating: 2.1, ratingCount: 3 });
+    });
+
+    it('should return empty Map when no ratings', async () => {
+      const mockDb = createMockDb({ resolveWith: [] });
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          CommunityRatingAggregationQuery,
+          { provide: DATABASE_CONNECTION, useValue: mockDb },
+        ],
+      }).compile();
+
+      query = module.get<CommunityRatingAggregationQuery>(CommunityRatingAggregationQuery);
+
+      const result = await query.aggregateAll();
+
+      expect(result).toBeInstanceOf(Map);
+      expect(result.size).toBe(0);
+    });
+
+    it('should filter out items with ratingCount 0', async () => {
+      const mockRows = [
+        { mediaItemId: 'media-1', averageRating: 4.5, ratingCount: 10 },
+        { mediaItemId: 'media-2', averageRating: null, ratingCount: 0 },
+        { mediaItemId: 'media-3', averageRating: 3.0, ratingCount: 5 },
+      ];
+      const mockDb = createMockDb({ resolveWith: mockRows });
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          CommunityRatingAggregationQuery,
+          { provide: DATABASE_CONNECTION, useValue: mockDb },
+        ],
+      }).compile();
+
+      query = module.get<CommunityRatingAggregationQuery>(CommunityRatingAggregationQuery);
+
+      const result = await query.aggregateAll();
+
+      expect(result.size).toBe(2);
+      expect(result.has('media-1')).toBe(true);
+      expect(result.has('media-2')).toBe(false);
+      expect(result.has('media-3')).toBe(true);
+    });
+
+    it('should throw DatabaseException on DB error', async () => {
+      const mockDb = createMockDb({ rejectWith: new Error('DB Error') });
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          CommunityRatingAggregationQuery,
+          { provide: DATABASE_CONNECTION, useValue: mockDb },
+        ],
+      }).compile();
+
+      query = module.get<CommunityRatingAggregationQuery>(CommunityRatingAggregationQuery);
+
+      await expect(query.aggregateAll()).rejects.toThrow(DatabaseException);
+    });
+  });
+
+  describe('findMediaItemIdsWithCommunityRatings', () => {
+    it('should return array of IDs', async () => {
+      const mockRows = [
+        { mediaItemId: 'media-1' },
+        { mediaItemId: 'media-2' },
+        { mediaItemId: 'media-3' },
+      ];
+      const mockDb = createMockDb({ resolveWith: mockRows });
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          CommunityRatingAggregationQuery,
+          { provide: DATABASE_CONNECTION, useValue: mockDb },
+        ],
+      }).compile();
+
+      query = module.get<CommunityRatingAggregationQuery>(CommunityRatingAggregationQuery);
+
+      const result = await query.findMediaItemIdsWithCommunityRatings();
+
+      expect(result).toEqual(['media-1', 'media-2', 'media-3']);
+    });
+
+    it('should return empty array when none found', async () => {
+      const mockDb = createMockDb({ resolveWith: [] });
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          CommunityRatingAggregationQuery,
+          { provide: DATABASE_CONNECTION, useValue: mockDb },
+        ],
+      }).compile();
+
+      query = module.get<CommunityRatingAggregationQuery>(CommunityRatingAggregationQuery);
+
+      const result = await query.findMediaItemIdsWithCommunityRatings();
+
+      expect(result).toEqual([]);
+    });
+
+    it('should throw DatabaseException on DB error', async () => {
+      const mockDb = createMockDb({ rejectWith: new Error('DB Error') });
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          CommunityRatingAggregationQuery,
+          { provide: DATABASE_CONNECTION, useValue: mockDb },
+        ],
+      }).compile();
+
+      query = module.get<CommunityRatingAggregationQuery>(CommunityRatingAggregationQuery);
+
+      await expect(query.findMediaItemIdsWithCommunityRatings()).rejects.toThrow(DatabaseException);
+    });
+  });
+});

--- a/apps/api/src/modules/stats/infrastructure/queries/community-rating-aggregation.query.ts
+++ b/apps/api/src/modules/stats/infrastructure/queries/community-rating-aggregation.query.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 
-import { isNotNull, eq, sql } from 'drizzle-orm';
+import { and, gt, isNotNull, eq, sql } from 'drizzle-orm';
 import { type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 
 import { withDbError } from '@/common/utils/db-error.utils';
@@ -40,8 +40,12 @@ export class CommunityRatingAggregationQuery implements ICommunityRatingAggregat
             ratingCount: sql<number>`COUNT(${schema.userMediaState.rating})::int`,
           })
           .from(schema.userMediaState)
-          .where(eq(schema.userMediaState.mediaItemId, mediaItemId))
-          .having(sql`COUNT(${schema.userMediaState.rating}) > 0`);
+          .where(
+            and(
+              eq(schema.userMediaState.mediaItemId, mediaItemId),
+              isNotNull(schema.userMediaState.rating),
+            ),
+          );
 
         if (!result.length || result[0].ratingCount === 0) {
           return null;
@@ -82,6 +86,20 @@ export class CommunityRatingAggregationQuery implements ICommunityRatingAggregat
         }
       }
       return map;
+    });
+  }
+
+  /**
+   * Returns IDs of media items that currently have non-zero community ratings in media_stats.
+   */
+  async findMediaItemIdsWithCommunityRatings(): Promise<string[]> {
+    return withDbError('find media items with community ratings', this.logger, async () => {
+      const rows = await this.db
+        .select({ mediaItemId: schema.mediaStats.mediaItemId })
+        .from(schema.mediaStats)
+        .where(gt(schema.mediaStats.communityRatingCount, 0));
+
+      return rows.map((row) => row.mediaItemId);
     });
   }
 }

--- a/apps/api/src/modules/stats/infrastructure/queries/community-rating-aggregation.query.ts
+++ b/apps/api/src/modules/stats/infrastructure/queries/community-rating-aggregation.query.ts
@@ -1,0 +1,87 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+
+import { isNotNull, eq, sql } from 'drizzle-orm';
+import { type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+
+import { withDbError } from '@/common/utils/db-error.utils';
+
+import { DATABASE_CONNECTION } from '../../../../database/database.module';
+import * as schema from '../../../../database/schema';
+import {
+  type CommunityRatingAggregation,
+  type ICommunityRatingAggregationPort,
+} from '../../domain/ports/community-rating-aggregation.port';
+
+/**
+ * Drizzle-based implementation of the community rating aggregation port.
+ * Queries user_media_state to compute average ratings per media item.
+ */
+@Injectable()
+export class CommunityRatingAggregationQuery implements ICommunityRatingAggregationPort {
+  private readonly logger = new Logger(CommunityRatingAggregationQuery.name);
+
+  constructor(
+    @Inject(DATABASE_CONNECTION)
+    private readonly db: PostgresJsDatabase<typeof schema>,
+  ) {}
+
+  /**
+   * Aggregates community ratings for a single media item.
+   * Returns null when there are no ratings.
+   */
+  async aggregateForMediaItem(mediaItemId: string): Promise<CommunityRatingAggregation | null> {
+    return withDbError(
+      'aggregate community rating for media item',
+      this.logger,
+      async () => {
+        const result = await this.db
+          .select({
+            averageRating: sql<number>`AVG(${schema.userMediaState.rating})::float`,
+            ratingCount: sql<number>`COUNT(${schema.userMediaState.rating})::int`,
+          })
+          .from(schema.userMediaState)
+          .where(eq(schema.userMediaState.mediaItemId, mediaItemId))
+          .having(sql`COUNT(${schema.userMediaState.rating}) > 0`);
+
+        if (!result.length || result[0].ratingCount === 0) {
+          return null;
+        }
+
+        return {
+          averageRating: result[0].averageRating,
+          ratingCount: result[0].ratingCount,
+        };
+      },
+      { mediaItemId },
+    );
+  }
+
+  /**
+   * Aggregates community ratings for all media items that have at least one rating.
+   * Returns a Map keyed by mediaItemId.
+   */
+  async aggregateAll(): Promise<Map<string, CommunityRatingAggregation>> {
+    return withDbError('aggregate all community ratings', this.logger, async () => {
+      const rows = await this.db
+        .select({
+          mediaItemId: schema.userMediaState.mediaItemId,
+          averageRating: sql<number>`AVG(${schema.userMediaState.rating})::float`,
+          ratingCount: sql<number>`COUNT(${schema.userMediaState.rating})::int`,
+        })
+        .from(schema.userMediaState)
+        .where(isNotNull(schema.userMediaState.rating))
+        .groupBy(schema.userMediaState.mediaItemId);
+
+      const map = new Map<string, CommunityRatingAggregation>();
+      for (const row of rows) {
+        if (row.ratingCount > 0) {
+          map.set(row.mediaItemId, {
+            averageRating: row.averageRating,
+            ratingCount: row.ratingCount,
+          });
+        }
+      }
+      return map;
+    });
+  }
+}

--- a/apps/api/src/modules/stats/infrastructure/repositories/drizzle-stats.repository.spec.ts
+++ b/apps/api/src/modules/stats/infrastructure/repositories/drizzle-stats.repository.spec.ts
@@ -123,7 +123,14 @@ describe('DrizzleStatsRepository', () => {
   describe('findByMediaItemId', () => {
     it('should return stats if found', async () => {
       const mockResult = [
-        { mediaItemId: 'media-1', watchersCount: 100, trendingRank: 5, popularity24h: 50 },
+        {
+          mediaItemId: 'media-1',
+          watchersCount: 100,
+          trendingRank: 5,
+          popularity24h: 50,
+          communityAverageRating: 75.5,
+          communityRatingCount: 10,
+        },
       ];
       const mockDb = createMockDb({ resolveWith: mockResult });
 
@@ -140,6 +147,8 @@ describe('DrizzleStatsRepository', () => {
         watchersCount: 100,
         trendingRank: 5,
         popularity24h: 50,
+        communityAverageRating: 75.5,
+        communityRatingCount: 10,
       });
     });
 
@@ -159,7 +168,14 @@ describe('DrizzleStatsRepository', () => {
 
     it('should handle null values gracefully', async () => {
       const mockResult = [
-        { mediaItemId: 'media-1', watchersCount: null, trendingRank: null, popularity24h: null },
+        {
+          mediaItemId: 'media-1',
+          watchersCount: null,
+          trendingRank: null,
+          popularity24h: null,
+          communityAverageRating: null,
+          communityRatingCount: null,
+        },
       ];
       const mockDb = createMockDb({ resolveWith: mockResult });
 
@@ -176,6 +192,8 @@ describe('DrizzleStatsRepository', () => {
         watchersCount: 0,
         trendingRank: undefined,
         popularity24h: undefined,
+        communityAverageRating: undefined,
+        communityRatingCount: undefined,
       });
     });
 
@@ -195,7 +213,14 @@ describe('DrizzleStatsRepository', () => {
   describe('findByTmdbId', () => {
     it('should return stats if found', async () => {
       const mockResult = [
-        { mediaItemId: 'media-1', watchersCount: 200, trendingRank: 3, popularity24h: 80 },
+        {
+          mediaItemId: 'media-1',
+          watchersCount: 200,
+          trendingRank: 3,
+          popularity24h: 80,
+          communityAverageRating: 80,
+          communityRatingCount: 15,
+        },
       ];
       const mockDb = createMockDb({ resolveWith: mockResult });
 
@@ -212,6 +237,8 @@ describe('DrizzleStatsRepository', () => {
         watchersCount: 200,
         trendingRank: 3,
         popularity24h: 80,
+        communityAverageRating: 80,
+        communityRatingCount: 15,
       });
       expect(mockDb.select).toHaveBeenCalled();
     });
@@ -284,7 +311,7 @@ describe('DrizzleStatsRepository', () => {
 
       repository = module.get<DrizzleStatsRepository>(DrizzleStatsRepository);
 
-      await repository.updateCommunityRating('media-1', 4.2, 15);
+      await repository.updateCommunityRating('media-1', 42, 15);
 
       // Should use INSERT ... ON CONFLICT (upsert pattern)
       expect(mockDb.insert).toHaveBeenCalled();
@@ -299,7 +326,7 @@ describe('DrizzleStatsRepository', () => {
 
       repository = module.get<DrizzleStatsRepository>(DrizzleStatsRepository);
 
-      await expect(repository.updateCommunityRating('media-1', 4.2, 15)).rejects.toThrow(
+      await expect(repository.updateCommunityRating('media-1', 42, 15)).rejects.toThrow(
         DatabaseException,
       );
     });

--- a/apps/api/src/modules/stats/infrastructure/repositories/drizzle-stats.repository.spec.ts
+++ b/apps/api/src/modules/stats/infrastructure/repositories/drizzle-stats.repository.spec.ts
@@ -273,4 +273,35 @@ describe('DrizzleStatsRepository', () => {
       );
     });
   });
+
+  describe('updateCommunityRating', () => {
+    it('should upsert community rating successfully', async () => {
+      const mockDb = createMockDb();
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [DrizzleStatsRepository, { provide: DATABASE_CONNECTION, useValue: mockDb }],
+      }).compile();
+
+      repository = module.get<DrizzleStatsRepository>(DrizzleStatsRepository);
+
+      await repository.updateCommunityRating('media-1', 4.2, 15);
+
+      // Should use INSERT ... ON CONFLICT (upsert pattern)
+      expect(mockDb.insert).toHaveBeenCalled();
+    });
+
+    it('should throw DatabaseException on error', async () => {
+      const mockDb = createMockDb({ rejectWith: new Error('DB Error') });
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [DrizzleStatsRepository, { provide: DATABASE_CONNECTION, useValue: mockDb }],
+      }).compile();
+
+      repository = module.get<DrizzleStatsRepository>(DrizzleStatsRepository);
+
+      await expect(repository.updateCommunityRating('media-1', 4.2, 15)).rejects.toThrow(
+        DatabaseException,
+      );
+    });
+  });
 });

--- a/apps/api/src/modules/stats/infrastructure/repositories/drizzle-stats.repository.ts
+++ b/apps/api/src/modules/stats/infrastructure/repositories/drizzle-stats.repository.ts
@@ -41,6 +41,8 @@ export class DrizzleStatsRepository implements IStatsRepository {
             qualityScore: stats.qualityScore,
             popularityScore: stats.popularityScore,
             freshnessScore: stats.freshnessScore,
+            communityAverageRating: stats.communityAverageRating,
+            communityRatingCount: stats.communityRatingCount,
             updatedAt: new Date(),
           })
           .onConflictDoUpdate({
@@ -53,6 +55,8 @@ export class DrizzleStatsRepository implements IStatsRepository {
               qualityScore: stats.qualityScore,
               popularityScore: stats.popularityScore,
               freshnessScore: stats.freshnessScore,
+              communityAverageRating: stats.communityAverageRating,
+              communityRatingCount: stats.communityRatingCount,
               updatedAt: new Date(),
             },
           });
@@ -78,6 +82,8 @@ export class DrizzleStatsRepository implements IStatsRepository {
           qualityScore: stat.qualityScore,
           popularityScore: stat.popularityScore,
           freshnessScore: stat.freshnessScore,
+          communityAverageRating: stat.communityAverageRating,
+          communityRatingCount: stat.communityRatingCount,
           updatedAt: now,
         }));
 
@@ -95,6 +101,8 @@ export class DrizzleStatsRepository implements IStatsRepository {
               qualityScore: sql`COALESCE(excluded.quality_score, media_stats.quality_score)`,
               popularityScore: sql`COALESCE(excluded.popularity_score, media_stats.popularity_score)`,
               freshnessScore: sql`COALESCE(excluded.freshness_score, media_stats.freshness_score)`,
+              communityAverageRating: sql`COALESCE(excluded.community_average_rating, media_stats.community_average_rating)`,
+              communityRatingCount: sql`COALESCE(excluded.community_rating_count, media_stats.community_rating_count)`,
               updatedAt: sql`excluded.updated_at`,
             },
           });
@@ -212,6 +220,41 @@ export class DrizzleStatsRepository implements IStatsRepository {
           });
       },
       { mediaItemId, watchersCount },
+    );
+  }
+
+  /**
+   * Upserts community rating fields for a media item.
+   * Creates the stats row if it doesn't exist.
+   * Uses INSERT ON CONFLICT to handle missing rows.
+   */
+  async updateCommunityRating(
+    mediaItemId: string,
+    averageRating: number,
+    ratingCount: number,
+  ): Promise<void> {
+    return withDbError(
+      'upsert community rating',
+      this.logger,
+      async () => {
+        await this.db
+          .insert(schema.mediaStats)
+          .values({
+            mediaItemId,
+            communityAverageRating: averageRating,
+            communityRatingCount: ratingCount,
+            updatedAt: new Date(),
+          })
+          .onConflictDoUpdate({
+            target: schema.mediaStats.mediaItemId,
+            set: {
+              communityAverageRating: averageRating,
+              communityRatingCount: ratingCount,
+              updatedAt: new Date(),
+            },
+          });
+      },
+      { mediaItemId, averageRating, ratingCount },
     );
   }
 }

--- a/apps/api/src/modules/stats/infrastructure/repositories/drizzle-stats.repository.ts
+++ b/apps/api/src/modules/stats/infrastructure/repositories/drizzle-stats.repository.ts
@@ -129,6 +129,8 @@ export class DrizzleStatsRepository implements IStatsRepository {
           watchersCount: result[0].watchersCount ?? 0,
           trendingRank: result[0].trendingRank ?? undefined,
           popularity24h: result[0].popularity24h ?? undefined,
+          communityAverageRating: result[0].communityAverageRating ?? undefined,
+          communityRatingCount: result[0].communityRatingCount ?? undefined,
         };
       },
       { mediaItemId },
@@ -146,6 +148,8 @@ export class DrizzleStatsRepository implements IStatsRepository {
             watchersCount: schema.mediaStats.watchersCount,
             trendingRank: schema.mediaStats.trendingRank,
             popularity24h: schema.mediaStats.popularity24h,
+            communityAverageRating: schema.mediaStats.communityAverageRating,
+            communityRatingCount: schema.mediaStats.communityRatingCount,
           })
           .from(schema.mediaStats)
           .innerJoin(schema.mediaItems, eq(schema.mediaStats.mediaItemId, schema.mediaItems.id))
@@ -159,6 +163,8 @@ export class DrizzleStatsRepository implements IStatsRepository {
           watchersCount: result[0].watchersCount ?? 0,
           trendingRank: result[0].trendingRank ?? undefined,
           popularity24h: result[0].popularity24h ?? undefined,
+          communityAverageRating: result[0].communityAverageRating ?? undefined,
+          communityRatingCount: result[0].communityRatingCount ?? undefined,
         };
       },
       { tmdbId },

--- a/apps/api/src/modules/stats/presentation/controllers/stats.controller.spec.ts
+++ b/apps/api/src/modules/stats/presentation/controllers/stats.controller.spec.ts
@@ -15,6 +15,7 @@ describe('StatsController', () => {
   let controller: StatsController;
   let statsQueryService: jest.Mocked<StatsQueryService>;
   let dropOffService: jest.Mocked<DropOffService>;
+  let communityRatingService: jest.Mocked<CommunityRatingService>;
   let mockQueue: any;
 
   beforeEach(async () => {
@@ -36,7 +37,7 @@ describe('StatsController', () => {
     };
 
     const mockCommunityRatingService = {
-      reconcileAll: jest.fn().mockResolvedValue({ updated: 0 }),
+      reconcileAll: jest.fn().mockResolvedValue({ updated: 0, reset: 0 }),
     };
 
     mockQueue = {
@@ -58,6 +59,7 @@ describe('StatsController', () => {
     controller = module.get<StatsController>(StatsController);
     statsQueryService = module.get(StatsQueryService);
     dropOffService = module.get(DropOffService);
+    communityRatingService = module.get(CommunityRatingService);
   });
 
   describe('syncTrendingStats', () => {
@@ -180,6 +182,33 @@ describe('StatsController', () => {
       expect(result).toEqual({
         message: 'No drop-off analysis available. Run POST /stats/drop-off/analyze/{tmdbId} first.',
         tmdbId: 12345,
+      });
+    });
+  });
+
+  describe('reconcileCommunityRatings', () => {
+    it('should call communityRatingService.reconcileAll and return result', async () => {
+      communityRatingService.reconcileAll.mockResolvedValue({ updated: 5, reset: 2 });
+
+      const result = await controller.reconcileCommunityRatings();
+
+      expect(result).toEqual({
+        message: 'Community ratings reconciliation complete',
+        updated: 5,
+        reset: 2,
+      });
+      expect(communityRatingService.reconcileAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return zero counts when nothing to reconcile', async () => {
+      communityRatingService.reconcileAll.mockResolvedValue({ updated: 0, reset: 0 });
+
+      const result = await controller.reconcileCommunityRatings();
+
+      expect(result).toEqual({
+        message: 'Community ratings reconciliation complete',
+        updated: 0,
+        reset: 0,
       });
     });
   });

--- a/apps/api/src/modules/stats/presentation/controllers/stats.controller.spec.ts
+++ b/apps/api/src/modules/stats/presentation/controllers/stats.controller.spec.ts
@@ -6,6 +6,7 @@ import {
   StatsBackfillService,
   StatsQueryService,
 } from '../../application/services';
+import { CommunityRatingService } from '../../application/services/community-rating.service';
 import { getQueueToken } from '@nestjs/bullmq';
 import { STATS_QUEUE, STATS_JOBS } from '../../stats.constants';
 import { StatsNotFoundException } from '@/common/exceptions';
@@ -34,6 +35,10 @@ describe('StatsController', () => {
       getAnalysis: jest.fn(),
     };
 
+    const mockCommunityRatingService = {
+      reconcileAll: jest.fn().mockResolvedValue({ updated: 0 }),
+    };
+
     mockQueue = {
       add: jest.fn().mockResolvedValue({ id: 'job-123' }),
     };
@@ -45,6 +50,7 @@ describe('StatsController', () => {
         { provide: ScoreRecalculationService, useValue: mockScoreRecalculationService },
         { provide: StatsBackfillService, useValue: mockStatsBackfillService },
         { provide: DropOffService, useValue: mockDropOffService },
+        { provide: CommunityRatingService, useValue: mockCommunityRatingService },
         { provide: getQueueToken(STATS_QUEUE), useValue: mockQueue },
       ],
     }).compile();

--- a/apps/api/src/modules/stats/presentation/controllers/stats.controller.ts
+++ b/apps/api/src/modules/stats/presentation/controllers/stats.controller.ts
@@ -13,6 +13,7 @@ import {
   StatsBackfillService,
   StatsQueryService,
 } from '../../application/services';
+import { CommunityRatingService } from '../../application/services/community-rating.service';
 import { STATS_QUEUE, STATS_JOBS } from '../../stats.constants';
 import {
   BackfillTotalWatchersQueryDto,
@@ -43,6 +44,7 @@ export class StatsController {
     private readonly scoreRecalculationService: ScoreRecalculationService,
     private readonly statsBackfillService: StatsBackfillService,
     private readonly dropOffService: DropOffService,
+    private readonly communityRatingService: CommunityRatingService,
     @InjectQueue(STATS_QUEUE) private readonly statsQueue: Queue,
   ) {}
 
@@ -292,6 +294,26 @@ export class StatsController {
     return {
       message: `Score recalculation complete`,
       total: result.total,
+    };
+  }
+
+  // === COMMUNITY RATINGS ===
+
+  @Post('reconcile-community-ratings')
+  @ApiBearerAuth()
+  @UseGuards(AdminJwtGuard)
+  @ApiTags('Service: Stats')
+  @ApiOperation({
+    summary: 'Reconcile community ratings',
+    description:
+      'Aggregates all user ratings and updates community_average_rating / community_rating_count in media_stats.',
+  })
+  async reconcileCommunityRatings() {
+    const result = await this.communityRatingService.reconcileAll();
+
+    return {
+      message: 'Community ratings reconciliation complete',
+      ...result,
     };
   }
 }

--- a/apps/api/src/modules/stats/stats.constants.ts
+++ b/apps/api/src/modules/stats/stats.constants.ts
@@ -11,6 +11,7 @@ export const STATS_JOBS = {
   SYNC_ELIGIBLE_TRENDING: 'sync-eligible-trending',
   ANALYZE_DROP_OFF: 'analyze-drop-off',
   BACKFILL_WATCHERS_CHUNK: 'backfill-watchers-chunk',
+  RECONCILE_COMMUNITY_RATINGS: 'reconcile-community-ratings',
 } as const;
 
 /**

--- a/apps/api/src/modules/stats/stats.module.ts
+++ b/apps/api/src/modules/stats/stats.module.ts
@@ -6,6 +6,7 @@ import { IngestionModule } from '../ingestion/ingestion.module';
 import { DropOffAnalyzerModule } from '../shared/drop-off-analyzer';
 import { ScoreCalculatorModule } from '../shared/score-calculator';
 
+import { CommunityRatingChangedListener } from './application/listeners/community-rating-changed.listener';
 import {
   DropOffService,
   ScoreRecalculationService,
@@ -13,8 +14,11 @@ import {
   StatsQueryService,
   TrendingSyncService,
 } from './application/services';
+import { CommunityRatingService } from './application/services/community-rating.service';
 import { StatsWorker } from './application/workers/stats.worker';
+import { COMMUNITY_RATING_AGGREGATION_PORT } from './domain/ports/community-rating-aggregation.port';
 import { STATS_REPOSITORY } from './domain/repositories/stats.repository.interface';
+import { CommunityRatingAggregationQuery } from './infrastructure/queries/community-rating-aggregation.query';
 import { DrizzleStatsRepository } from './infrastructure/repositories/drizzle-stats.repository';
 import { StatsController } from './presentation/controllers/stats.controller';
 import { STATS_QUEUE } from './stats.constants';
@@ -45,10 +49,17 @@ import { STATS_QUEUE } from './stats.constants';
     StatsBackfillService,
     StatsQueryService,
     DropOffService,
+    CommunityRatingService,
+    CommunityRatingChangedListener,
+    CommunityRatingAggregationQuery,
     StatsWorker,
     {
       provide: STATS_REPOSITORY,
       useClass: DrizzleStatsRepository,
+    },
+    {
+      provide: COMMUNITY_RATING_AGGREGATION_PORT,
+      useClass: CommunityRatingAggregationQuery,
     },
   ],
   exports: [TrendingSyncService, StatsQueryService, DropOffService, STATS_REPOSITORY],

--- a/apps/api/src/modules/stats/stats.module.ts
+++ b/apps/api/src/modules/stats/stats.module.ts
@@ -51,7 +51,6 @@ import { STATS_QUEUE } from './stats.constants';
     DropOffService,
     CommunityRatingService,
     CommunityRatingChangedListener,
-    CommunityRatingAggregationQuery,
     StatsWorker,
     {
       provide: STATS_REPOSITORY,

--- a/apps/api/test/catalog/_fixtures.ts
+++ b/apps/api/test/catalog/_fixtures.ts
@@ -24,6 +24,8 @@ export const moviesFixture: MovieWithMedia[] = [
       popularityScore: 0.9,
       liveWatchers: null,
       totalWatchers: null,
+      communityAverageRating: null,
+      communityRatingCount: null,
     },
     externalRatings: {
       tmdb: { rating: 7, voteCount: 100 },
@@ -56,6 +58,8 @@ export const moviesFixture: MovieWithMedia[] = [
       popularityScore: 0.6,
       liveWatchers: null,
       totalWatchers: null,
+      communityAverageRating: null,
+      communityRatingCount: null,
     },
     externalRatings: {
       tmdb: { rating: 6.5, voteCount: 50 },
@@ -88,6 +92,8 @@ export const moviesFixture: MovieWithMedia[] = [
       popularityScore: 0.4,
       liveWatchers: null,
       totalWatchers: null,
+      communityAverageRating: null,
+      communityRatingCount: null,
     },
     externalRatings: {
       tmdb: { rating: 9.1, voteCount: 1000 },
@@ -123,6 +129,8 @@ export const moviesFixture: MovieWithMedia[] = [
       popularityScore: 0.2,
       liveWatchers: null,
       totalWatchers: null,
+      communityAverageRating: null,
+      communityRatingCount: null,
     },
     externalRatings: {
       tmdb: { rating: 4.1, voteCount: 5 },

--- a/apps/web-client/src/modules/details/components/__tests__/community-rating.spec.tsx
+++ b/apps/web-client/src/modules/details/components/__tests__/community-rating.spec.tsx
@@ -19,7 +19,11 @@ jest.mock('@/shared/i18n', () => ({
       details: {
         communityRating: {
           label: 'Community Rating',
-          ratings: 'ratings',
+          ratings: {
+            one: 'rating',
+            few: 'ratings',
+            many: 'ratings',
+          },
         },
       },
     },

--- a/apps/web-client/src/modules/details/components/__tests__/community-rating.spec.tsx
+++ b/apps/web-client/src/modules/details/components/__tests__/community-rating.spec.tsx
@@ -1,0 +1,135 @@
+/**
+ * Tests for CommunityRating component.
+ *
+ * Covers: rendering above threshold, hiding below threshold,
+ * correct rating formatting, and i18n label display.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { CommunityRating } from '../community-rating';
+import { COMMUNITY_RATING_MIN_THRESHOLD } from '../../constants/community-rating';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+jest.mock('@/shared/i18n', () => ({
+  useTranslation: () => ({
+    dict: {
+      details: {
+        communityRating: {
+          label: 'Community Rating',
+          ratings: 'ratings',
+        },
+      },
+    },
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CommunityRating', () => {
+  // =========================================================================
+  // Rendering above threshold
+  // =========================================================================
+
+  describe('when rating count is at or above threshold', () => {
+    it('renders rating and count when count equals threshold', () => {
+      render(
+        <CommunityRating
+          averageRating={75}
+          ratingCount={COMMUNITY_RATING_MIN_THRESHOLD}
+        />,
+      );
+
+      expect(screen.getByText('7.5')).toBeInTheDocument();
+      expect(screen.getByText(`${COMMUNITY_RATING_MIN_THRESHOLD} ratings`)).toBeInTheDocument();
+    });
+
+    it('renders rating and count when count exceeds threshold', () => {
+      render(<CommunityRating averageRating={82} ratingCount={150} />);
+
+      expect(screen.getByText('8.2')).toBeInTheDocument();
+      expect(screen.getByText('150 ratings')).toBeInTheDocument();
+    });
+  });
+
+  // =========================================================================
+  // Hidden below threshold
+  // =========================================================================
+
+  describe('when rating count is below threshold', () => {
+    it('returns null when count is below threshold', () => {
+      const { container } = render(
+        <CommunityRating
+          averageRating={90}
+          ratingCount={COMMUNITY_RATING_MIN_THRESHOLD - 1}
+        />,
+      );
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('returns null when count is zero', () => {
+      const { container } = render(
+        <CommunityRating averageRating={50} ratingCount={0} />,
+      );
+
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  // =========================================================================
+  // Rating formatting
+  // =========================================================================
+
+  describe('rating formatting', () => {
+    it('formats rating from 0-100 scale to 1-10 display (78.5 -> 7.8)', () => {
+      render(<CommunityRating averageRating={78.5} ratingCount={10} />);
+
+      // formatRating(78.5): 78.5 > 10, so 78.5 / 10 = 7.85, toFixed(1) = "7.8"
+      expect(screen.getByText('7.8')).toBeInTheDocument();
+    });
+
+    it('formats a perfect score (100 -> 10.0)', () => {
+      render(<CommunityRating averageRating={100} ratingCount={20} />);
+
+      expect(screen.getByText('10.0')).toBeInTheDocument();
+    });
+
+    it('formats a low score (15 -> 1.5)', () => {
+      render(<CommunityRating averageRating={15} ratingCount={5} />);
+
+      expect(screen.getByText('1.5')).toBeInTheDocument();
+    });
+  });
+
+  // =========================================================================
+  // i18n label
+  // =========================================================================
+
+  describe('i18n labels', () => {
+    it('displays the ratings count label from translation dictionary', () => {
+      render(<CommunityRating averageRating={60} ratingCount={42} />);
+
+      expect(screen.getByText('42 ratings')).toBeInTheDocument();
+    });
+  });
+
+  // =========================================================================
+  // Star icon
+  // =========================================================================
+
+  describe('star icon', () => {
+    it('renders the star icon with fill', () => {
+      const { container } = render(
+        <CommunityRating averageRating={80} ratingCount={10} />,
+      );
+
+      const svg = container.querySelector('svg');
+      expect(svg).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web-client/src/modules/details/components/__tests__/details-hero.spec.tsx
+++ b/apps/web-client/src/modules/details/components/__tests__/details-hero.spec.tsx
@@ -1,0 +1,117 @@
+/**
+ * Tests for DetailsHero component — CommunityRating integration.
+ *
+ * Covers: conditional rendering of CommunityRating based on
+ * stats.communityAverageRating and stats.communityRatingCount presence.
+ */
+
+import { render, screen } from '@testing-library/react';
+import type { DetailsHeroProps } from '../details-hero';
+import { DetailsHero } from '../details-hero';
+
+// ---------------------------------------------------------------------------
+// Mocks — stub child components to isolate conditional rendering logic
+// ---------------------------------------------------------------------------
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => <div data-testid="next-image" {...props} />,
+}));
+
+jest.mock('@/shared/utils/format', () => ({
+  formatYear: (date: string) => date.slice(0, 4),
+}));
+
+jest.mock('@/shared/i18n', () => ({
+  useTranslation: () => ({ dict: {} }),
+}));
+
+jest.mock('../hero-backdrop', () => ({
+  HeroBackdrop: () => <div data-testid="hero-backdrop" />,
+}));
+
+jest.mock('../ratingo-score', () => ({
+  RatingoScore: (props: { score: number }) => (
+    <div data-testid="ratingo-score">{props.score}</div>
+  ),
+}));
+
+jest.mock('../community-rating', () => ({
+  CommunityRating: (props: { averageRating: number; ratingCount: number }) => (
+    <div data-testid="community-rating">
+      {props.averageRating} / {props.ratingCount}
+    </div>
+  ),
+}));
+
+jest.mock('../rating-presets', () => ({
+  RatingPresets: () => <div data-testid="rating-presets" />,
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const BASE_PROPS: DetailsHeroProps = {
+  title: 'Test Movie',
+  releaseDate: '2024-01-15',
+  genres: [{ id: 1, name: 'Drama' }],
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('DetailsHero — CommunityRating integration', () => {
+  it('renders CommunityRating when both communityAverageRating and communityRatingCount are present', () => {
+    render(
+      <DetailsHero
+        {...BASE_PROPS}
+        stats={{
+          qualityScore: 80,
+          communityAverageRating: 75,
+          communityRatingCount: 42,
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId('community-rating')).toBeInTheDocument();
+    expect(screen.getByTestId('community-rating')).toHaveTextContent('75 / 42');
+  });
+
+  it('does NOT render CommunityRating when communityAverageRating is null', () => {
+    render(
+      <DetailsHero
+        {...BASE_PROPS}
+        stats={{
+          qualityScore: 80,
+          communityAverageRating: null,
+          communityRatingCount: 42,
+        }}
+      />,
+    );
+
+    expect(screen.queryByTestId('community-rating')).not.toBeInTheDocument();
+  });
+
+  it('does NOT render CommunityRating when communityRatingCount is null', () => {
+    render(
+      <DetailsHero
+        {...BASE_PROPS}
+        stats={{
+          qualityScore: 80,
+          communityAverageRating: 75,
+          communityRatingCount: null,
+        }}
+      />,
+    );
+
+    expect(screen.queryByTestId('community-rating')).not.toBeInTheDocument();
+  });
+
+  it('does NOT render CommunityRating when stats is null', () => {
+    render(<DetailsHero {...BASE_PROPS} stats={null} />);
+
+    expect(screen.queryByTestId('community-rating')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web-client/src/modules/details/components/community-rating.tsx
+++ b/apps/web-client/src/modules/details/components/community-rating.tsx
@@ -1,0 +1,40 @@
+/**
+ * Community average rating — secondary indicator below Ratingo Score.
+ * Visually subdued to avoid competing with the hero metric.
+ */
+
+'use client';
+
+import { Star } from 'lucide-react';
+import { formatRating } from '@/shared/utils/format';
+import { useTranslation } from '@/shared/i18n';
+import { COMMUNITY_RATING_MIN_THRESHOLD } from '../constants/community-rating';
+
+interface CommunityRatingProps {
+  averageRating: number;
+  ratingCount: number;
+}
+
+export function CommunityRating({ averageRating, ratingCount }: CommunityRatingProps) {
+  const { dict } = useTranslation();
+
+  if (ratingCount < COMMUNITY_RATING_MIN_THRESHOLD) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center gap-1.5 pl-0.5">
+      <Star className="w-3 h-3 text-yellow-400/70 fill-yellow-400/70" />
+      <span className="text-xs text-cinema-text-secondary">
+        {dict.details.communityRating.label}:
+      </span>
+      <span className="text-xs font-medium text-cinema-text-muted">
+        {formatRating(averageRating)}
+      </span>
+      <span className="text-cinema-text-muted/50 text-[10px]">&middot;</span>
+      <span className="text-[10px] text-cinema-text-muted/70">
+        {ratingCount} {dict.details.communityRating.ratings}
+      </span>
+    </div>
+  );
+}

--- a/apps/web-client/src/modules/details/components/community-rating.tsx
+++ b/apps/web-client/src/modules/details/components/community-rating.tsx
@@ -6,7 +6,7 @@
 'use client';
 
 import { Star } from 'lucide-react';
-import { formatRating } from '@/shared/utils/format';
+import { formatRating, pluralize } from '@/shared/utils';
 import { useTranslation } from '@/shared/i18n';
 import { COMMUNITY_RATING_MIN_THRESHOLD } from '../constants/community-rating';
 
@@ -33,7 +33,7 @@ export function CommunityRating({ averageRating, ratingCount }: CommunityRatingP
       </span>
       <span className="text-cinema-text-muted/50 text-[10px]">&middot;</span>
       <span className="text-[10px] text-cinema-text-muted/70">
-        {ratingCount} {dict.details.communityRating.ratings}
+        {ratingCount} {pluralize(ratingCount, dict.details.communityRating.ratings)}
       </span>
     </div>
   );

--- a/apps/web-client/src/modules/details/components/details-hero.tsx
+++ b/apps/web-client/src/modules/details/components/details-hero.tsx
@@ -12,6 +12,7 @@ import type { MediaType } from '@/shared/types';
 import { formatYear } from '@/shared/utils/format';
 import { HeroBackdrop } from './hero-backdrop';
 import { RatingoScore } from './ratingo-score';
+import { CommunityRating } from './community-rating';
 import { RatingPresets } from './rating-presets';
 
 export interface DetailsHeroProps {
@@ -85,6 +86,12 @@ export function DetailsHero({
               {/* Ratingo score + User rating */}
               <div className="space-y-3">
                 {rating != null && <RatingoScore score={rating} />}
+                {stats?.communityAverageRating != null && stats?.communityRatingCount != null && (
+                  <CommunityRating
+                    averageRating={stats.communityAverageRating}
+                    ratingCount={stats.communityRatingCount}
+                  />
+                )}
                 {mediaItemId && mediaType && (
                   <RatingPresets mediaItemId={mediaItemId} mediaType={mediaType} />
                 )}

--- a/apps/web-client/src/modules/details/components/index.ts
+++ b/apps/web-client/src/modules/details/components/index.ts
@@ -39,6 +39,7 @@ export { RatingPresets } from './rating-presets';
 // Atomic components for Hero section
 export { RatingBadge } from './rating-badge';
 export { RatingoScore } from './ratingo-score';
+export { CommunityRating } from './community-rating';
 export { QualityBadge } from './quality-badge';
 export { PopularityBadge } from './popularity-badge';
 export { QuickPitchScroll } from './quick-pitch-scroll';

--- a/apps/web-client/src/modules/details/constants/community-rating.ts
+++ b/apps/web-client/src/modules/details/constants/community-rating.ts
@@ -1,0 +1,2 @@
+/** Minimum ratings to display community average. Must match backend. */
+export const COMMUNITY_RATING_MIN_THRESHOLD = 2;

--- a/apps/web-client/src/modules/details/constants/community-rating.ts
+++ b/apps/web-client/src/modules/details/constants/community-rating.ts
@@ -1,2 +1,2 @@
-/** Minimum ratings to display community average. Must match backend. */
+/** Minimum number of ratings required to display the community average. */
 export const COMMUNITY_RATING_MIN_THRESHOLD = 2;

--- a/apps/web-client/src/shared/i18n/locales/en.json
+++ b/apps/web-client/src/shared/i18n/locales/en.json
@@ -229,7 +229,11 @@
     "ratingSubtitle": "Aggregated quality score",
     "communityRating": {
       "label": "Community Rating",
-      "ratings": "ratings"
+      "ratings": {
+        "one": "rating",
+        "few": "ratings",
+        "many": "ratings"
+      }
     },
     "ratingTooltip": {
       "title": "Ratingo rating",

--- a/apps/web-client/src/shared/i18n/locales/en.json
+++ b/apps/web-client/src/shared/i18n/locales/en.json
@@ -227,6 +227,10 @@
     "watchingNow": "interested now",
     "totalWatchers": "watched overall",
     "ratingSubtitle": "Aggregated quality score",
+    "communityRating": {
+      "label": "Community Rating",
+      "ratings": "ratings"
+    },
     "ratingTooltip": {
       "title": "Ratingo rating",
       "subtitle": "Quality × Relevance",

--- a/apps/web-client/src/shared/i18n/locales/uk.json
+++ b/apps/web-client/src/shared/i18n/locales/uk.json
@@ -227,6 +227,10 @@
     "watchingNow": "цікавляться зараз",
     "totalWatchers": "дивились загалом",
     "ratingSubtitle": "Агрегована оцінка якості",
+    "communityRating": {
+      "label": "Оцінка спільноти",
+      "ratings": "оцінок"
+    },
     "ratingTooltip": {
       "title": "Ratingo рейтинг",
       "subtitle": "Якість × Актуальність",

--- a/apps/web-client/src/shared/i18n/locales/uk.json
+++ b/apps/web-client/src/shared/i18n/locales/uk.json
@@ -229,7 +229,11 @@
     "ratingSubtitle": "Агрегована оцінка якості",
     "communityRating": {
       "label": "Оцінка спільноти",
-      "ratings": "оцінок"
+      "ratings": {
+        "one": "оцінка",
+        "few": "оцінки",
+        "many": "оцінок"
+      }
     },
     "ratingTooltip": {
       "title": "Ratingo рейтинг",

--- a/packages/api-contract/openapi.json
+++ b/packages/api-contract/openapi.json
@@ -7834,6 +7834,18 @@
             "example": 6423,
             "description": "Total unique watchers all time",
             "nullable": true
+          },
+          "communityAverageRating": {
+            "type": "number",
+            "example": 78.5,
+            "description": "Community average rating (0-100 scale)",
+            "nullable": true
+          },
+          "communityRatingCount": {
+            "type": "number",
+            "example": 1240,
+            "description": "Number of community ratings",
+            "nullable": true
           }
         }
       },

--- a/packages/api-contract/src/api-types.ts
+++ b/packages/api-contract/src/api-types.ts
@@ -2273,6 +2273,16 @@ export interface components {
              * @example 6423
              */
             totalWatchers?: number | null;
+            /**
+             * @description Community average rating (0-100 scale)
+             * @example 78.5
+             */
+            communityAverageRating?: number | null;
+            /**
+             * @description Number of community ratings
+             * @example 1240
+             */
+            communityRatingCount?: number | null;
         };
         ExternalRatingItemDto: {
             /** @example 8.8 */


### PR DESCRIPTION
## Summary
- Aggregate user ratings into community average, displayed as a secondary metric below the Ratingo Score on movie/show detail pages
- Event-driven recalculation via `UserMediaRatingChangedEvent` listener + periodic reconciliation via admin endpoint and BullMQ job
- Visual hierarchy: Ratingo Score (hero) > Community Rating (subdued inline) > Personal Rating

## Changes

### Backend
- **Schema**: `community_average_rating` + `community_rating_count` columns in `media_stats`
- **Domain**: `ICommunityRatingAggregationPort`, `IStatsRepository.updateCommunityRating()`, extended `RatingoStats`
- **Infrastructure**: `CommunityRatingAggregationQuery` (SQL aggregation), `DrizzleStatsRepository` (upsert + COALESCE)
- **Application**: `CommunityRatingService` (recalculate per-item + reconcileAll with stale reset), `CommunityRatingChangedListener`
- **Presentation**: `POST /stats/reconcile-community-ratings` admin endpoint, `RatingoStatsDto` extended
- **Worker**: `RECONCILE_COMMUNITY_RATINGS` job type in `StatsWorker`

### Frontend
- `CommunityRating` component — subdued inline text with star icon, label, rating, count
- Threshold: display when >= 2 ratings (`COMMUNITY_RATING_MIN_THRESHOLD`)
- i18n: uk ("Оцінка спільноти") + en ("Community Rating")
- Integrated into `DetailsHero` between RatingoScore and RatingPresets

### Tests
- 251 backend suites / 3363 tests
- 46 frontend suites / 530 tests
- New specs: service, listener, aggregation query, repository, worker, controller, component, details-hero

## Test plan
- [x] `npm run test:api` — all passing
- [x] `npm run test:client` — all passing
- [x] `npm run build:api` — compiles
- [x] `npm run build:client` — compiles
- [x] `npm run lint:api` — clean
- [x] `npm run contracts:update` — OpenAPI schema includes new fields
- [x] Typecheck (`tsc --noEmit`) — clean
- [ ] Manual: rate a movie/show, verify community rating appears after threshold met

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Примітки до випуску

* **Нові функції**
  * Додано відображення середнього рейтингу спільноти на сторінці деталей (показується при досягненні мінімального порога) та експорт цього поля через публічне API.
  * Додано фонова обробка й ручний ендпойнт для реконсиляції/перерахунку спільнотних рейтингів; подія оновлення рейтингу тепер тригерить перерахунок.

* **Тестування**
  * Додано набори юніт/інтеграційних тестів для нових поведінок та мапінгів.

* **Локалізація**
  * Додано тексти для відображення community rating у словниках i18n.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->