### PR TITLE
feat(search): search by alternative titles from TMDB

### DIFF
--- a/apps/api/drizzle_v2/0020_add_alternative_titles.sql
+++ b/apps/api/drizzle_v2/0020_add_alternative_titles.sql
@@ -1,0 +1,36 @@
+-- Add alternative_titles column for improved search
+ALTER TABLE media_items ADD COLUMN alternative_titles text[];
+
+--> statement-breakpoint
+
+-- Create immutable wrapper for array_to_string (needed for generated columns)
+CREATE OR REPLACE FUNCTION immutable_array_to_string(arr text[], sep text)
+RETURNS text
+LANGUAGE sql IMMUTABLE PARALLEL SAFE
+AS $$ SELECT array_to_string(arr, sep) $$;
+
+--> statement-breakpoint
+
+-- Recreate search_vector generated column to include alternative_titles
+-- Must drop dependent index first
+DROP INDEX IF EXISTS media_search_idx;
+ALTER TABLE media_items DROP COLUMN search_vector;
+ALTER TABLE media_items ADD COLUMN search_vector tsvector
+  GENERATED ALWAYS AS (
+    to_tsvector('simple',
+      coalesce(title, '') || ' ' ||
+      coalesce(original_title, '') || ' ' ||
+      coalesce(overview, '') || ' ' ||
+      coalesce(immutable_array_to_string(alternative_titles, ' '), ''))
+  ) STORED;
+
+--> statement-breakpoint
+
+-- Recreate GIN index for full-text search
+CREATE INDEX media_search_idx ON media_items USING GIN (search_vector);
+
+--> statement-breakpoint
+
+-- GIN trigram index for fuzzy search on alternative titles
+CREATE INDEX media_alt_titles_trgm_idx ON media_items
+  USING GIN (coalesce(immutable_array_to_string(alternative_titles, ' '), '') gin_trgm_ops);

--- a/apps/api/drizzle_v2/meta/_journal.json
+++ b/apps/api/drizzle_v2/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1771789728875,
       "tag": "0019_flawless_amphibian",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1772006400000,
+      "tag": "0020_add_alternative_titles",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/database/schema.ts
+++ b/apps/api/src/database/schema.ts
@@ -121,6 +121,7 @@ export const mediaItems = pgTable(
     // Basic Info
     title: text('title').notNull(),
     originalTitle: text('original_title'),
+    alternativeTitles: text('alternative_titles').array(),
     slug: text('slug').notNull(), // Unique per type, not globally
     overview: text('overview'),
 
@@ -165,7 +166,7 @@ export const mediaItems = pgTable(
 
     // Full Text Search Vector (auto-generated)
     searchVector: tsvector('search_vector').generatedAlwaysAs(
-      sql`to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(original_title, '') || ' ' || coalesce(overview, ''))`,
+      sql`to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(original_title, '') || ' ' || coalesce(overview, '') || ' ' || coalesce(immutable_array_to_string(alternative_titles, ' '), ''))`,
     ),
     createdAt: timestamp('created_at').defaultNow().notNull(),
     updatedAt: timestamp('updated_at').defaultNow().notNull(),

--- a/apps/api/src/database/schema.ts
+++ b/apps/api/src/database/schema.ts
@@ -533,7 +533,7 @@ export const oauthAccounts = pgTable(
     userId: uuid('user_id')
       .references(() => users.id, { onDelete: 'cascade' })
       .notNull(),
-    /** Provider identifier: 'google', 'facebook', 'apple' */
+    /** Provider identifier: 'google', 'facebook' */
     provider: text('provider').notNull(),
     /** Provider-specific user ID (e.g., Google sub, Facebook ID) */
     providerAccountId: text('provider_account_id').notNull(),

--- a/apps/api/src/modules/auth/domain/types/oauth-provider.spec.ts
+++ b/apps/api/src/modules/auth/domain/types/oauth-provider.spec.ts
@@ -8,11 +8,10 @@ describe('OAuthProvider', () => {
     it('should contain expected providers', () => {
       expect(OAUTH_PROVIDER.GOOGLE).toBe('google');
       expect(OAUTH_PROVIDER.FACEBOOK).toBe('facebook');
-      expect(OAUTH_PROVIDER.APPLE).toBe('apple');
     });
 
     it('should be a frozen-like const object', () => {
-      expect(Object.keys(OAUTH_PROVIDER)).toHaveLength(3);
+      expect(Object.keys(OAUTH_PROVIDER)).toHaveLength(2);
     });
   });
 
@@ -25,14 +24,14 @@ describe('OAuthProvider', () => {
       expect(isOAuthProvider('')).toBe(false);
     });
 
-    it.each(['Google', 'GOOGLE', 'Facebook', 'FACEBOOK', 'Apple', 'APPLE'])(
+    it.each(['Google', 'GOOGLE', 'Facebook', 'FACEBOOK'])(
       'should reject case-mismatched provider "%s"',
       (value) => {
         expect(isOAuthProvider(value)).toBe(false);
       },
     );
 
-    it.each(['github', 'twitter', 'linkedin', 'microsoft'])(
+    it.each(['apple', 'github', 'twitter', 'linkedin', 'microsoft'])(
       'should reject unsupported provider "%s"',
       (value) => {
         expect(isOAuthProvider(value)).toBe(false);

--- a/apps/api/src/modules/auth/domain/types/oauth-provider.ts
+++ b/apps/api/src/modules/auth/domain/types/oauth-provider.ts
@@ -5,7 +5,6 @@
 export const OAUTH_PROVIDER = {
   GOOGLE: 'google',
   FACEBOOK: 'facebook',
-  APPLE: 'apple',
 } as const;
 
 export type OAuthProvider = (typeof OAUTH_PROVIDER)[keyof typeof OAUTH_PROVIDER];

--- a/apps/api/src/modules/auth/infrastructure/repositories/drizzle-oauth-accounts.repository.spec.ts
+++ b/apps/api/src/modules/auth/infrastructure/repositories/drizzle-oauth-accounts.repository.spec.ts
@@ -110,7 +110,7 @@ describe('DrizzleOAuthAccountsRepository', () => {
       selectChain.where.mockResolvedValueOnce([]);
       const repo = new DrizzleOAuthAccountsRepository(db);
 
-      const result = await repo.findByUserAndProvider('u-1', 'apple');
+      const result = await repo.findByUserAndProvider('u-1', 'facebook');
 
       expect(result).toBeNull();
     });
@@ -170,7 +170,7 @@ describe('DrizzleOAuthAccountsRepository', () => {
       db._deleteWhereResult.returning.mockResolvedValueOnce([]);
       const repo = new DrizzleOAuthAccountsRepository(db);
 
-      const result = await repo.deleteByUserAndProvider('u-1', 'apple');
+      const result = await repo.deleteByUserAndProvider('u-1', 'facebook');
 
       expect(result).toBe(false);
     });

--- a/apps/api/src/modules/auth/presentation/dto/linked-account.dto.ts
+++ b/apps/api/src/modules/auth/presentation/dto/linked-account.dto.ts
@@ -21,6 +21,10 @@ export class LinkedAccountDto {
   })
   displayName: string | null;
 
-  @ApiProperty({ example: '2025-01-15T10:30:00.000Z', description: 'When the account was linked' })
+  @ApiProperty({
+    format: 'date-time',
+    example: '2025-01-15T10:30:00.000Z',
+    description: 'When the account was linked',
+  })
   linkedAt: string;
 }

--- a/apps/api/src/modules/auth/presentation/filters/oauth-exception.filter.spec.ts
+++ b/apps/api/src/modules/auth/presentation/filters/oauth-exception.filter.spec.ts
@@ -393,20 +393,6 @@ describe('OAuthExceptionFilter', () => {
       );
     });
 
-    it('should extract apple from /auth/apple/callback', () => {
-      const exception = new UnauthorizedException('OAUTH_STATE_INVALID');
-      const request = createMockRequest({
-        url: '/auth/apple/callback',
-        oauthStatePayload: undefined,
-      });
-      const reply = createMockReply();
-      const host = createMockHost(request, reply);
-
-      filter.catch(exception, host);
-
-      expect(reply.redirect).toHaveBeenCalledWith(expect.stringContaining('/auth/callback/apple?'));
-    });
-
     it('should return null for unknown provider /api/auth/unknown', () => {
       const exception = new UnauthorizedException('OAUTH_CANCELLED');
       const request = createMockRequest({

--- a/apps/api/src/modules/catalog/application/services/catalog-search.service.ts
+++ b/apps/api/src/modules/catalog/application/services/catalog-search.service.ts
@@ -55,6 +55,7 @@ export class CatalogSearchService {
         tmdbId: r.tmdbId,
         title: r.title,
         originalTitle: r.originalTitle,
+        alternativeTitles: r.alternativeTitles,
         year: r.releaseDate ? new Date(r.releaseDate).getFullYear() || null : null,
         posterPath: r.posterPath,
         rating: r.rating || 0,

--- a/apps/api/src/modules/catalog/domain/models/search-result.model.ts
+++ b/apps/api/src/modules/catalog/domain/models/search-result.model.ts
@@ -9,6 +9,7 @@ export interface LocalSearchResult {
   type: MediaType;
   title: string;
   originalTitle: string | null;
+  alternativeTitles: string[] | null;
   slug: string;
   posterPath: string | null;
   rating: number;

--- a/apps/api/src/modules/catalog/domain/types/search.types.ts
+++ b/apps/api/src/modules/catalog/domain/types/search.types.ts
@@ -31,6 +31,7 @@ export interface LocalSearchResultItem extends BaseSearchResultItem {
   source: typeof SEARCH_SOURCE.LOCAL;
   id: string;
   slug: string;
+  alternativeTitles: string[] | null;
 }
 
 /**

--- a/apps/api/src/modules/catalog/infrastructure/mappers/media-item-persistence.mapper.ts
+++ b/apps/api/src/modules/catalog/infrastructure/mappers/media-item-persistence.mapper.ts
@@ -21,6 +21,7 @@ export class MediaItemPersistenceMapper {
       imdbId: media.externalIds.imdbId || null,
       title: media.title || media.originalTitle || `Untitled ${media.externalIds.tmdbId}`,
       originalTitle: media.originalTitle,
+      alternativeTitles: media.alternativeTitles?.length ? media.alternativeTitles : null,
       slug,
       overview: media.overview || null,
       ingestionStatus: media.ingestionStatus,
@@ -98,6 +99,9 @@ export class MediaItemPersistenceMapper {
       ...(media.overview !== undefined && { overview: media.overview }),
       ...(media.originCountries !== undefined && { originCountries: media.originCountries }),
       ...(media.originalLanguage !== undefined && { originalLanguage: media.originalLanguage }),
+      ...(media.alternativeTitles !== undefined && {
+        alternativeTitles: media.alternativeTitles?.length ? media.alternativeTitles : null,
+      }),
     };
 
     // Filter out undefined values

--- a/apps/api/src/modules/catalog/infrastructure/repositories/drizzle-media.repository.ts
+++ b/apps/api/src/modules/catalog/infrastructure/repositories/drizzle-media.repository.ts
@@ -656,6 +656,7 @@ export class DrizzleMediaRepository implements IMediaRepository {
           type: schema.mediaItems.type,
           title: schema.mediaItems.title,
           originalTitle: schema.mediaItems.originalTitle,
+          alternativeTitles: schema.mediaItems.alternativeTitles,
           slug: schema.mediaItems.slug,
           posterPath: schema.mediaItems.posterPath,
           rating: schema.mediaItems.rating,
@@ -686,6 +687,10 @@ export class DrizzleMediaRepository implements IMediaRepository {
               OR ${schema.mediaItems.originalTitle} ILIKE ${likePattern}
               OR ${schema.mediaItems.title} % ${searchTerm}
               OR ${schema.mediaItems.originalTitle} % ${searchTerm}
+              OR EXISTS (
+                SELECT 1 FROM unnest(${schema.mediaItems.alternativeTitles}) AS alt
+                WHERE alt ILIKE ${likePattern} OR alt % ${searchTerm}
+              )
             )`,
           ),
         )
@@ -693,7 +698,8 @@ export class DrizzleMediaRepository implements IMediaRepository {
           // Order by similarity score (higher = better match)
           sql`GREATEST(
             similarity(${schema.mediaItems.title}, ${searchTerm}),
-            similarity(COALESCE(${schema.mediaItems.originalTitle}, ''), ${searchTerm})
+            similarity(COALESCE(${schema.mediaItems.originalTitle}, ''), ${searchTerm}),
+            COALESCE((SELECT MAX(similarity(alt, ${searchTerm})) FROM unnest(${schema.mediaItems.alternativeTitles}) AS alt), 0)
           ) DESC`,
           desc(schema.mediaItems.popularity),
         )

--- a/apps/api/src/modules/catalog/presentation/dtos/search.dto.ts
+++ b/apps/api/src/modules/catalog/presentation/dtos/search.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 import { ImageDto } from '@/common/dtos/image.dto';
 import { MediaType } from '@/common/enums/media-type.enum';
@@ -42,6 +42,13 @@ export class SearchItemDto {
     description: 'If true, this item exists in local DB',
   })
   isImported: boolean;
+
+  @ApiPropertyOptional({
+    type: String,
+    nullable: true,
+    description: 'Alternative title that matched the search query',
+  })
+  matchedAlternativeTitle?: string | null;
 }
 
 export class SearchResponseDto {

--- a/apps/api/src/modules/catalog/presentation/mappers/search.mapper.spec.ts
+++ b/apps/api/src/modules/catalog/presentation/mappers/search.mapper.spec.ts
@@ -34,6 +34,7 @@ describe('SearchMapper', () => {
         tmdbId: 603,
         title: 'The Matrix',
         originalTitle: 'The Matrix',
+        alternativeTitles: null,
         year: 1999,
         posterPath: '/poster.jpg',
         rating: 8.7,
@@ -66,6 +67,7 @@ describe('SearchMapper', () => {
         },
         rating: 8.7,
         isImported: true,
+        matchedAlternativeTitle: null,
       });
     });
 
@@ -106,6 +108,7 @@ describe('SearchMapper', () => {
         },
         rating: 9.3,
         isImported: false,
+        matchedAlternativeTitle: null,
       });
     });
 
@@ -118,6 +121,7 @@ describe('SearchMapper', () => {
         tmdbId: 999,
         title: 'No Poster Movie',
         originalTitle: null,
+        alternativeTitles: null,
         year: null,
         posterPath: null,
         rating: 0,
@@ -148,6 +152,7 @@ describe('SearchMapper', () => {
             tmdbId: 272,
             title: 'Batman Begins',
             originalTitle: 'Batman Begins',
+            alternativeTitles: null,
             year: 2005,
             posterPath: '/batman1.jpg',
             rating: 8.2,
@@ -175,6 +180,108 @@ describe('SearchMapper', () => {
       expect(result.tmdb).toHaveLength(1);
       expect(result.local[0].isImported).toBe(true);
       expect(result.tmdb[0].isImported).toBe(false);
+    });
+
+    it('should set matchedAlternativeTitle when alt title matches query', () => {
+      const localItem: LocalSearchResultItem = {
+        source: SEARCH_SOURCE.LOCAL,
+        type: MediaType.SHOW,
+        id: 'uuid-456',
+        slug: 'invincible',
+        tmdbId: 95557,
+        title: 'НЕПЕРЕМОЖНИЙ',
+        originalTitle: 'Invincible',
+        alternativeTitles: ['Невразливий', 'Невколупний'],
+        year: 2021,
+        posterPath: '/invincible.jpg',
+        rating: 8.5,
+      };
+
+      const input: HybridSearchResult = {
+        query: 'Невразливий',
+        local: [localItem],
+        tmdb: [],
+      };
+
+      const result = SearchMapper.toResponseDto(input);
+
+      expect(result.local[0].matchedAlternativeTitle).toBe('Невразливий');
+    });
+
+    it('should match via reverse containment (query contains alt title)', () => {
+      const localItem: LocalSearchResultItem = {
+        source: SEARCH_SOURCE.LOCAL,
+        type: MediaType.SHOW,
+        id: 'uuid-456',
+        slug: 'invincible',
+        tmdbId: 95557,
+        title: 'НЕПЕРЕМОЖНИЙ',
+        originalTitle: 'Invincible',
+        alternativeTitles: ['Невразливий', 'Невколупний'],
+        year: 2021,
+        posterPath: '/invincible.jpg',
+        rating: 8.5,
+      };
+
+      const input: HybridSearchResult = {
+        query: 'Невразливий серіал',
+        local: [localItem],
+        tmdb: [],
+      };
+
+      const result = SearchMapper.toResponseDto(input);
+
+      expect(result.local[0].matchedAlternativeTitle).toBe('Невразливий');
+    });
+
+    it('should set matchedAlternativeTitle to null for TMDB results', () => {
+      const input: HybridSearchResult = {
+        query: 'test',
+        local: [],
+        tmdb: [
+          {
+            source: SEARCH_SOURCE.TMDB,
+            type: MediaType.MOVIE,
+            tmdbId: 123,
+            title: 'Test Movie',
+            originalTitle: 'Test Movie',
+            year: 2024,
+            posterPath: null,
+            rating: 7,
+            isImported: false,
+          },
+        ],
+      };
+
+      const result = SearchMapper.toResponseDto(input);
+
+      expect(result.tmdb[0].matchedAlternativeTitle).toBeNull();
+    });
+
+    it('should set matchedAlternativeTitle to null when no alt title matches', () => {
+      const localItem: LocalSearchResultItem = {
+        source: SEARCH_SOURCE.LOCAL,
+        type: MediaType.SHOW,
+        id: 'uuid-456',
+        slug: 'invincible',
+        tmdbId: 95557,
+        title: 'НЕПЕРЕМОЖНИЙ',
+        originalTitle: 'Invincible',
+        alternativeTitles: ['Невразливий', 'Невколупний'],
+        year: 2021,
+        posterPath: '/invincible.jpg',
+        rating: 8.5,
+      };
+
+      const input: HybridSearchResult = {
+        query: 'НЕПЕРЕМОЖНИЙ',
+        local: [localItem],
+        tmdb: [],
+      };
+
+      const result = SearchMapper.toResponseDto(input);
+
+      expect(result.local[0].matchedAlternativeTitle).toBeNull();
     });
   });
 });

--- a/apps/api/src/modules/catalog/presentation/mappers/search.mapper.ts
+++ b/apps/api/src/modules/catalog/presentation/mappers/search.mapper.ts
@@ -12,14 +12,15 @@ import { SearchItemDto, SearchResponseDto } from '../dtos/search.dto';
  */
 export class SearchMapper {
   static toResponseDto(result: HybridSearchResult): SearchResponseDto {
+    const { query } = result;
     return {
-      query: result.query,
-      local: result.local.map(SearchMapper.toLocalItemDto),
+      query,
+      local: result.local.map((item) => SearchMapper.toLocalItemDto(item, query)),
       tmdb: result.tmdb.map(SearchMapper.toTmdbItemDto),
     };
   }
 
-  private static toLocalItemDto(item: LocalSearchResultItem): SearchItemDto {
+  private static toLocalItemDto(item: LocalSearchResultItem, query: string): SearchItemDto {
     return {
       source: item.source,
       type: item.type,
@@ -33,6 +34,7 @@ export class SearchMapper {
       poster: ImageMapper.toPoster(item.posterPath),
       rating: item.rating,
       isImported: true,
+      matchedAlternativeTitle: SearchMapper.findMatchedAltTitle(item.alternativeTitles, query),
     };
   }
 
@@ -47,6 +49,35 @@ export class SearchMapper {
       poster: ImageMapper.toPoster(item.posterPath),
       rating: item.rating,
       isImported: item.isImported,
+      matchedAlternativeTitle: null,
     };
+  }
+
+  /**
+   * Finds the alternative title that best matches the search query.
+   * Returns null if no alt title matched (i.e., title/originalTitle matched directly).
+   *
+   * Checks substring match (mirrors DB ILIKE) and reverse containment.
+   * Trigram-only matches (DB `%` operator) cannot be replicated in JS,
+   * so those cases return null — the result still appears, just without a label.
+   */
+  private static findMatchedAltTitle(
+    alternativeTitles: string[] | null,
+    query: string,
+  ): string | null {
+    if (!alternativeTitles?.length) return null;
+
+    const lowerQuery = query.toLowerCase().trim();
+    if (!lowerQuery) return null;
+
+    // Substring match (mirrors ILIKE '%query%' in DB)
+    const substringMatch = alternativeTitles.find((alt) => alt.toLowerCase().includes(lowerQuery));
+    if (substringMatch) return substringMatch;
+
+    // Reverse: query contains alt title (e.g. query "Невразливий серіал" contains alt "Невразливий")
+    const reverseMatch = alternativeTitles.find((alt) => lowerQuery.includes(alt.toLowerCase()));
+    if (reverseMatch) return reverseMatch;
+
+    return null;
   }
 }

--- a/apps/api/src/modules/ingestion/domain/models/normalized-media.model.ts
+++ b/apps/api/src/modules/ingestion/domain/models/normalized-media.model.ts
@@ -119,6 +119,8 @@ export interface NormalizedMedia {
   type: MediaType;
   title: string;
   originalTitle?: string | null;
+  /** Alternative/alias titles for improved search (from TMDB alternative_titles) */
+  alternativeTitles?: string[];
   overview?: string | null;
 
   ingestionStatus?: IngestionStatus;

--- a/apps/api/src/modules/tmdb/constants/alt-title.constants.ts
+++ b/apps/api/src/modules/tmdb/constants/alt-title.constants.ts
@@ -1,0 +1,9 @@
+/**
+ * Countries whose alternative titles are indexed for search.
+ * Intentionally limited to primary markets to reduce DB bloat.
+ * Origin countries of each title are also dynamically included at extraction time.
+ */
+export const ALT_TITLE_COUNTRIES = new Set(['UA', 'US', 'RU', 'GB']);
+
+/** Maximum alternative titles stored per media item */
+export const MAX_ALT_TITLES = 20;

--- a/apps/api/src/modules/tmdb/mappers/tmdb.mapper.spec.ts
+++ b/apps/api/src/modules/tmdb/mappers/tmdb.mapper.spec.ts
@@ -87,6 +87,154 @@ describe('TmdbMapper', () => {
     },
   };
 
+  describe('extractAlternativeTitles', () => {
+    it('should return empty array when no alternative_titles data', () => {
+      const data = { ...mockMovie, alternative_titles: undefined };
+      const result = TmdbMapper.extractAlternativeTitles(
+        data,
+        MediaType.MOVIE,
+        'Fight Club',
+        'Fight Club',
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('should filter by allowed countries (UA, US, RU, GB + origin)', () => {
+      const data = {
+        ...mockMovie,
+        alternative_titles: {
+          titles: [
+            { iso_3166_1: 'UA', title: 'Бійцівський клуб', type: '' },
+            { iso_3166_1: 'JP', title: 'ファイト・クラブ', type: '' },
+            { iso_3166_1: 'RU', title: 'Бойцовский клуб', type: '' },
+            { iso_3166_1: 'DE', title: 'Fight Club', type: '' },
+          ],
+        },
+      };
+      const result = TmdbMapper.extractAlternativeTitles(
+        data,
+        MediaType.MOVIE,
+        'Fight Club',
+        'Fight Club',
+      );
+      expect(result).toEqual(['Бійцівський клуб', 'Бойцовский клуб']);
+    });
+
+    it('should include origin country titles dynamically', () => {
+      const data = {
+        ...mockMovie,
+        production_countries: [{ iso_3166_1: 'KR', name: 'South Korea' }],
+        alternative_titles: {
+          titles: [
+            { iso_3166_1: 'KR', title: '파이트 클럽', type: '' },
+            { iso_3166_1: 'JP', title: 'ファイト', type: '' },
+          ],
+        },
+      };
+      const result = TmdbMapper.extractAlternativeTitles(
+        data,
+        MediaType.MOVIE,
+        'Fight Club',
+        'Fight Club',
+      );
+      expect(result).toEqual(['파이트 클럽']);
+    });
+
+    it('should deduplicate against primary title and originalTitle', () => {
+      const data = {
+        ...mockMovie,
+        alternative_titles: {
+          titles: [
+            { iso_3166_1: 'US', title: 'Fight Club', type: '' },
+            { iso_3166_1: 'UA', title: 'Бійцівський клуб', type: '' },
+          ],
+        },
+      };
+      const result = TmdbMapper.extractAlternativeTitles(
+        data,
+        MediaType.MOVIE,
+        'Fight Club',
+        'Fight Club',
+      );
+      expect(result).toEqual(['Бійцівський клуб']);
+    });
+
+    it('should deduplicate case-insensitively', () => {
+      const data = {
+        ...mockMovie,
+        alternative_titles: {
+          titles: [
+            { iso_3166_1: 'US', title: 'fight club', type: '' },
+            { iso_3166_1: 'GB', title: 'FIGHT CLUB', type: '' },
+            { iso_3166_1: 'UA', title: 'Бійцівський клуб', type: '' },
+          ],
+        },
+      };
+      const result = TmdbMapper.extractAlternativeTitles(
+        data,
+        MediaType.MOVIE,
+        'Fight Club',
+        'Fight Club',
+      );
+      expect(result).toEqual(['Бійцівський клуб']);
+    });
+
+    it('should cap at MAX_ALT_TITLES (20)', () => {
+      const titles = Array.from({ length: 30 }, (_, i) => ({
+        iso_3166_1: 'UA',
+        title: `Alt Title ${i}`,
+        type: '',
+      }));
+      const data = {
+        ...mockMovie,
+        alternative_titles: { titles },
+      };
+      const result = TmdbMapper.extractAlternativeTitles(
+        data,
+        MediaType.MOVIE,
+        'Fight Club',
+        'Fight Club',
+      );
+      expect(result).toHaveLength(20);
+    });
+
+    it('should use results array for TV shows', () => {
+      const data = {
+        ...mockShow,
+        alternative_titles: {
+          results: [{ iso_3166_1: 'UA', title: 'Пуститися берега', type: '' }],
+        },
+      };
+      const result = TmdbMapper.extractAlternativeTitles(
+        data,
+        MediaType.SHOW,
+        'Breaking Bad',
+        'Breaking Bad',
+      );
+      expect(result).toEqual(['Пуститися берега']);
+    });
+
+    it('should skip empty/whitespace titles', () => {
+      const data = {
+        ...mockMovie,
+        alternative_titles: {
+          titles: [
+            { iso_3166_1: 'UA', title: '', type: '' },
+            { iso_3166_1: 'UA', title: '   ', type: '' },
+            { iso_3166_1: 'UA', title: 'Real Title', type: '' },
+          ],
+        },
+      };
+      const result = TmdbMapper.extractAlternativeTitles(
+        data,
+        MediaType.MOVIE,
+        'Fight Club',
+        'Fight Club',
+      );
+      expect(result).toEqual(['Real Title']);
+    });
+  });
+
   describe('toDomain', () => {
     it('should map a movie correctly', () => {
       const result = TmdbMapper.toDomain(mockMovie, MediaType.MOVIE);

--- a/apps/api/src/modules/tmdb/mappers/tmdb.mapper.ts
+++ b/apps/api/src/modules/tmdb/mappers/tmdb.mapper.ts
@@ -14,10 +14,12 @@ import {
   type WatchProvidersMap,
   type WatchProvider,
 } from '../../ingestion/public';
+import { ALT_TITLE_COUNTRIES, MAX_ALT_TITLES } from '../constants/alt-title.constants';
 import {
   type TmdbMediaResponse,
   type TmdbMovieResponse,
   type TmdbShowResponse,
+  type TmdbAlternativeTitle,
   type TmdbCastMember,
   type TmdbCrewMember,
   type TmdbCreator,
@@ -50,6 +52,9 @@ export class TmdbMapper {
   static toDomain(data: TmdbMediaResponse, type: MediaType): NormalizedMedia | null {
     const isMovie = type === MediaType.MOVIE;
     const title = isMovie ? (data as TmdbMovieResponse).title : (data as TmdbShowResponse).name;
+    const originalTitle = isMovie
+      ? (data as TmdbMovieResponse).original_title
+      : (data as TmdbShowResponse).original_name;
 
     // Only title is required - overview can be empty
     // This ensures we don't lose originCountries/originalLanguage for items without localized overview
@@ -66,10 +71,8 @@ export class TmdbMapper {
           null,
       },
       type,
-      title: isMovie ? (data as TmdbMovieResponse).title : (data as TmdbShowResponse).name,
-      originalTitle: isMovie
-        ? (data as TmdbMovieResponse).original_title
-        : (data as TmdbShowResponse).original_name,
+      title,
+      originalTitle,
       overview: data.overview || null,
       slug: generateSlug(
         isMovie ? (data as TmdbMovieResponse).title : (data as TmdbShowResponse).name,
@@ -115,6 +118,7 @@ export class TmdbMapper {
       videos: this.extractVideos(data),
       credits: this.extractCredits(data, type),
       watchProvidersRaw: this.extractProviders(data),
+      alternativeTitles: this.extractAlternativeTitles(data, type, title, originalTitle),
 
       details: {},
     };
@@ -152,6 +156,57 @@ export class TmdbMapper {
       strict: true,
       locale: 'uk',
     });
+  }
+
+  /**
+   * Extracts alternative titles from TMDB API response.
+   * Filters by relevant countries (UA, US, RU, GB + origin country),
+   * deduplicates against primary title/originalTitle, caps at MAX_ALT_TITLES.
+   */
+  static extractAlternativeTitles(
+    data: TmdbMediaResponse,
+    type: MediaType,
+    title: string,
+    originalTitle: string | null,
+  ): string[] {
+    const isMovie = type === MediaType.MOVIE;
+    const altTitlesData = data.alternative_titles;
+    if (!altTitlesData) return [];
+
+    // Movies use { titles: [...] }, Shows use { results: [...] }
+    const rawTitles: TmdbAlternativeTitle[] = isMovie
+      ? altTitlesData.titles || []
+      : altTitlesData.results || [];
+
+    if (rawTitles.length === 0) return [];
+
+    // Include origin country titles
+    const originCountries = isMovie
+      ? (data as TmdbMovieResponse).production_countries?.map((c) => c.iso_3166_1) || []
+      : (data as TmdbShowResponse).origin_country || [];
+
+    const allowedCountries = new Set([...ALT_TITLE_COUNTRIES, ...originCountries]);
+
+    // Deduplicate against primary title and original_title
+    const existingTitles = new Set(
+      [title, originalTitle].filter(Boolean).map((t) => t!.toLowerCase().trim()),
+    );
+
+    const result: string[] = [];
+    const seen = new Set<string>();
+
+    for (const entry of rawTitles) {
+      if (!allowedCountries.has(entry.iso_3166_1)) continue;
+      const normalized = entry.title?.trim();
+      if (!normalized) continue;
+      const lower = normalized.toLowerCase();
+      if (existingTitles.has(lower) || seen.has(lower)) continue;
+      seen.add(lower);
+      result.push(normalized);
+      if (result.length >= MAX_ALT_TITLES) break;
+    }
+
+    return result;
   }
 
   /**

--- a/apps/api/src/modules/tmdb/tmdb.adapter.ts
+++ b/apps/api/src/modules/tmdb/tmdb.adapter.ts
@@ -102,7 +102,7 @@ export class TmdbAdapter implements MetadataProviderPort {
   public async getMovie(tmdbId: number): Promise<NormalizedMedia | null> {
     try {
       const data = await this.fetch<TmdbMediaResponse>(`/movie/${tmdbId}`, {
-        append_to_response: 'credits,videos,release_dates,watch/providers',
+        append_to_response: 'credits,videos,release_dates,watch/providers,alternative_titles',
         include_video_language: 'uk,en',
       });
       const result = TmdbMapper.toDomain(data, MediaType.MOVIE);
@@ -139,6 +139,7 @@ export class TmdbAdapter implements MetadataProviderPort {
           // Preserve origin metadata even in fallback path
           originCountries: movieData.production_countries?.map((c) => c.iso_3166_1) || null,
           originalLanguage: data.original_language || null,
+          alternativeTitles: [],
         } as NormalizedMedia;
       }
       return result;
@@ -159,7 +160,8 @@ export class TmdbAdapter implements MetadataProviderPort {
   public async getShow(tmdbId: number): Promise<NormalizedMedia | null> {
     try {
       const data = await this.fetch<TmdbMediaResponse>(`/tv/${tmdbId}`, {
-        append_to_response: 'external_ids,aggregate_credits,videos,content_ratings,watch/providers',
+        append_to_response:
+          'external_ids,aggregate_credits,videos,content_ratings,watch/providers,alternative_titles',
         include_video_language: 'uk,en',
       });
       const result = TmdbMapper.toDomain(data, MediaType.SHOW);
@@ -191,6 +193,7 @@ export class TmdbAdapter implements MetadataProviderPort {
           // Preserve origin metadata even in fallback path
           originCountries: showData.origin_country || null,
           originalLanguage: data.original_language || null,
+          alternativeTitles: [],
         } as NormalizedMedia;
       }
       return result;

--- a/apps/api/src/modules/tmdb/types/tmdb-api.types.ts
+++ b/apps/api/src/modules/tmdb/types/tmdb-api.types.ts
@@ -128,6 +128,15 @@ export interface TmdbCreator {
 }
 
 /**
+ * Alternative title entry from TMDB API
+ */
+export interface TmdbAlternativeTitle {
+  iso_3166_1: string;
+  title: string;
+  type: string;
+}
+
+/**
  * External IDs from TMDB API
  */
 export interface TmdbExternalIds {
@@ -158,6 +167,10 @@ export interface TmdbBaseResponse {
   external_ids?: TmdbExternalIds;
   'watch/providers'?: {
     results: Record<string, TmdbWatchProviderRegion>;
+  };
+  alternative_titles?: {
+    titles?: TmdbAlternativeTitle[]; // Movies
+    results?: TmdbAlternativeTitle[]; // TV Shows
   };
 }
 

--- a/apps/web-client/src/shared/components/header/search/search-content.tsx
+++ b/apps/web-client/src/shared/components/header/search/search-content.tsx
@@ -82,6 +82,8 @@ export function SearchContent({ search, listClassName }: SearchContentProps) {
                 posterUrl={item.poster?.small}
                 slug={item.slug}
                 isLocal
+                matchedAlternativeTitle={item.matchedAlternativeTitle}
+                alsoKnownAsLabel={dict.search.alsoKnownAs}
                 onSelect={() => item.slug && handleSelect(item.slug, item.type as MediaType)}
               />
             ))}

--- a/apps/web-client/src/shared/components/header/search/search-result-item.tsx
+++ b/apps/web-client/src/shared/components/header/search/search-result-item.tsx
@@ -16,6 +16,8 @@ interface SearchResultItemProps {
   isLocal: boolean;
   isImporting?: boolean;
   notImportedLabel?: string;
+  matchedAlternativeTitle?: string | null;
+  alsoKnownAsLabel?: string;
   onSelect: () => void;
 }
 
@@ -32,6 +34,8 @@ export function SearchResultItem({
   isLocal,
   isImporting,
   notImportedLabel,
+  matchedAlternativeTitle,
+  alsoKnownAsLabel,
   onSelect,
 }: SearchResultItemProps) {
   const TypeIcon = type === 'movie' ? Film : Tv;
@@ -39,7 +43,7 @@ export function SearchResultItem({
   return (
     <CommandItem
       key={`${isLocal ? 'local' : 'tmdb'}-${tmdbId}`}
-      value={`${title} ${year ?? ''} ${isLocal ? '' : 'tmdb'}`}
+      value={`${title} ${matchedAlternativeTitle ?? ''} ${year ?? ''} ${isLocal ? '' : 'tmdb'}`}
       onSelect={onSelect}
       disabled={isImporting}
       className="gap-3 py-2 cursor-pointer"
@@ -62,6 +66,11 @@ export function SearchResultItem({
       {/* Info */}
       <div className="flex flex-col gap-0.5 min-w-0 flex-1">
         <span className={`truncate ${isLocal ? 'font-medium' : ''}`}>{title}</span>
+        {matchedAlternativeTitle && (
+          <span className="text-xs text-cinema-text-muted truncate">
+            {alsoKnownAsLabel} {matchedAlternativeTitle}
+          </span>
+        )}
         <span className="text-xs text-cinema-text-muted flex items-center gap-1.5">
           <TypeIcon className="h-3 w-3" />
           {year && year > 0 && <span>{year}</span>}

--- a/apps/web-client/src/shared/i18n/locales/en.json
+++ b/apps/web-client/src/shared/i18n/locales/en.json
@@ -32,7 +32,8 @@
     "noResults": "Nothing found",
     "inCatalog": "In catalog",
     "fromTmdb": "Not yet added",
-    "notImported": "click to add"
+    "notImported": "click to add",
+    "alsoKnownAs": "also:"
   },
   "import": {
     "importing": "Adding...",

--- a/apps/web-client/src/shared/i18n/locales/uk.json
+++ b/apps/web-client/src/shared/i18n/locales/uk.json
@@ -32,7 +32,8 @@
     "noResults": "Нічого не знайдено",
     "inCatalog": "У каталозі",
     "fromTmdb": "Ще не додано",
-    "notImported": "клікни щоб додати"
+    "notImported": "клікни щоб додати",
+    "alsoKnownAs": "також:"
   },
   "import": {
     "importing": "Додаємо...",

--- a/packages/api-contract/openapi.json
+++ b/packages/api-contract/openapi.json
@@ -3226,8 +3226,7 @@
               "example": "google",
               "enum": [
                 "google",
-                "facebook",
-                "apple"
+                "facebook"
               ],
               "type": "string"
             }
@@ -10592,6 +10591,7 @@
           },
           "linkedAt": {
             "type": "string",
+            "format": "date-time",
             "example": "2025-01-15T10:30:00.000Z",
             "description": "When the account was linked"
           }

--- a/packages/api-contract/openapi.json
+++ b/packages/api-contract/openapi.json
@@ -2983,6 +2983,42 @@
         ]
       }
     },
+    "/api/auth/password": {
+      "patch": {
+        "operationId": "AuthController_changePassword",
+        "summary": "Change current user password",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChangePasswordDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Password changed successfully"
+          },
+          "401": {
+            "description": "Not authenticated"
+          },
+          "403": {
+            "description": "Invalid current password"
+          }
+        },
+        "tags": [
+          "Auth"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
     "/api/auth/me": {
       "get": {
         "operationId": "AuthController_me",
@@ -3053,14 +3089,24 @@
         ]
       }
     },
-    "/api/auth/google/callback": {
+    "/api/auth/facebook": {
       "get": {
-        "operationId": "AuthController_googleCallback",
-        "summary": "Google OAuth callback",
-        "parameters": [],
+        "operationId": "AuthController_facebookAuth",
+        "summary": "Initiate Facebook OAuth flow",
+        "parameters": [
+          {
+            "name": "returnTo",
+            "required": false,
+            "in": "query",
+            "description": "URL to redirect after auth",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "302": {
-            "description": "Redirect to frontend with exchange code"
+            "description": "Redirect to Facebook"
           }
         },
         "tags": [
@@ -3121,6 +3167,90 @@
         ]
       }
     },
+    "/api/auth/providers": {
+      "get": {
+        "operationId": "AuthController_getLinkedAccounts",
+        "summary": "Get linked OAuth providers",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Linked accounts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/LinkedAccountDto"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Auth"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/auth/providers/{provider}": {
+      "delete": {
+        "operationId": "AuthController_unlinkProvider",
+        "summary": "Unlink OAuth provider",
+        "parameters": [
+          {
+            "name": "provider",
+            "required": true,
+            "in": "path",
+            "description": "OAuth provider to unlink",
+            "schema": {
+              "example": "google",
+              "enum": [
+                "google",
+                "facebook",
+                "apple"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Provider unlinked"
+          },
+          "403": {
+            "description": "Cannot unlink last authentication method"
+          }
+        },
+        "tags": [
+          "Auth"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
     "/api/auth/config": {
       "get": {
         "operationId": "AuthController_getConfig",
@@ -3145,17 +3275,7 @@
                       ]
                     },
                     "data": {
-                      "type": "object",
-                      "properties": {
-                        "google": {
-                          "type": "object",
-                          "properties": {
-                            "enabled": {
-                              "type": "boolean"
-                            }
-                          }
-                        }
-                      }
+                      "$ref": "#/components/schemas/AuthConfigDto"
                     }
                   }
                 }
@@ -3197,36 +3317,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/UpdateProfileDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "401": {
-            "description": "Unauthorized"
-          }
-        },
-        "tags": [
-          "Users"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/users/me/password": {
-      "patch": {
-        "operationId": "UsersController_changePassword",
-        "summary": "Change current user password (auth: Bearer)",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ChangePasswordDto"
               }
             }
           }
@@ -9678,6 +9768,11 @@
             "type": "boolean",
             "example": false,
             "description": "If true, this item exists in local DB"
+          },
+          "matchedAlternativeTitle": {
+            "type": "string",
+            "nullable": true,
+            "description": "Alternative title that matched the search query"
           }
         },
         "required": [
@@ -10289,6 +10384,23 @@
           "refreshToken"
         ]
       },
+      "ChangePasswordDto": {
+        "type": "object",
+        "properties": {
+          "currentPassword": {
+            "type": "string",
+            "example": "OldPass123"
+          },
+          "newPassword": {
+            "type": "string",
+            "example": "NewPass456"
+          }
+        },
+        "required": [
+          "currentPassword",
+          "newPassword"
+        ]
+      },
       "PrivacyDto": {
         "type": "object",
         "properties": {
@@ -10415,6 +10527,20 @@
           "profile": {
             "$ref": "#/components/schemas/ProfileDto"
           },
+          "hasPassword": {
+            "type": "boolean",
+            "description": "Whether the user has a password set (false for OAuth-only accounts)"
+          },
+          "linkedProviders": {
+            "description": "List of linked OAuth provider names",
+            "example": [
+              "google"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "stats": {
             "$ref": "#/components/schemas/StatsDto"
           }
@@ -10426,6 +10552,8 @@
           "avatarUrl",
           "role",
           "profile",
+          "hasPassword",
+          "linkedProviders",
           "stats"
         ]
       },
@@ -10440,6 +10568,74 @@
         },
         "required": [
           "code"
+        ]
+      },
+      "LinkedAccountDto": {
+        "type": "object",
+        "properties": {
+          "provider": {
+            "type": "string",
+            "example": "google",
+            "description": "OAuth provider name"
+          },
+          "email": {
+            "type": "string",
+            "example": "user@gmail.com",
+            "nullable": true,
+            "description": "Email from OAuth provider"
+          },
+          "displayName": {
+            "type": "string",
+            "example": "John Doe",
+            "nullable": true,
+            "description": "Display name from OAuth provider"
+          },
+          "linkedAt": {
+            "type": "string",
+            "example": "2025-01-15T10:30:00.000Z",
+            "description": "When the account was linked"
+          }
+        },
+        "required": [
+          "provider",
+          "linkedAt"
+        ]
+      },
+      "ProviderConfigDto": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether this OAuth provider is enabled"
+          }
+        },
+        "required": [
+          "enabled"
+        ]
+      },
+      "AuthConfigDto": {
+        "type": "object",
+        "properties": {
+          "google": {
+            "description": "Google OAuth configuration",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProviderConfigDto"
+              }
+            ]
+          },
+          "facebook": {
+            "description": "Facebook OAuth configuration",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProviderConfigDto"
+              }
+            ]
+          }
+        },
+        "required": [
+          "google",
+          "facebook"
         ]
       },
       "UpdateProfileDto": {
@@ -10494,23 +10690,6 @@
             "example": true
           }
         }
-      },
-      "ChangePasswordDto": {
-        "type": "object",
-        "properties": {
-          "currentPassword": {
-            "type": "string",
-            "example": "OldPass123"
-          },
-          "newPassword": {
-            "type": "string",
-            "example": "NewPass456"
-          }
-        },
-        "required": [
-          "currentPassword",
-          "newPassword"
-        ]
       },
       "CreateAvatarUploadUrlDto": {
         "type": "object",

--- a/packages/api-contract/src/api-types.ts
+++ b/packages/api-contract/src/api-types.ts
@@ -3391,6 +3391,7 @@ export interface components {
              */
             displayName?: string | null;
             /**
+             * Format: date-time
              * @description When the account was linked
              * @example 2025-01-15T10:30:00.000Z
              */
@@ -7276,7 +7277,7 @@ export interface operations {
             header?: never;
             path: {
                 /** @description OAuth provider to unlink */
-                provider: "google" | "facebook" | "apple";
+                provider: "google" | "facebook";
             };
             cookie?: never;
         };

--- a/packages/api-contract/src/api-types.ts
+++ b/packages/api-contract/src/api-types.ts
@@ -671,6 +671,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/auth/password": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Change current user password */
+        patch: operations["AuthController_changePassword"];
+        trace?: never;
+    };
     "/api/auth/me": {
         parameters: {
             query?: never;
@@ -705,15 +722,15 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/auth/google/callback": {
+    "/api/auth/facebook": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /** Google OAuth callback */
-        get: operations["AuthController_googleCallback"];
+        /** Initiate Facebook OAuth flow */
+        get: operations["AuthController_facebookAuth"];
         put?: never;
         post?: never;
         delete?: never;
@@ -734,6 +751,40 @@ export interface paths {
         /** Exchange one-time code for tokens */
         post: operations["AuthController_exchangeCode"];
         delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/providers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get linked OAuth providers */
+        get: operations["AuthController_getLinkedAccounts"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/providers/{provider}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Unlink OAuth provider */
+        delete: operations["AuthController_unlinkProvider"];
         options?: never;
         head?: never;
         patch?: never;
@@ -772,23 +823,6 @@ export interface paths {
         head?: never;
         /** Update current user profile (auth: Bearer) */
         patch: operations["UsersController_updateProfile"];
-        trace?: never;
-    };
-    "/api/users/me/password": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /** Change current user password (auth: Bearer) */
-        patch: operations["UsersController_changePassword"];
         trace?: never;
     };
     "/api/users/me/avatar/upload-url": {
@@ -2989,6 +3023,8 @@ export interface components {
              * @example false
              */
             isImported: boolean;
+            /** @description Alternative title that matched the search query */
+            matchedAlternativeTitle?: string | null;
         };
         SearchResponseDto: {
             query: string;
@@ -3266,6 +3302,12 @@ export interface components {
             /** @example eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9... */
             refreshToken: string;
         };
+        ChangePasswordDto: {
+            /** @example OldPass123 */
+            currentPassword: string;
+            /** @example NewPass456 */
+            newPassword: string;
+        };
         PrivacyDto: {
             /** @example true */
             isProfilePublic: boolean;
@@ -3314,6 +3356,15 @@ export interface components {
              */
             role: "user" | "admin";
             profile: components["schemas"]["ProfileDto"];
+            /** @description Whether the user has a password set (false for OAuth-only accounts) */
+            hasPassword: boolean;
+            /**
+             * @description List of linked OAuth provider names
+             * @example [
+             *       "google"
+             *     ]
+             */
+            linkedProviders: string[];
             stats: components["schemas"]["StatsDto"];
         };
         ExchangeCodeDto: {
@@ -3322,6 +3373,38 @@ export interface components {
              * @example abc123xyz...
              */
             code: string;
+        };
+        LinkedAccountDto: {
+            /**
+             * @description OAuth provider name
+             * @example google
+             */
+            provider: string;
+            /**
+             * @description Email from OAuth provider
+             * @example user@gmail.com
+             */
+            email?: string | null;
+            /**
+             * @description Display name from OAuth provider
+             * @example John Doe
+             */
+            displayName?: string | null;
+            /**
+             * @description When the account was linked
+             * @example 2025-01-15T10:30:00.000Z
+             */
+            linkedAt: string;
+        };
+        ProviderConfigDto: {
+            /** @description Whether this OAuth provider is enabled */
+            enabled: boolean;
+        };
+        AuthConfigDto: {
+            /** @description Google OAuth configuration */
+            google: components["schemas"]["ProviderConfigDto"];
+            /** @description Facebook OAuth configuration */
+            facebook: components["schemas"]["ProviderConfigDto"];
         };
         UpdateProfileDto: {
             /** @example ratingo_fan */
@@ -3348,12 +3431,6 @@ export interface components {
             allowFollowers?: boolean;
             /** @example true */
             autoSubscribeOnWatch?: boolean;
-        };
-        ChangePasswordDto: {
-            /** @example OldPass123 */
-            currentPassword: string;
-            /** @example NewPass456 */
-            newPassword: string;
         };
         CreateAvatarUploadUrlDto: {
             /** @enum {string} */
@@ -7018,6 +7095,42 @@ export interface operations {
             };
         };
     };
+    AuthController_changePassword: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ChangePasswordDto"];
+            };
+        };
+        responses: {
+            /** @description Password changed successfully */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Not authenticated */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Invalid current password */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
     AuthController_me: {
         parameters: {
             query?: never;
@@ -7070,16 +7183,19 @@ export interface operations {
             };
         };
     };
-    AuthController_googleCallback: {
+    AuthController_facebookAuth: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description URL to redirect after auth */
+                returnTo?: string;
+            };
             header?: never;
             path?: never;
             cookie?: never;
         };
         requestBody?: never;
         responses: {
-            /** @description Redirect to frontend with exchange code */
+            /** @description Redirect to Facebook */
             302: {
                 headers: {
                     [name: string]: unknown;
@@ -7130,6 +7246,58 @@ export interface operations {
             };
         };
     };
+    AuthController_getLinkedAccounts: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Linked accounts */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {boolean} */
+                        success: true;
+                        data: components["schemas"]["LinkedAccountDto"][];
+                    };
+                };
+            };
+        };
+    };
+    AuthController_unlinkProvider: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description OAuth provider to unlink */
+                provider: "google" | "facebook" | "apple";
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Provider unlinked */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Cannot unlink last authentication method */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
     AuthController_getConfig: {
         parameters: {
             query?: never;
@@ -7148,11 +7316,7 @@ export interface operations {
                     "application/json": {
                         /** @enum {boolean} */
                         success: true;
-                        data: {
-                            google?: {
-                                enabled?: boolean;
-                            };
-                        };
+                        data: components["schemas"]["AuthConfigDto"];
                     };
                 };
             };
@@ -7186,28 +7350,6 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": components["schemas"]["UpdateProfileDto"];
-            };
-        };
-        responses: {
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    UsersController_changePassword: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ChangePasswordDto"];
             };
         };
         responses: {


### PR DESCRIPTION
## Summary
- Store TMDB alternative titles in `alternative_titles text[]` column and search against them (ILIKE + trigram `%`)
- Show matched alternative title in search results UI ("також: Невразливий")
- Zero extra TMDB API calls — piggyback on existing `append_to_response`

Closes #50

## Changes

### Backend
- **Migration**: `alternative_titles text[]` column, `immutable_array_to_string()` wrapper, recreated `search_vector` generated column, GIN indexes (FTS + trigram)
- **TMDB ingestion**: extract alt titles filtered by UA/US/RU/GB + origin country, dedup against title/originalTitle, cap at 20
- **Search query**: alt titles in WHERE (ILIKE + trigram) and ORDER BY (similarity scoring)
- **DTO/Mapper**: `matchedAlternativeTitle` field with substring + reverse containment matching
- **Constants**: extracted `ALT_TITLE_COUNTRIES` and `MAX_ALT_TITLES` to `tmdb/constants/alt-title.constants.ts`

### Frontend
- "також: {title}" / "also: {title}" label under matched search results
- Alt title included in cmdk `CommandItem` value for client-side filtering

### Tests
- 7 new tests for `extractAlternativeTitles` (country filter, dedup, cap, shows vs movies, empty input)
- 2 new tests for search mapper (reverse containment, TMDB explicit null)
- Updated existing assertions for new field

## Test plan
- [ ] Search "Невколупний" → finds "НЕПЕРЕМОЖНИЙ" with "також: Невколупний"
- [ ] Search "НЕПЕРЕМОЖНИЙ" → finds directly, no "також:" label
- [ ] Search "Invincible" → finds via originalTitle, no "також:" label
- [ ] `npm run test:api` — 265 suites, 3657 tests pass
- [ ] `npm run build:api && npm run build:client` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Нотатки до випуску

* **Нові функції**
  * Пошук за альтернативними назвами медіа; результати показують альтернативну назву, що збіглася з запитом.
  * Додано обмеження та фільтрацію альтернативних назв із зовнішніх джерел; краще ранжування та нечіткий пошук.

* **API / Аутентифікація**
  * Оновлено потік OAuth (перехід на Facebook) та додано кінцеву точку для зміни пароля.

* **Тести**
  * Додані юніт-тести для обробки та матчингу альтернативних назв.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->