### PR TITLE
feat(web-client): style offline fallback page

### DIFF
--- a/apps/web-client/src/app/(main)/~offline/page.tsx
+++ b/apps/web-client/src/app/(main)/~offline/page.tsx
@@ -1,10 +1,36 @@
+'use client';
+
+import { WifiOff, RefreshCw, Home } from 'lucide-react';
+import Link from 'next/link';
+import { Button } from '@/shared/ui';
+
 export default function OfflinePage() {
   return (
-    <div className="flex min-h-[60vh] flex-col items-center justify-center px-4 text-center">
-      <h1 className="mb-4 text-4xl font-bold text-white">Ви офлайн</h1>
-      <p className="max-w-md text-lg text-cinema-muted">
-        Схоже, що немає з&apos;єднання з інтернетом. Перевірте підключення та спробуйте ще раз.
-      </p>
+    <div className="flex min-h-[60vh] items-center justify-center px-4">
+      <div className="max-w-md w-full text-center">
+        <div className="mx-auto w-16 h-16 bg-blue-500/10 rounded-full flex items-center justify-center mb-6">
+          <WifiOff className="w-8 h-8 text-blue-500" />
+        </div>
+
+        <h1 className="text-2xl font-bold text-white mb-2">Ви офлайн</h1>
+
+        <p className="text-cinema-text-muted mb-8">
+          Немає з&apos;єднання з інтернетом. Перевірте підключення та спробуйте ще раз.
+        </p>
+
+        <div className="flex flex-col sm:flex-row gap-3 justify-center">
+          <Button onClick={() => window.location.reload()}>
+            <RefreshCw className="w-4 h-4 mr-2" />
+            Спробувати знову
+          </Button>
+          <Button variant="secondary" asChild>
+            <Link href="/">
+              <Home className="w-4 h-4 mr-2" />
+              На головну
+            </Link>
+          </Button>
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Style the `/~offline` page to match the app's design language (error.tsx, not-found.tsx)
- Add `WifiOff` icon in blue accent circle
- Add "Спробувати знову" (reload) and "На головну" (home link) buttons
- Make the page a client component for `window.location.reload()`

## Test plan
- [ ] `npm run build:client` → build succeeds
- [ ] Start production server (`npm run start` in web-client)
- [ ] Visit page to register SW → DevTools → Application → Service Workers shows `sw.js`
- [ ] Enable Offline in Network tab → reload → see styled offline page with WifiOff icon and buttons

Depends on #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)