### PR TITLE
feat(web-client): add Calendar to navigation

### DIFF
--- a/apps/web-client/src/shared/components/header/trending-toggle.tsx
+++ b/apps/web-client/src/shared/components/header/trending-toggle.tsx
@@ -8,13 +8,18 @@ import { LinkToggleGroup } from '@/shared/ui';
 export function TrendingToggle() {
   const { dict } = useTranslation();
   const pathname = usePathname();
-  const value = pathname.startsWith('/browse/movies') ? 'movies' : 'shows';
+  const value = pathname.startsWith('/browse/movies')
+    ? 'movies'
+    : pathname.startsWith('/calendar')
+      ? 'calendar'
+      : 'shows';
 
   return (
     <LinkToggleGroup
       items={[
         { value: 'shows', label: dict.nav.shows, href: '/browse/shows-trending' as Route },
         { value: 'movies', label: dict.nav.movies, href: '/browse/movies-trending' as Route },
+        { value: 'calendar', label: dict.nav.calendar, href: '/calendar' as Route },
       ]}
       value={value}
       shape="pill"

--- a/apps/web-client/src/shared/components/mobile-dock/__tests__/mobile-dock.spec.tsx
+++ b/apps/web-client/src/shared/components/mobile-dock/__tests__/mobile-dock.spec.tsx
@@ -45,6 +45,7 @@ jest.mock('lucide-react', () => ({
   Search: () => <svg data-testid="icon-search" />,
   Play: () => <svg data-testid="icon-play" />,
   Bookmark: () => <svg data-testid="icon-bookmark" />,
+  CalendarDays: () => <svg data-testid="icon-calendar" />,
 }));
 
 const mockOpenLogin = jest.fn();
@@ -66,7 +67,7 @@ jest.mock('@/shared/stores/search-dialog.store', () => ({
 }));
 
 const mockDict = {
-  nav: { shows: 'Серіали', movies: 'Фільми', search: 'Пошук' },
+  nav: { shows: 'Серіали', movies: 'Фільми', search: 'Пошук', calendar: 'Календар' },
   auth: { activity: 'Активність', saved: 'Збережене' },
 };
 
@@ -95,7 +96,20 @@ describe('MobileDock', () => {
   /* ---- Rendering ---- */
 
   describe('rendering', () => {
-    it('renders all 5 navigation items', () => {
+    it('renders 5 items for guest: Shows, Movies, Search, Calendar, Saved', () => {
+      mockIsAuthenticated = false;
+      render(<MobileDock />);
+
+      expect(screen.getByText('Серіали')).toBeInTheDocument();
+      expect(screen.getByText('Фільми')).toBeInTheDocument();
+      expect(screen.getByText('Пошук')).toBeInTheDocument();
+      expect(screen.getByText('Календар')).toBeInTheDocument();
+      expect(screen.getByText('Збережене')).toBeInTheDocument();
+      expect(screen.queryByText('Активність')).not.toBeInTheDocument();
+    });
+
+    it('renders 5 items for authenticated: Shows, Movies, Search, Activity, Saved', () => {
+      mockIsAuthenticated = true;
       render(<MobileDock />);
 
       expect(screen.getByText('Серіали')).toBeInTheDocument();
@@ -103,6 +117,7 @@ describe('MobileDock', () => {
       expect(screen.getByText('Пошук')).toBeInTheDocument();
       expect(screen.getByText('Активність')).toBeInTheDocument();
       expect(screen.getByText('Збережене')).toBeInTheDocument();
+      expect(screen.queryByText('Календар')).not.toBeInTheDocument();
     });
 
     it('renders nav landmark with accessible label', () => {
@@ -113,7 +128,20 @@ describe('MobileDock', () => {
       ).toBeInTheDocument();
     });
 
-    it('renders all dock icons', () => {
+    it('renders guest dock icons (calendar instead of play)', () => {
+      mockIsAuthenticated = false;
+      render(<MobileDock />);
+
+      expect(screen.getByTestId('icon-flame')).toBeInTheDocument();
+      expect(screen.getByTestId('icon-film')).toBeInTheDocument();
+      expect(screen.getByTestId('icon-search')).toBeInTheDocument();
+      expect(screen.getByTestId('icon-calendar')).toBeInTheDocument();
+      expect(screen.getByTestId('icon-bookmark')).toBeInTheDocument();
+      expect(screen.queryByTestId('icon-play')).not.toBeInTheDocument();
+    });
+
+    it('renders authenticated dock icons (play instead of calendar)', () => {
+      mockIsAuthenticated = true;
       render(<MobileDock />);
 
       expect(screen.getByTestId('icon-flame')).toBeInTheDocument();
@@ -121,6 +149,7 @@ describe('MobileDock', () => {
       expect(screen.getByTestId('icon-search')).toBeInTheDocument();
       expect(screen.getByTestId('icon-play')).toBeInTheDocument();
       expect(screen.getByTestId('icon-bookmark')).toBeInTheDocument();
+      expect(screen.queryByTestId('icon-calendar')).not.toBeInTheDocument();
     });
 
     it('has md:hidden CSS class for mobile-only visibility', () => {
@@ -179,14 +208,34 @@ describe('MobileDock', () => {
       expect(screen.getByText('Фільми')).not.toHaveClass('font-medium');
     });
 
-    it('no tab is active on the home page', () => {
+    it('no tab is active on the home page (guest)', () => {
       mockUsePathname.mockReturnValue('/');
+      mockIsAuthenticated = false;
+      render(<MobileDock />);
+
+      expect(screen.getByText('Серіали')).not.toHaveClass('font-medium');
+      expect(screen.getByText('Фільми')).not.toHaveClass('font-medium');
+      expect(screen.getByText('Календар')).not.toHaveClass('font-medium');
+      expect(screen.getByText('Збережене')).not.toHaveClass('font-medium');
+    });
+
+    it('no tab is active on the home page (authenticated)', () => {
+      mockUsePathname.mockReturnValue('/');
+      mockIsAuthenticated = true;
       render(<MobileDock />);
 
       expect(screen.getByText('Серіали')).not.toHaveClass('font-medium');
       expect(screen.getByText('Фільми')).not.toHaveClass('font-medium');
       expect(screen.getByText('Активність')).not.toHaveClass('font-medium');
       expect(screen.getByText('Збережене')).not.toHaveClass('font-medium');
+    });
+
+    it('marks Calendar tab active on /calendar path (guest)', () => {
+      mockUsePathname.mockReturnValue('/calendar');
+      mockIsAuthenticated = false;
+      render(<MobileDock />);
+
+      expect(screen.getByText('Календар')).toHaveClass('font-medium');
     });
   });
 
@@ -209,27 +258,43 @@ describe('MobileDock', () => {
     });
   });
 
-  /* ---- Activity tab auth guard ---- */
+  /* ---- Activity tab (authenticated only) ---- */
 
   describe('Activity tab', () => {
-    it('calls openLogin and does not navigate when user is not authenticated', () => {
+    it('is not rendered for guests (Calendar shown instead)', () => {
       mockIsAuthenticated = false;
       render(<MobileDock />);
 
-      fireEvent.click(screen.getByText('Активність'));
-
-      expect(mockOpenLogin).toHaveBeenCalledTimes(1);
-      expect(mockRouterPush).not.toHaveBeenCalled();
+      expect(screen.queryByText('Активність')).not.toBeInTheDocument();
+      expect(screen.getByText('Календар')).toBeInTheDocument();
     });
 
-    it('navigates to /activity when user is authenticated', () => {
+    it('renders as a plain link for authenticated users', () => {
       mockIsAuthenticated = true;
       render(<MobileDock />);
 
-      fireEvent.click(screen.getByText('Активність'));
+      const link = screen.getByText('Активність').closest('a');
+      expect(link).toHaveAttribute('href', '/activity');
+    });
+  });
 
-      expect(mockOpenLogin).not.toHaveBeenCalled();
-      expect(mockRouterPush).toHaveBeenCalledWith('/activity');
+  /* ---- Calendar tab (guest only) ---- */
+
+  describe('Calendar tab', () => {
+    it('renders as a plain link for guests', () => {
+      mockIsAuthenticated = false;
+      render(<MobileDock />);
+
+      const link = screen.getByText('Календар').closest('a');
+      expect(link).toHaveAttribute('href', '/calendar');
+    });
+
+    it('is not rendered for authenticated users (Activity shown instead)', () => {
+      mockIsAuthenticated = true;
+      render(<MobileDock />);
+
+      expect(screen.queryByText('Календар')).not.toBeInTheDocument();
+      expect(screen.getByText('Активність')).toBeInTheDocument();
     });
   });
 

--- a/apps/web-client/src/shared/components/mobile-dock/__tests__/mobile-dock.spec.tsx
+++ b/apps/web-client/src/shared/components/mobile-dock/__tests__/mobile-dock.spec.tsx
@@ -237,6 +237,17 @@ describe('MobileDock', () => {
 
       expect(screen.getByText('Календар')).toHaveClass('font-medium');
     });
+
+    it('no tab is active when authenticated user visits /calendar path', () => {
+      mockUsePathname.mockReturnValue('/calendar');
+      mockIsAuthenticated = true;
+      render(<MobileDock />);
+
+      expect(screen.getByText('Серіали')).not.toHaveClass('font-medium');
+      expect(screen.getByText('Фільми')).not.toHaveClass('font-medium');
+      expect(screen.getByText('Активність')).not.toHaveClass('font-medium');
+      expect(screen.getByText('Збережене')).not.toHaveClass('font-medium');
+    });
   });
 
   /* ---- Search tab ---- */

--- a/apps/web-client/src/shared/components/mobile-dock/mobile-dock.tsx
+++ b/apps/web-client/src/shared/components/mobile-dock/mobile-dock.tsx
@@ -1,7 +1,7 @@
 /**
  * Fixed bottom navigation dock for mobile screens.
- * Provides 1-tap access to Shows, Movies, Search, and Saved.
- * 4th slot: Calendar for guests, Activity for authenticated users.
+ * Provides 1-tap access to Shows, Movies, Search, Calendar/Activity, and Saved.
+ * 4th slot: Calendar for guests; Activity for authenticated users.
  * Hidden on md+ breakpoints via CSS (no hydration mismatch).
  */
 

--- a/apps/web-client/src/shared/components/mobile-dock/mobile-dock.tsx
+++ b/apps/web-client/src/shared/components/mobile-dock/mobile-dock.tsx
@@ -1,6 +1,7 @@
 /**
  * Fixed bottom navigation dock for mobile screens.
- * Provides 1-tap access to Shows, Movies, Search, Activity, and Saved.
+ * Provides 1-tap access to Shows, Movies, Search, and Saved.
+ * 4th slot: Calendar for guests, Activity for authenticated users.
  * Hidden on md+ breakpoints via CSS (no hydration mismatch).
  */
 
@@ -8,7 +9,7 @@
 
 import { useCallback } from 'react';
 import { usePathname } from 'next/navigation';
-import { Flame, Film, Search, Play, Bookmark } from 'lucide-react';
+import { Flame, Film, Search, Play, Bookmark, CalendarDays } from 'lucide-react';
 import { useAuth, useAuthModalStore } from '@/core/auth';
 import { useSearchDialogStore } from '@/shared/stores/search-dialog.store';
 import { useTranslation } from '@/shared/i18n';
@@ -54,13 +55,21 @@ export function MobileDock() {
           onClick={openSearch}
           isActive={false}
         />
-        <MobileDockItem
-          icon={Play}
-          label={dict.auth.activity}
-          href="/activity"
-          isActive={pathname.startsWith('/activity')}
-          onBeforeNavigate={requireAuth}
-        />
+        {isAuthenticated ? (
+          <MobileDockItem
+            icon={Play}
+            label={dict.auth.activity}
+            href="/activity"
+            isActive={pathname.startsWith('/activity')}
+          />
+        ) : (
+          <MobileDockItem
+            icon={CalendarDays}
+            label={dict.nav.calendar}
+            href="/calendar"
+            isActive={pathname.startsWith('/calendar')}
+          />
+        )}
         <MobileDockItem
           icon={Bookmark}
           label={dict.auth.saved}

--- a/apps/web-client/src/shared/i18n/locales/en.json
+++ b/apps/web-client/src/shared/i18n/locales/en.json
@@ -232,7 +232,8 @@
     "shows": "Shows",
     "search": "Search",
     "watchlist": "My list",
-    "airings": "Airings"
+    "airings": "Airings",
+    "calendar": "Calendar"
   },
   "details": {
     "backToHome": "Back",

--- a/apps/web-client/src/shared/i18n/locales/uk.json
+++ b/apps/web-client/src/shared/i18n/locales/uk.json
@@ -232,7 +232,8 @@
     "shows": "Серіали",
     "search": "Пошук",
     "watchlist": "Мій список",
-    "airings": "Надходження"
+    "airings": "Надходження",
+    "calendar": "Календар"
   },
   "details": {
     "backToHome": "Назад",


### PR DESCRIPTION
## Summary
- Add "Календар" as 3rd item in header toggle (Серіали | Фільми | Календар)
- Mobile dock: guests see Calendar instead of Activity (which is useless without auth)
- Authenticated users keep Activity in the dock as before
- Add `nav.calendar` i18n keys (uk/en)

## Rationale
For guest users, the Activity tab in the mobile dock is a dead end (opens login modal, no preview value). Calendar provides real content value without auth — "what's airing this week" — and serves as a discovery tool for new users.

## Test plan
- [x] 39 mobile dock tests pass (guest/auth rendering, active state, icons)
- [x] Build passes
- [ ] Visual: guest mobile dock shows Серіали | Фільми | Пошук | Календар | Збережене
- [ ] Visual: authenticated mobile dock shows Серіали | Фільми | Пошук | Активність | Збережене
- [ ] Header toggle shows 3 items: Серіали | Фільми | Календар

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Нові функції
- Додана календарна навігація до мобільного меню та перемикача трендів.
- Календар доступний для гостей; авторизовані користувачі бачать вкладку «Активність» замість календаря.
- Розширена локалізація: додано підтримку мітки «Календар» англійською та українською мовами.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->