### PR TITLE
feat: show TVMaze episode ratings in episode list

### DIFF
--- a/apps/api/src/modules/catalog/domain/repositories/show.repository.interface.ts
+++ b/apps/api/src/modules/catalog/domain/repositories/show.repository.interface.ts
@@ -126,6 +126,7 @@ export interface EpisodeInfo {
   airDate: Date | null;
   runtime: number | null;
   stillPath: string | null;
+  voteAverage: number | null;
 }
 
 /**

--- a/apps/api/src/modules/catalog/infrastructure/queries/show-details.query.ts
+++ b/apps/api/src/modules/catalog/infrastructure/queries/show-details.query.ts
@@ -110,6 +110,7 @@ export class ShowDetailsQuery {
           airDate: schema.episodes.airDate,
           runtime: schema.episodes.runtime,
           stillPath: schema.episodes.stillPath,
+          voteAverage: schema.episodes.voteAverage,
         })
         .from(schema.episodes)
         .innerJoin(schema.seasons, eq(schema.episodes.seasonId, schema.seasons.id))

--- a/apps/api/src/modules/catalog/presentation/dtos/show-response.dto.ts
+++ b/apps/api/src/modules/catalog/presentation/dtos/show-response.dto.ts
@@ -29,6 +29,9 @@ export class EpisodeDto {
 
   @ApiProperty({ example: '/path/to/still.jpg', required: false, nullable: true })
   stillPath: string | null;
+
+  @ApiProperty({ example: 8.5, required: false, nullable: true })
+  voteAverage: number | null;
 }
 
 export class SeasonDto {

--- a/apps/api/src/modules/ingestion/infrastructure/adapters/tvmaze/tvmaze.adapter.spec.ts
+++ b/apps/api/src/modules/ingestion/infrastructure/adapters/tvmaze/tvmaze.adapter.spec.ts
@@ -43,6 +43,7 @@ describe('TvMazeAdapter', () => {
             airstamp: '2023-01-01T20:00:00+00:00',
             runtime: 60,
             image: { original: 'http://image.com/1.jpg' },
+            rating: { average: 8.5 },
           },
         ],
       });
@@ -59,7 +60,7 @@ describe('TvMazeAdapter', () => {
         airDate: new Date('2023-01-01T20:00:00+00:00'),
         runtime: 60,
         stillPath: 'http://image.com/1.jpg',
-        rating: null,
+        rating: 8.5,
       });
     });
 
@@ -112,6 +113,7 @@ describe('TvMazeAdapter', () => {
             airstamp: '2024-10-01T20:00:00+00:00',
             runtime: 45,
             image: null,
+            rating: { average: 7.0 },
           },
         ],
       });
@@ -128,7 +130,7 @@ describe('TvMazeAdapter', () => {
         airDate: new Date('2024-10-01T20:00:00+00:00'),
         runtime: 45,
         stillPath: null,
-        rating: null,
+        rating: 7.0,
       });
     });
 
@@ -140,6 +142,46 @@ describe('TvMazeAdapter', () => {
 
       const result = await adapter.getEpisodesByShowName('NonexistentShow12345');
       expect(result).toEqual([]);
+    });
+
+    it('should map null and missing rating to null', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: 86953, name: 'Test' }),
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          {
+            id: 1,
+            season: 1,
+            number: 1,
+            name: 'Ep1',
+            summary: null,
+            airstamp: null,
+            runtime: null,
+            image: null,
+            rating: { average: null },
+          },
+          {
+            id: 2,
+            season: 1,
+            number: 2,
+            name: 'Ep2',
+            summary: null,
+            airstamp: null,
+            runtime: null,
+            image: null,
+          },
+        ],
+      });
+
+      const result = await adapter.getEpisodesByShowName('Test');
+
+      expect(result).toHaveLength(2);
+      expect(result[0].rating).toBeNull();
+      expect(result[1].rating).toBeNull();
     });
 
     it('should return empty array on API error', async () => {

--- a/apps/api/src/modules/ingestion/infrastructure/adapters/tvmaze/tvmaze.adapter.ts
+++ b/apps/api/src/modules/ingestion/infrastructure/adapters/tvmaze/tvmaze.adapter.ts
@@ -25,6 +25,7 @@ interface TvMazeEpisodeResponse {
   airstamp: string | null;
   runtime: number | null;
   image: { original: string; medium: string } | null;
+  rating: { average: number | null } | null;
 }
 
 /**
@@ -96,7 +97,7 @@ export class TvMazeAdapter {
       airDate: ep.airstamp ? new Date(ep.airstamp) : null,
       runtime: ep.runtime,
       stillPath: ep.image?.original || null,
-      rating: null,
+      rating: ep.rating?.average ?? null,
     };
   }
 

--- a/apps/web-client/src/modules/details/components/episode-card.tsx
+++ b/apps/web-client/src/modules/details/components/episode-card.tsx
@@ -11,6 +11,7 @@ import type { components } from '@ratingo/api-contract';
 import type { getDictionary } from '@/shared/i18n';
 import { formatDate } from '@/shared/utils/format';
 import { cn, resolveMediaImageUrl, IMAGE_SIZES } from '@/shared/utils';
+import { ScorePill } from '@/shared/components/score-pill';
 import { EpisodeCheckbox } from './episode-checkbox';
 import { MarkWatchedPopover } from './mark-watched-popover';
 
@@ -185,6 +186,10 @@ export function EpisodeCard({
             {runtime && <span>{runtime}</span>}
           </div>
         </div>
+
+        {episode.voteAverage != null && (
+          <ScorePill rating={episode.voteAverage} className="flex-shrink-0" />
+        )}
       </div>
     </div>
   );

--- a/apps/web-client/src/shared/components/index.ts
+++ b/apps/web-client/src/shared/components/index.ts
@@ -1,6 +1,7 @@
 export { Carousel } from './carousel';
 export { GoogleAnalytics } from './google-analytics';
 export { LazySection } from './lazy-section';
+export { ScorePill } from './score-pill';
 export { UserRatingBadge } from './user-rating-badge';
 export * from './header';
 export * from './footer';

--- a/apps/web-client/src/shared/components/score-pill.tsx
+++ b/apps/web-client/src/shared/components/score-pill.tsx
@@ -1,0 +1,22 @@
+import { cn } from '@/shared/utils';
+
+interface ScorePillProps {
+  rating: number;
+  source?: string;
+  className?: string;
+}
+
+export function ScorePill({ rating, source = 'TVMaze', className }: ScorePillProps) {
+  return (
+    <span
+      aria-label={`${source} rating: ${rating.toFixed(1)}`}
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-full border border-white/[0.08] bg-white/[0.04] px-2 py-0.5 text-xs font-medium text-cinema-text-secondary',
+        className,
+      )}
+    >
+      {rating.toFixed(1)}
+      <span className="text-[9px] uppercase tracking-[0.12em] opacity-50">{source}</span>
+    </span>
+  );
+}

--- a/packages/api-contract/openapi.json
+++ b/packages/api-contract/openapi.json
@@ -9274,6 +9274,11 @@
             "type": "string",
             "example": "/path/to/still.jpg",
             "nullable": true
+          },
+          "voteAverage": {
+            "type": "number",
+            "example": 8.5,
+            "nullable": true
           }
         },
         "required": [

--- a/packages/api-contract/src/api-types.ts
+++ b/packages/api-contract/src/api-types.ts
@@ -2847,6 +2847,8 @@ export interface components {
             runtime?: number | null;
             /** @example /path/to/still.jpg */
             stillPath?: string | null;
+            /** @example 8.5 */
+            voteAverage?: number | null;
         };
         SeasonDto: {
             /** @example 1 */


### PR DESCRIPTION
## Summary
- Wire TVMaze `rating.average` through the ingestion adapter instead of hardcoding `null`
- Expose `voteAverage` in `EpisodeDto` API response via show-details query
- Display rating as a subtle `ScorePill` pill badge next to each episode (number + "TVMAZE" source label)
- New reusable `ScorePill` shared component with `source` prop for future extensibility

## Changes
- **Ingestion adapter**: map `ep.rating?.average ?? null` in TVMaze adapter + updated tests
- **Domain**: add `voteAverage` to `EpisodeInfo` interface
- **Presentation**: add `voteAverage` to `EpisodeDto` + show-details query select
- **API contract**: regenerated OpenAPI types
- **Frontend**: `ScorePill` component with pill design (rating + source label at 50% opacity)

## Test plan
- [x] TVMaze adapter tests pass (7 tests including null/missing rating edge cases)
- [x] Show details query/mapper tests pass (59 tests)
- [x] API builds clean
- [x] Frontend builds clean
- [x] Rating displays as \`[ 8.6  TVMAZE ]\` pill badge next to episode info

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Нові функції
* Додано можливість відображення рейтингу для кожного епізоду у деталях серіалів
* Інтегровано оцінки з зовнішніх джерел для збагачення інформації про епізоди

<!-- end of auto-generated comment: release notes by coderabbit.ai -->