### PR TITLE
fix(catalog): resolve slug collisions proactively

### DIFF
--- a/apps/api/src/modules/catalog/infrastructure/repositories/drizzle-media.repository.spec.ts
+++ b/apps/api/src/modules/catalog/infrastructure/repositories/drizzle-media.repository.spec.ts
@@ -488,6 +488,130 @@ describe('DrizzleMediaRepository', () => {
     });
   });
 
+  describe('upsert', () => {
+    const buildUpsertMock = (
+      options: {
+        slugOwnerTmdbId?: number | null;
+        txError?: Error;
+      } = {},
+    ) => {
+      const { slugOwnerTmdbId = null, txError } = options;
+      const resolveResult = slugOwnerTmdbId !== null ? [{ tmdbId: slugOwnerTmdbId }] : [];
+      const selectChain = createThenable(resolveResult);
+      const insertChain = createThenable([{ id: 'new-id' }], undefined, ['onConflictDoNothing']);
+
+      const txInternals = {
+        select: jest.fn().mockReturnValue(selectChain),
+        insert: jest.fn().mockReturnValue(insertChain),
+        update: jest.fn().mockReturnValue(createThenable()),
+      };
+
+      let txCallCount = 0;
+      const mockDb = {
+        select: jest.fn().mockReturnValue(selectChain),
+        insert: jest.fn().mockReturnValue(insertChain),
+        transaction: jest.fn(async (cb: any) => {
+          txCallCount++;
+          if (txError && txCallCount === 1) throw txError;
+          return cb(txInternals);
+        }),
+      };
+
+      return { mockDb, txInternals };
+    };
+
+    const buildUpsertRepo = async (mockDb: any) => {
+      const module = await Test.createTestingModule({
+        providers: [
+          DrizzleMediaRepository,
+          { provide: DATABASE_CONNECTION, useValue: mockDb },
+          { provide: GENRE_REPOSITORY, useValue: { syncGenres: jest.fn() } },
+          { provide: MOVIE_REPOSITORY, useValue: { upsertDetails: jest.fn() } },
+          { provide: SHOW_REPOSITORY, useValue: {} },
+          { provide: HeroMediaQuery, useValue: {} },
+        ],
+      }).compile();
+      return module.get(DrizzleMediaRepository);
+    };
+
+    it('should proactively resolve slug when taken by different tmdbId', async () => {
+      const { mockDb } = buildUpsertMock({ slugOwnerTmdbId: 100 });
+      repository = await buildUpsertRepo(mockDb);
+
+      const media = { ...baseMedia, slug: 'sandwich', externalIds: { tmdbId: 200, imdbId: null } };
+      await repository.upsert(media as NormalizedMedia);
+
+      expect(mockDb.select).toHaveBeenCalled();
+      expect(mockDb.transaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('should use original slug when not taken', async () => {
+      const { mockDb } = buildUpsertMock();
+      repository = await buildUpsertRepo(mockDb);
+
+      await repository.upsert(baseMedia as NormalizedMedia);
+
+      expect(mockDb.select).toHaveBeenCalled();
+      expect(mockDb.transaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('should use original slug when taken by same tmdbId (re-sync)', async () => {
+      const { mockDb } = buildUpsertMock({ slugOwnerTmdbId: baseMedia.externalIds.tmdbId });
+      repository = await buildUpsertRepo(mockDb);
+
+      await repository.upsert(baseMedia as NormalizedMedia);
+
+      expect(mockDb.transaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle race condition via catch-and-retry', async () => {
+      const slugConflictError = Object.assign(new Error('unique_violation'), {
+        code: PG_ERROR_CODE.UNIQUE_VIOLATION,
+        constraint_name: DB_CONSTRAINT.MEDIA_TYPE_SLUG,
+      });
+      const { mockDb } = buildUpsertMock({ txError: slugConflictError });
+      repository = await buildUpsertRepo(mockDb);
+
+      await repository.upsert(baseMedia as NormalizedMedia);
+
+      expect(mockDb.transaction).toHaveBeenCalledTimes(2);
+    });
+
+    it('should throw DatabaseException when retry slug equals resolved slug', async () => {
+      // Slug already has tmdbId suffix → createRetrySlug returns the same slug
+      const slugConflictError = Object.assign(new Error('unique_violation'), {
+        code: PG_ERROR_CODE.UNIQUE_VIOLATION,
+        constraint_name: DB_CONSTRAINT.MEDIA_TYPE_SLUG,
+      });
+      // resolveSlug returns "title" (same tmdbId=1 owns it), but tx fails with slug collision
+      const { mockDb } = buildUpsertMock({
+        slugOwnerTmdbId: baseMedia.externalIds.tmdbId,
+        txError: slugConflictError,
+      });
+      repository = await buildUpsertRepo(mockDb);
+
+      // slug="title", tmdbId=1 → retrySlug = "title-1", which differs from "title" → retry happens
+      // But if slug were already "title-1", retrySlug would equal slug → DatabaseException
+      const media = {
+        ...baseMedia,
+        slug: `title-${baseMedia.externalIds.tmdbId}`,
+        externalIds: baseMedia.externalIds,
+      };
+
+      await expect(repository.upsert(media as NormalizedMedia)).rejects.toThrow(DatabaseException);
+      expect(mockDb.transaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw DatabaseException on non-slug error', async () => {
+      const { mockDb } = buildUpsertMock({ txError: new Error('Connection refused') });
+      repository = await buildUpsertRepo(mockDb);
+
+      await expect(repository.upsert(baseMedia as NormalizedMedia)).rejects.toThrow(
+        DatabaseException,
+      );
+    });
+  });
+
   describe('findEligibleForTrending', () => {
     it('should return eligible items with tmdbId and type', async () => {
       const mockRows = [

--- a/apps/api/src/modules/catalog/infrastructure/repositories/drizzle-media.repository.spec.ts
+++ b/apps/api/src/modules/catalog/infrastructure/repositories/drizzle-media.repository.spec.ts
@@ -610,6 +610,20 @@ describe('DrizzleMediaRepository', () => {
         DatabaseException,
       );
     });
+
+    it('should throw DatabaseException when resolveSlug SELECT fails', async () => {
+      const selectChain = createThenable([], new Error('Connection refused'));
+      const mockDb = {
+        select: jest.fn().mockReturnValue(selectChain),
+        transaction: jest.fn(),
+      };
+      repository = await buildUpsertRepo(mockDb);
+
+      await expect(repository.upsert(baseMedia as NormalizedMedia)).rejects.toThrow(
+        DatabaseException,
+      );
+      expect(mockDb.transaction).not.toHaveBeenCalled();
+    });
   });
 
   describe('findEligibleForTrending', () => {

--- a/apps/api/src/modules/catalog/infrastructure/repositories/drizzle-media.repository.ts
+++ b/apps/api/src/modules/catalog/infrastructure/repositories/drizzle-media.repository.ts
@@ -178,7 +178,7 @@ export class DrizzleMediaRepository implements IMediaRepository {
           target: [schema.mediaItems.type, schema.mediaItems.tmdbId], // Composite key: type + tmdb_id
           set: {
             title: payload.title,
-            slug: payload.slug,
+            // slug intentionally omitted: preserve collision-resolved slugs (e.g., "sandwich-200")
             ingestionStatus: payload.ingestionStatus,
             updatedAt: new Date(),
           },
@@ -306,19 +306,28 @@ export class DrizzleMediaRepository implements IMediaRepository {
    * Performs a full transactional upsert of a media item.
    * Updates base table, type-specific details, and syncs genres.
    *
-   * Handles slug collision by retrying with unique slug (appends tmdbId).
+   * Proactively resolves slug collisions before INSERT to avoid PG errors.
+   * Keeps catch-and-retry as safety net for race conditions.
    *
    * @throws {DatabaseException} If database transaction fails
    */
   async upsert(media: NormalizedMedia): Promise<void> {
+    const slug = await this.resolveSlug(media.type, media.slug, media.externalIds.tmdbId);
+
     try {
-      await this.upsertWithSlug(media, media.slug);
+      await this.upsertWithSlug(media, slug);
     } catch (error: unknown) {
-      // Check if it's a slug collision - retry with unique slug
+      // Safety net for race conditions: another process took the slug between check and INSERT
       if (isSlugCollision(error, DB_CONSTRAINT.MEDIA_TYPE_SLUG)) {
-        const retrySlug = createRetrySlug(media.slug, media.externalIds.tmdbId);
+        const retrySlug = createRetrySlug(slug, media.externalIds.tmdbId);
+
+        // Guard: if retry produces the same slug, we can't recover
+        if (retrySlug === slug) {
+          this.handleUpsertError(error, media);
+        }
+
         this.logger.warn(
-          `Slug collision for "${media.slug}", retrying with "${retrySlug}" (tmdbId: ${media.externalIds.tmdbId})`,
+          `Slug collision race condition for "${slug}", retrying with "${retrySlug}" (tmdbId: ${media.externalIds.tmdbId})`,
         );
         await this.upsertWithSlug(media, retrySlug);
         return;
@@ -327,6 +336,36 @@ export class DrizzleMediaRepository implements IMediaRepository {
       // Not a slug collision - handle as regular error
       this.handleUpsertError(error, media);
     }
+  }
+
+  /**
+   * Proactively checks if slug is taken by a different media item.
+   * Returns unique slug (with tmdbId suffix) if collision detected, original slug otherwise.
+   */
+  private async resolveSlug(
+    type: MediaType,
+    slug: string | undefined,
+    tmdbId: number,
+  ): Promise<string> {
+    if (!slug) return createRetrySlug(undefined, tmdbId);
+
+    const existing = await this.db
+      .select({ tmdbId: schema.mediaItems.tmdbId })
+      .from(schema.mediaItems)
+      .where(and(eq(schema.mediaItems.type, type), eq(schema.mediaItems.slug, slug)))
+      .limit(1);
+
+    // Slug is free, or belongs to the same item (re-sync)
+    if (!existing[0] || existing[0].tmdbId === tmdbId) {
+      return slug;
+    }
+
+    // Slug taken by different item — use unique slug
+    const uniqueSlug = generateUniqueSlug(slug, tmdbId);
+    this.logger.log(
+      `Slug "${slug}" taken by tmdbId ${existing[0].tmdbId}, using "${uniqueSlug}" for tmdbId ${tmdbId}`,
+    );
+    return uniqueSlug;
   }
 
   /**

--- a/apps/api/src/modules/catalog/infrastructure/repositories/drizzle-media.repository.ts
+++ b/apps/api/src/modules/catalog/infrastructure/repositories/drizzle-media.repository.ts
@@ -312,7 +312,13 @@ export class DrizzleMediaRepository implements IMediaRepository {
    * @throws {DatabaseException} If database transaction fails
    */
   async upsert(media: NormalizedMedia): Promise<void> {
-    const slug = await this.resolveSlug(media.type, media.slug, media.externalIds.tmdbId);
+    let slug: string;
+    try {
+      slug = await this.resolveSlug(media.type, media.slug, media.externalIds.tmdbId);
+    } catch (error) {
+      this.handleUpsertError(error, media);
+      return; // handleUpsertError always throws, but TS needs explicit return
+    }
 
     try {
       await this.upsertWithSlug(media, slug);


### PR DESCRIPTION
## Summary
- **Production bug**: two TMDB movies with identical titles (e.g. "Sandwich") generated the same slug → `unique_violation` on `media_type_slug_idx`
- `upsertStub`: removed `slug` from ON CONFLICT UPDATE SET to preserve collision-resolved slugs on re-import
- `upsert`: added `resolveSlug()` — SELECT-checks slug availability before INSERT, avoids PG error noise
- Retry path: fixed double-collision bug (used resolved slug instead of original), added guard for `retrySlug === slug`

## Test plan
- [x] 6 new unit tests for `upsert` covering: proactive resolution, slug not taken, re-sync, race condition retry, double-collision guard, non-slug error
- [x] All 3369 tests pass (1 pre-existing flaky timing test excluded)
- [x] Lint clean
- [x] Pre-push hooks pass (lint + typecheck + build + full test suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Примітки до випуску

* **Bug Fixes**
  * Покращено обробку конфліктів слагів у каталозі медіа: проактивне визначення безконфліктного слагу, повторні спроби при умовах перегонки та уточнені повідомлення логування.

* **Tests**
  * Додано комплексний набір тестів для перевірки вставки та повторних спроб у різних сценаріях помилок, конфліктів слагів і граничних випадків.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->