### PR TITLE
perf(ingestion): separate backfill queue for high-throughput TMDB jobs

### DIFF
--- a/apps/api/src/config/queue.config.ts
+++ b/apps/api/src/config/queue.config.ts
@@ -55,7 +55,7 @@ export const WORKER_CONFIG = {
 
   /**
    * Backfill queue worker config.
-   * Jobs: backfill-alt-titles-item, backfill-imdb-item (TMDB-only, no Trakt).
+   * Jobs: backfill-alt-titles-item, backfill-imdb-item (TMDB-only — no Trakt/OMDb/TVMaze).
    * Duration: 200-2000ms (single TMDB API call + DB update)
    *
    * Higher throughput than ingestion: TMDB allows ~40 req/s.

--- a/apps/api/src/config/queue.config.ts
+++ b/apps/api/src/config/queue.config.ts
@@ -54,6 +54,22 @@ export const WORKER_CONFIG = {
   },
 
   /**
+   * Backfill queue worker config.
+   * Jobs: backfill-alt-titles-item, backfill-imdb-item (TMDB-only, no Trakt).
+   * Duration: 200-2000ms (single TMDB API call + DB update)
+   *
+   * Higher throughput than ingestion: TMDB allows ~40 req/s.
+   * 15 concurrent jobs × ~300ms avg = ~50 req/s → capped by limiter at 600/min.
+   */
+  backfill: {
+    lockDuration: 30_000, // 30 seconds (short jobs)
+    limiter: {
+      max: 600, // 600 jobs per minute (~10/sec, well within TMDB 40/sec)
+      duration: 60_000,
+    },
+  },
+
+  /**
    * Catalog policy queue worker config.
    * Jobs: re-evaluate-all, evaluate-catalog-item, watchdog
    * Duration: 100ms-30s (policy evaluation + DB writes)

--- a/apps/api/src/modules/ingestion/application/pipelines/backfill-alt-titles.pipeline.ts
+++ b/apps/api/src/modules/ingestion/application/pipelines/backfill-alt-titles.pipeline.ts
@@ -14,7 +14,7 @@ import { ALT_TITLE_COUNTRIES, MAX_ALT_TITLES } from '../../../tmdb/public';
 import { TmdbAdapter } from '../../../tmdb/public';
 import {
   BACKFILL_ALT_TITLES_BATCH_SIZE,
-  INGESTION_QUEUE,
+  BACKFILL_QUEUE,
   IngestionJob,
 } from '../../ingestion.constants';
 
@@ -34,7 +34,7 @@ export class BackfillAltTitlesPipeline {
   constructor(
     @Inject(DATABASE_CONNECTION)
     private readonly db: PostgresJsDatabase<typeof schema>,
-    @InjectQueue(INGESTION_QUEUE)
+    @InjectQueue(BACKFILL_QUEUE)
     private readonly queue: Queue,
     private readonly tmdbAdapter: TmdbAdapter,
     @Inject(MEDIA_REPOSITORY)

--- a/apps/api/src/modules/ingestion/application/pipelines/backfill-imdb.pipeline.ts
+++ b/apps/api/src/modules/ingestion/application/pipelines/backfill-imdb.pipeline.ts
@@ -9,7 +9,7 @@ import { MediaType } from '@/common/enums/media-type.enum';
 import { DATABASE_CONNECTION } from '@/database/database.module';
 import * as schema from '@/database/schema';
 
-import { INGESTION_QUEUE, IngestionJob } from '../../ingestion.constants';
+import { BACKFILL_QUEUE, IngestionJob } from '../../ingestion.constants';
 import { SyncMediaService } from '../services/sync-media.service';
 
 /**
@@ -34,7 +34,7 @@ export class BackfillImdbPipeline {
   constructor(
     @Inject(DATABASE_CONNECTION)
     private readonly db: PostgresJsDatabase<typeof schema>,
-    @InjectQueue(INGESTION_QUEUE)
+    @InjectQueue(BACKFILL_QUEUE)
     private readonly queue: Queue,
     private readonly syncService: SyncMediaService,
   ) {}

--- a/apps/api/src/modules/ingestion/application/pipelines/backfill-imdb.pipeline.ts
+++ b/apps/api/src/modules/ingestion/application/pipelines/backfill-imdb.pipeline.ts
@@ -9,8 +9,8 @@ import { MediaType } from '@/common/enums/media-type.enum';
 import { DATABASE_CONNECTION } from '@/database/database.module';
 import * as schema from '@/database/schema';
 
+import { TmdbAdapter } from '../../../tmdb/public';
 import { BACKFILL_QUEUE, IngestionJob } from '../../ingestion.constants';
-import { SyncMediaService } from '../services/sync-media.service';
 
 /**
  * Batch size for backfill dispatcher pagination.
@@ -25,7 +25,9 @@ const BACKFILL_BATCH_SIZE = 100;
  *
  * This pipeline:
  * 1. Dispatcher: finds all shows with NULL imdb_id and queues item jobs
- * 2. Item job: re-syncs the show via SyncMediaService (which now fetches external_ids)
+ * 2. Item job: fetches external IDs from TMDB (single API call) + direct DB update
+ *
+ * TMDB-only: no Trakt/OMDb/TVMaze calls. Safe for high-throughput backfill queue.
  */
 @Injectable()
 export class BackfillImdbPipeline {
@@ -36,7 +38,7 @@ export class BackfillImdbPipeline {
     private readonly db: PostgresJsDatabase<typeof schema>,
     @InjectQueue(BACKFILL_QUEUE)
     private readonly queue: Queue,
-    private readonly syncService: SyncMediaService,
+    private readonly tmdbAdapter: TmdbAdapter,
   ) {}
 
   /**
@@ -95,9 +97,21 @@ export class BackfillImdbPipeline {
   }
 
   /**
-   * Item job: re-syncs a single show to fetch IMDb ID and OMDb ratings.
+   * Item job: fetches external IDs from TMDB and updates the DB directly.
+   * TMDB-only — single API call, no Trakt/OMDb/TVMaze.
    */
   async processItem(tmdbId: number, jobId: string): Promise<void> {
-    await this.syncService.syncShow(tmdbId, undefined, jobId);
+    const result = await this.tmdbAdapter.getExternalIds(tmdbId, MediaType.SHOW);
+    if (!result?.imdbId) {
+      this.logger.debug(`[${jobId}] No IMDb ID found for tmdbId=${tmdbId}`);
+      return;
+    }
+
+    await this.db
+      .update(schema.mediaItems)
+      .set({ imdbId: result.imdbId })
+      .where(eq(schema.mediaItems.tmdbId, tmdbId));
+
+    this.logger.debug(`[${jobId}] Updated imdbId for tmdbId=${tmdbId} → ${result.imdbId}`);
   }
 }

--- a/apps/api/src/modules/ingestion/application/pipelines/backfill-imdb.pipeline.ts
+++ b/apps/api/src/modules/ingestion/application/pipelines/backfill-imdb.pipeline.ts
@@ -110,7 +110,7 @@ export class BackfillImdbPipeline {
     await this.db
       .update(schema.mediaItems)
       .set({ imdbId: result.imdbId })
-      .where(eq(schema.mediaItems.tmdbId, tmdbId));
+      .where(and(eq(schema.mediaItems.tmdbId, tmdbId), eq(schema.mediaItems.type, MediaType.SHOW)));
 
     this.logger.debug(`[${jobId}] Updated imdbId for tmdbId=${tmdbId} → ${result.imdbId}`);
   }

--- a/apps/api/src/modules/ingestion/application/workers/backfill.worker.spec.ts
+++ b/apps/api/src/modules/ingestion/application/workers/backfill.worker.spec.ts
@@ -1,0 +1,107 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Job } from 'bullmq';
+
+import { MediaType } from '@/common/enums/media-type.enum';
+
+import { IngestionJob } from '../../ingestion.constants';
+import { destroyTraktRateLimiter } from '../../infrastructure/adapters/trakt/base-trakt-http';
+import { BackfillAltTitlesPipeline } from '../pipelines/backfill-alt-titles.pipeline';
+import { BackfillImdbPipeline } from '../pipelines/backfill-imdb.pipeline';
+
+import { BackfillWorker } from './backfill.worker';
+
+afterAll(() => {
+  destroyTraktRateLimiter();
+});
+
+describe('BackfillWorker', () => {
+  let worker: BackfillWorker;
+  let backfillAltTitlesPipeline: any;
+  let backfillImdbPipeline: any;
+
+  beforeEach(async () => {
+    backfillAltTitlesPipeline = {
+      processItem: jest.fn().mockResolvedValue(undefined),
+    };
+
+    backfillImdbPipeline = {
+      processItem: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BackfillWorker,
+        { provide: BackfillAltTitlesPipeline, useValue: backfillAltTitlesPipeline },
+        { provide: BackfillImdbPipeline, useValue: backfillImdbPipeline },
+      ],
+    }).compile();
+
+    worker = module.get<BackfillWorker>(BackfillWorker);
+  });
+
+  describe('process - BACKFILL_ALT_TITLES_ITEM', () => {
+    it('should route to backfillAltTitlesPipeline.processItem()', async () => {
+      const job = {
+        name: IngestionJob.BACKFILL_ALT_TITLES_ITEM,
+        data: {
+          mediaItemId: 'item-1',
+          tmdbId: 550,
+          type: MediaType.MOVIE,
+          title: 'Test Movie',
+          originalTitle: 'Original Test',
+        },
+        id: 'alt-titles-1',
+      } as Job;
+
+      await worker.process(job);
+
+      expect(backfillAltTitlesPipeline.processItem).toHaveBeenCalledWith({
+        mediaItemId: 'item-1',
+        tmdbId: 550,
+        type: MediaType.MOVIE,
+        title: 'Test Movie',
+        originalTitle: 'Original Test',
+      });
+    });
+  });
+
+  describe('process - BACKFILL_IMDB_ITEM', () => {
+    it('should route to backfillImdbPipeline.processItem()', async () => {
+      const job = {
+        name: IngestionJob.BACKFILL_IMDB_ITEM,
+        data: { tmdbId: 100 },
+        id: 'imdb-1',
+      } as Job;
+
+      await worker.process(job);
+
+      expect(backfillImdbPipeline.processItem).toHaveBeenCalledWith(100, 'imdb-1');
+    });
+  });
+
+  describe('unknown job types', () => {
+    it('should log warning for unknown job type', async () => {
+      const job = { name: 'UNKNOWN_BACKFILL_JOB' as any, data: {}, id: 'unknown-1' } as Job;
+      const loggerSpy = jest.spyOn((worker as any).logger, 'warn');
+
+      await worker.process(job);
+
+      expect(loggerSpy).toHaveBeenCalledWith('Unknown backfill job type: UNKNOWN_BACKFILL_JOB');
+    });
+  });
+
+  describe('error handling', () => {
+    it('should log and rethrow errors', async () => {
+      const error = new Error('Pipeline failed');
+      backfillImdbPipeline.processItem.mockRejectedValue(error);
+
+      const job = {
+        name: IngestionJob.BACKFILL_IMDB_ITEM,
+        data: { tmdbId: 100 },
+        id: 'err-1',
+      } as Job;
+
+      await expect(worker.process(job)).rejects.toThrow(error);
+    });
+  });
+});

--- a/apps/api/src/modules/ingestion/application/workers/backfill.worker.ts
+++ b/apps/api/src/modules/ingestion/application/workers/backfill.worker.ts
@@ -1,0 +1,69 @@
+import { Processor, WorkerHost } from '@nestjs/bullmq';
+import { Logger } from '@nestjs/common';
+
+import { type Job } from 'bullmq';
+
+import { type MediaType } from '@/common/enums/media-type.enum';
+import { WORKER_CONFIG } from '@/config/queue.config';
+
+import { BACKFILL_QUEUE, IngestionJob } from '../../ingestion.constants';
+import { BackfillAltTitlesPipeline } from '../pipelines/backfill-alt-titles.pipeline';
+import { BackfillImdbPipeline } from '../pipelines/backfill-imdb.pipeline';
+
+/**
+ * High-throughput worker for backfill item jobs (TMDB-only, no Trakt).
+ *
+ * Separated from SyncWorker so backfill jobs bypass the Trakt rate limiter.
+ * Concurrency: 15 jobs in parallel — TMDB allows ~40 req/s, each job makes 1 call.
+ */
+@Processor(BACKFILL_QUEUE, {
+  concurrency: 15,
+  lockDuration: WORKER_CONFIG.backfill.lockDuration,
+  limiter: WORKER_CONFIG.backfill.limiter,
+})
+export class BackfillWorker extends WorkerHost {
+  private readonly logger = new Logger(BackfillWorker.name);
+
+  constructor(
+    private readonly backfillAltTitlesPipeline: BackfillAltTitlesPipeline,
+    private readonly backfillImdbPipeline: BackfillImdbPipeline,
+  ) {
+    super();
+  }
+
+  async process(
+    job: Job<{
+      tmdbId?: number;
+      type?: MediaType;
+      mediaItemId?: string;
+      title?: string;
+      originalTitle?: string | null;
+    }>,
+  ): Promise<void> {
+    this.logger.debug(`[job:${job.id}] Processing ${job.name}`);
+    try {
+      switch (job.name) {
+        case IngestionJob.BACKFILL_ALT_TITLES_ITEM:
+          await this.backfillAltTitlesPipeline.processItem({
+            mediaItemId: job.data.mediaItemId!,
+            tmdbId: job.data.tmdbId!,
+            type: job.data.type!,
+            title: job.data.title!,
+            originalTitle: job.data.originalTitle ?? null,
+          });
+          break;
+
+        case IngestionJob.BACKFILL_IMDB_ITEM:
+          await this.backfillImdbPipeline.processItem(job.data.tmdbId!, job.id ?? 'unknown');
+          break;
+
+        default:
+          this.logger.warn(`Unknown backfill job type: ${job.name}`);
+      }
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      this.logger.error(`[job:${job.id}] Failed: ${err.message}`, err.stack);
+      throw error;
+    }
+  }
+}

--- a/apps/api/src/modules/ingestion/application/workers/sync.worker.ts
+++ b/apps/api/src/modules/ingestion/application/workers/sync.worker.ts
@@ -144,22 +144,12 @@ export class SyncWorker extends WorkerHost {
         case IngestionJob.BACKFILL_IMDB_DISPATCHER:
           await this.backfillImdbPipeline.dispatch();
           break;
-        case IngestionJob.BACKFILL_IMDB_ITEM:
-          await this.backfillImdbPipeline.processItem(job.data.tmdbId!, jid);
-          break;
+        // Note: BACKFILL_IMDB_ITEM and BACKFILL_ALT_TITLES_ITEM are handled
+        // by BackfillWorker on the dedicated backfill queue (higher throughput).
 
-        // Alternative titles backfill pipeline
+        // Alternative titles backfill dispatcher (stays here — single job)
         case IngestionJob.BACKFILL_ALT_TITLES_DISPATCHER:
           await this.backfillAltTitlesPipeline.dispatch();
-          break;
-        case IngestionJob.BACKFILL_ALT_TITLES_ITEM:
-          await this.backfillAltTitlesPipeline.processItem({
-            mediaItemId: job.data.mediaItemId!,
-            tmdbId: job.data.tmdbId!,
-            type: job.data.type!,
-            title: job.data.title!,
-            originalTitle: job.data.originalTitle ?? null,
-          });
           break;
 
         default:

--- a/apps/api/src/modules/ingestion/ingestion.constants.ts
+++ b/apps/api/src/modules/ingestion/ingestion.constants.ts
@@ -1,7 +1,13 @@
 /**
- * Queue name for ingestion tasks.
+ * Queue name for ingestion tasks (Trakt/OMDb/TVMaze — rate-limited).
  */
 export const INGESTION_QUEUE = 'ingestion';
+
+/**
+ * Queue name for backfill tasks (TMDB-only — high throughput).
+ * Separated from ingestion queue to avoid Trakt rate limiter bottleneck.
+ */
+export const BACKFILL_QUEUE = 'backfill';
 
 /**
  * Job names for ingestion queue.

--- a/apps/api/src/modules/ingestion/ingestion.constants.ts
+++ b/apps/api/src/modules/ingestion/ingestion.constants.ts
@@ -10,6 +10,17 @@ export const INGESTION_QUEUE = 'ingestion';
 export const BACKFILL_QUEUE = 'backfill';
 
 /**
+ * Shared default job options for both ingestion and backfill queues.
+ * Backfill queue overrides `removeOnComplete` for higher observability.
+ */
+export const DEFAULT_INGESTION_JOB_OPTIONS = {
+  attempts: 3,
+  backoff: { type: 'exponential' as const, delay: 2000 },
+  removeOnComplete: 100,
+  removeOnFail: 50,
+} as const;
+
+/**
  * Job names for ingestion queue.
  * Used by Producer (Controller) and Consumer (Worker).
  */
@@ -43,12 +54,12 @@ export enum IngestionJob {
 
   /** Dispatcher job: finds shows without IMDb ID and queues re-sync */
   BACKFILL_IMDB_DISPATCHER = 'backfill-imdb-dispatcher',
-  /** Item job: re-syncs a single show to fetch IMDb ID */
+  /** Item job: fetches external IDs from TMDB for a single show. @queue backfill */
   BACKFILL_IMDB_ITEM = 'backfill-imdb-item',
 
   /** Dispatcher job: finds items without alternative titles and queues TMDB fetch */
   BACKFILL_ALT_TITLES_DISPATCHER = 'backfill-alt-titles-dispatcher',
-  /** Item job: fetches alternative titles from TMDB for a single item */
+  /** Item job: fetches alternative titles from TMDB for a single item. @queue backfill */
   BACKFILL_ALT_TITLES_ITEM = 'backfill-alt-titles-item',
 }
 

--- a/apps/api/src/modules/ingestion/ingestion.module.ts
+++ b/apps/api/src/modules/ingestion/ingestion.module.ts
@@ -37,7 +37,11 @@ import { TraktListsAdapter } from './infrastructure/adapters/trakt/trakt-lists.a
 import { TraktRatingsAdapter } from './infrastructure/adapters/trakt/trakt-ratings.adapter';
 import { TvMazeAdapter } from './infrastructure/adapters/tvmaze/tvmaze.adapter';
 import { SnapshotsRepository } from './infrastructure/repositories/snapshots.repository';
-import { BACKFILL_QUEUE, INGESTION_QUEUE } from './ingestion.constants';
+import {
+  BACKFILL_QUEUE,
+  DEFAULT_INGESTION_JOB_OPTIONS,
+  INGESTION_QUEUE,
+} from './ingestion.constants';
 import { IngestionController } from './presentation/controllers/ingestion.controller';
 
 /**
@@ -58,26 +62,13 @@ import { IngestionController } from './presentation/controllers/ingestion.contro
     ConfigModule.forFeature(schedulerConfig),
     BullModule.registerQueue({
       name: INGESTION_QUEUE,
-      defaultJobOptions: {
-        attempts: 3,
-        backoff: {
-          type: 'exponential',
-          delay: 2000,
-        },
-        removeOnComplete: 100,
-        removeOnFail: 50,
-      },
+      defaultJobOptions: DEFAULT_INGESTION_JOB_OPTIONS,
     }),
     BullModule.registerQueue({
       name: BACKFILL_QUEUE,
       defaultJobOptions: {
-        attempts: 3,
-        backoff: {
-          type: 'exponential',
-          delay: 2000,
-        },
-        removeOnComplete: 100,
-        removeOnFail: 50,
+        ...DEFAULT_INGESTION_JOB_OPTIONS,
+        removeOnComplete: { age: 3600, count: 1000 }, // higher for fast queue observability
       },
     }),
   ],

--- a/apps/api/src/modules/ingestion/ingestion.module.ts
+++ b/apps/api/src/modules/ingestion/ingestion.module.ts
@@ -27,6 +27,7 @@ import { SnapshotsService } from './application/services/snapshots.service';
 import { SyncMediaService } from './application/services/sync-media.service';
 import { TrackedSyncService } from './application/services/tracked-sync.service';
 import { TvMazeEnrichmentService } from './application/services/tvmaze-enrichment.service';
+import { BackfillWorker } from './application/workers/backfill.worker';
 import { SyncWorker } from './application/workers/sync.worker';
 import { TRAKT_LISTS_PORT } from './domain/ports/trakt-lists.port';
 import { TRAKT_RATINGS_PORT } from './domain/ports/trakt-ratings.port';
@@ -36,7 +37,7 @@ import { TraktListsAdapter } from './infrastructure/adapters/trakt/trakt-lists.a
 import { TraktRatingsAdapter } from './infrastructure/adapters/trakt/trakt-ratings.adapter';
 import { TvMazeAdapter } from './infrastructure/adapters/tvmaze/tvmaze.adapter';
 import { SnapshotsRepository } from './infrastructure/repositories/snapshots.repository';
-import { INGESTION_QUEUE } from './ingestion.constants';
+import { BACKFILL_QUEUE, INGESTION_QUEUE } from './ingestion.constants';
 import { IngestionController } from './presentation/controllers/ingestion.controller';
 
 /**
@@ -57,6 +58,18 @@ import { IngestionController } from './presentation/controllers/ingestion.contro
     ConfigModule.forFeature(schedulerConfig),
     BullModule.registerQueue({
       name: INGESTION_QUEUE,
+      defaultJobOptions: {
+        attempts: 3,
+        backoff: {
+          type: 'exponential',
+          delay: 2000,
+        },
+        removeOnComplete: 100,
+        removeOnFail: 50,
+      },
+    }),
+    BullModule.registerQueue({
+      name: BACKFILL_QUEUE,
       defaultJobOptions: {
         attempts: 3,
         backoff: {
@@ -94,6 +107,7 @@ import { IngestionController } from './presentation/controllers/ingestion.contro
     SyncMediaService,
     TrackedSyncService,
     SyncWorker,
+    BackfillWorker,
     SnapshotsService,
     IngestionSchedulerService,
     // Pipeline classes

--- a/apps/api/src/modules/tmdb/tmdb.adapter.ts
+++ b/apps/api/src/modules/tmdb/tmdb.adapter.ts
@@ -242,7 +242,7 @@ export class TmdbAdapter implements MetadataProviderPort {
   }
 
   /**
-   * Fetches only external IDs (IMDb, TVDb) for a media item.
+   * Fetches only external IDs (IMDb) for a media item.
    * Lightweight: single TMDB call, no credits/videos/providers.
    * Returns null on 404.
    */

--- a/apps/api/src/modules/tmdb/tmdb.adapter.ts
+++ b/apps/api/src/modules/tmdb/tmdb.adapter.ts
@@ -25,6 +25,7 @@ import { TmdbMapper } from './mappers/tmdb.mapper';
 import type {
   TmdbAlternativeTitle,
   TmdbMediaResponse,
+  TmdbMovieResponse,
   TmdbSeasonDetailResponse,
 } from './types/tmdb-api.types';
 
@@ -235,6 +236,38 @@ export class TmdbAdapter implements MetadataProviderPort {
     } catch (error) {
       if (error instanceof TmdbApiException && error.details?.statusCode === HttpStatus.NOT_FOUND) {
         return [];
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Fetches only external IDs (IMDb, TVDb) for a media item.
+   * Lightweight: single TMDB call, no credits/videos/providers.
+   * Returns null on 404.
+   */
+  public async getExternalIds(
+    tmdbId: number,
+    type: MediaType,
+  ): Promise<{ imdbId: string | null } | null> {
+    const prefix = type === MediaType.MOVIE ? 'movie' : 'tv';
+    const endpoint = `/${prefix}/${tmdbId}`;
+
+    try {
+      const data = await this.fetch<TmdbMediaResponse>(endpoint, {
+        append_to_response: 'external_ids',
+      });
+
+      const imdbId =
+        data.external_ids?.imdb_id ||
+        (type === MediaType.MOVIE ? (data as TmdbMovieResponse).imdb_id : null) ||
+        null;
+
+      return { imdbId };
+    } catch (error) {
+      if (error instanceof TmdbApiException && error.details?.statusCode === HttpStatus.NOT_FOUND) {
+        this.logger.warn(`TMDB ${prefix} ${tmdbId} not found (404)`);
+        return null;
       }
       throw error;
     }


### PR DESCRIPTION
## Summary
- Dedicated `backfill` BullMQ queue with `BackfillWorker` (concurrency=15, 600 jobs/min)
- Both `BACKFILL_ALT_TITLES_ITEM` and `BACKFILL_IMDB_ITEM` are now **truly TMDB-only** — safe for high throughput
- `BACKFILL_IMDB_ITEM` rewritten: replaced `syncService.syncShow()` (Trakt+OMDb+TVMaze+TMDB) with lightweight `TmdbAdapter.getExternalIds()` + direct DB update
- Estimated improvement: **3+ hours → ~3 minutes** for 5000-item backfill

## Changes
- **New** `TmdbAdapter.getExternalIds()` — single TMDB API call, returns only IMDb ID
- **Rewritten** `BackfillImdbPipeline.processItem()` — TMDB-only + direct `UPDATE imdb_id`
- **New** `BackfillWorker` — processes both backfill item jobs on fast queue
- **New** `BACKFILL_QUEUE` constant + BullMQ queue registration
- **New** `DEFAULT_INGESTION_JOB_OPTIONS` — DRY queue config
- `SyncWorker` no longer handles backfill item jobs (dispatchers stay)
- `IngestionJob` enum annotated with `@queue backfill` for clarity
- Backfill queue uses `removeOnComplete: { age: 3600, count: 1000 }` for better observability

## Local test results
| Metric | Value |
|--------|-------|
| Jobs | 116 |
| Completed | 116 |
| Failed | 0 |
| Total time | **3.3 seconds** |
| Avg throughput | 28ms/job |

## Test plan
- [x] `npm run build:api` — passes
- [x] Ingestion + TMDB tests: 19 suites, 252 tests — all pass
- [x] Lint: 0 new errors
- [x] Local run: 116 jobs in 3.3s, 0 failures, 13 IMDb IDs updated
- [ ] Deploy and re-trigger backfill on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Додано окрему чергу backfill з підвищеною пропускною здатністю та стандартними опціями задач.
  * Додано бекфіл-воркер для обробки елементів (альт. назви та IMDb ID) з TMDB-орієнтованим шляхом оновлення.
  * Додано легкий метод TMDB для отримання зовнішніх ідентифікаторів (наприклад, imdb_id).

* **Changes**
  * Маршрутизація обробки item-рівня переміщена в нову backfill-чергу; основний воркер делегує ці задачі.

* **Tests**
  * Додано юніт-тести для нового бекфіл-воркера (маршрутизація, обробка помилок, невідомі типи).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->