### PR TITLE
refactor(web-client): replace mobile search drawer with full-screen overlay

### DIFF
--- a/apps/web-client/src/app/(main)/layout.tsx
+++ b/apps/web-client/src/app/(main)/layout.tsx
@@ -8,6 +8,8 @@ import {
   Footer,
   AnnouncementBarProvider,
   MobileDock,
+  MobileSearchOverlay,
+  SearchKeyboardShortcut,
 } from '@/shared/components';
 import { GlobalAuthModal } from '@/modules/auth';
 import { MainContent } from './main-content';
@@ -24,6 +26,8 @@ export default function MainLayout({ children }: MainLayoutProps) {
         <MainContent>{children}</MainContent>
         <Footer />
         <MobileDock />
+        <MobileSearchOverlay />
+        <SearchKeyboardShortcut />
         <GlobalAuthModal />
       </HeaderContextProvider>
     </AnnouncementBarProvider>

--- a/apps/web-client/src/shared/components/header/index.ts
+++ b/apps/web-client/src/shared/components/header/index.ts
@@ -5,7 +5,7 @@
 export { Header } from './header';
 export { UserMenu } from './user-menu';
 export { HeaderContextProvider, useHeaderContext } from './header-context';
-export { SearchCommand } from './search';
+export { SearchCommand, MobileSearchOverlay, SearchKeyboardShortcut } from './search';
 export { TrendingToggle } from './trending-toggle';
 export { Logo } from './logo';
 export {

--- a/apps/web-client/src/shared/components/header/search/index.ts
+++ b/apps/web-client/src/shared/components/header/search/index.ts
@@ -1,1 +1,3 @@
 export { SearchCommand } from './search-command';
+export { MobileSearchOverlay } from './mobile-search-overlay';
+export { SearchKeyboardShortcut } from './search-keyboard-shortcut';

--- a/apps/web-client/src/shared/components/header/search/mobile-search-overlay.tsx
+++ b/apps/web-client/src/shared/components/header/search/mobile-search-overlay.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { X } from 'lucide-react';
+
+import { Button } from '@/shared/ui';
+import { useTranslation } from '@/shared/i18n';
+import { useIsMobile } from '@/shared/hooks/use-mobile';
+import { useSearch } from './use-search';
+import { SearchContent } from './search-content';
+
+/**
+ * Full-screen mobile search overlay.
+ *
+ * Renders independently from SearchCommand so it works even when the header
+ * search button is hidden on mobile. Uses a plain fixed overlay instead of
+ * Vaul Drawer because Vaul's keyboard handling repositions content via JS
+ * transforms, causing the input to overlap the iOS status bar in PWA standalone.
+ *
+ * Opened via shared useSearchDialogStore (same store used by MobileDock).
+ */
+export function MobileSearchOverlay() {
+  const { dict } = useTranslation();
+  const isMobile = useIsMobile();
+  const search = useSearch();
+  const { open, setOpen } = search;
+
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  const visible = mounted && isMobile && open;
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    },
+    [setOpen],
+  );
+
+  // Escape key to close
+  useEffect(() => {
+    if (!visible) return;
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [visible, handleKeyDown]);
+
+  // Body scroll lock while overlay is open
+  useEffect(() => {
+    if (!visible) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [visible]);
+
+  // Auto-focus the cmdk search input after the overlay appears
+  useEffect(() => {
+    if (!visible) return;
+    const timer = setTimeout(() => {
+      const input = document.querySelector<HTMLInputElement>('[cmdk-input]');
+      input?.focus();
+    }, 100);
+    return () => clearTimeout(timer);
+  }, [visible]);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={dict.search.placeholder}
+      className="fixed inset-0 z-50 flex flex-col bg-background pt-[env(safe-area-inset-top,0px)] pb-[env(safe-area-inset-bottom,0px)] animate-in fade-in slide-in-from-bottom-4 duration-200"
+    >
+      <div className="flex items-center justify-between px-3 py-2 border-b border-border">
+        <span className="sr-only">{dict.search.hint}</span>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => setOpen(false)}
+          className="ml-auto h-8 w-8 text-muted-foreground"
+          aria-label={dict.common.close}
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+      <SearchContent
+        search={search}
+        listClassName="max-h-none flex-1 overflow-y-auto"
+      />
+    </div>
+  );
+}

--- a/apps/web-client/src/shared/components/header/search/search-command.tsx
+++ b/apps/web-client/src/shared/components/header/search/search-command.tsx
@@ -5,25 +5,17 @@ import { Search } from 'lucide-react';
 
 import { Button } from '@/shared/ui';
 import { Dialog, DialogContent, DialogTitle, DialogDescription } from '@/shared/ui/dialog';
-import {
-  Drawer,
-  DrawerContent,
-  DrawerTitle,
-  DrawerDescription,
-} from '@/shared/ui/drawer';
 import { useTranslation } from '@/shared/i18n';
 import { useIsMobile } from '@/shared/hooks/use-mobile';
 import { useSearch } from './use-search';
 import { SearchContent } from './search-content';
 
 /**
- * Search command with keyboard shortcut (Cmd+K).
- * Desktop: centered Dialog. Mobile: bottom sheet Drawer (~70% height).
+ * Desktop search command with keyboard shortcut (Cmd+K).
+ * Renders trigger button + centered Dialog.
  *
- * Dialog/Drawer rendering is deferred until after mount to avoid a hydration
- * mismatch: useIsMobile returns false during SSR, which would render Dialog on
- * mobile and then swap to Drawer after the effect fires. Since search starts
- * closed this has zero visual impact.
+ * On mobile, this only renders the trigger button (hidden via parent CSS).
+ * The mobile search overlay is rendered separately by MobileSearchOverlay.
  */
 export function SearchCommand() {
   const { dict } = useTranslation();
@@ -36,7 +28,6 @@ export function SearchCommand() {
 
   return (
     <>
-      {/* Trigger button — always SSR-rendered */}
       <Button
         variant="ghost"
         size="sm"
@@ -50,34 +41,14 @@ export function SearchCommand() {
         </kbd>
       </Button>
 
-      {/* Deferred until after mount to avoid hydration mismatch */}
-      {mounted && (
-        <>
-          {/* Desktop: centered Dialog */}
-          {!isMobile && (
-            <Dialog open={open} onOpenChange={setOpen}>
-              <DialogContent className="overflow-hidden p-0 gap-0">
-                <DialogTitle className="sr-only">{dict.search.placeholder}</DialogTitle>
-                <DialogDescription className="sr-only">{dict.search.hint}</DialogDescription>
-                <SearchContent search={search} />
-              </DialogContent>
-            </Dialog>
-          )}
-
-          {/* Mobile: bottom sheet Drawer */}
-          {isMobile && (
-            <Drawer open={open} onOpenChange={setOpen}>
-              <DrawerContent className="h-[70dvh] pb-[env(safe-area-inset-bottom)] [&>div:first-child]:hidden">
-                <DrawerTitle className="sr-only">{dict.search.placeholder}</DrawerTitle>
-                <DrawerDescription className="sr-only">{dict.search.hint}</DrawerDescription>
-                <SearchContent
-                  search={search}
-                  listClassName="max-h-none flex-1 overflow-y-auto"
-                />
-              </DrawerContent>
-            </Drawer>
-          )}
-        </>
+      {mounted && !isMobile && (
+        <Dialog open={open} onOpenChange={setOpen}>
+          <DialogContent className="overflow-hidden p-0 gap-0">
+            <DialogTitle className="sr-only">{dict.search.placeholder}</DialogTitle>
+            <DialogDescription className="sr-only">{dict.search.hint}</DialogDescription>
+            <SearchContent search={search} />
+          </DialogContent>
+        </Dialog>
       )}
     </>
   );

--- a/apps/web-client/src/shared/components/header/search/search-keyboard-shortcut.tsx
+++ b/apps/web-client/src/shared/components/header/search/search-keyboard-shortcut.tsx
@@ -5,7 +5,7 @@ import { useEffect } from 'react';
 import { useSearchDialogStore } from '@/shared/stores/search-dialog.store';
 
 /**
- * Registers the Cmd+K / Ctrl+K keyboard shortcut that toggles the search dialog.
+ * Registers the Cmd+K / Ctrl+K keyboard shortcut that opens the search dialog.
  *
  * Render this component exactly once in the layout so that only a single
  * keydown listener is active at a time, regardless of how many search-related
@@ -15,9 +15,10 @@ import { useSearchDialogStore } from '@/shared/stores/search-dialog.store';
 export function SearchKeyboardShortcut() {
   useEffect(() => {
     const down = (e: KeyboardEvent) => {
+      if (e.repeat) return;
       if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
-        useSearchDialogStore.getState().toggle();
+        useSearchDialogStore.getState().open();
       }
     };
     document.addEventListener('keydown', down);

--- a/apps/web-client/src/shared/components/header/search/search-keyboard-shortcut.tsx
+++ b/apps/web-client/src/shared/components/header/search/search-keyboard-shortcut.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { useSearchDialogStore } from '@/shared/stores/search-dialog.store';
+
+/**
+ * Registers the Cmd+K / Ctrl+K keyboard shortcut that toggles the search dialog.
+ *
+ * Render this component exactly once in the layout so that only a single
+ * keydown listener is active at a time, regardless of how many search-related
+ * components are mounted (e.g. SearchCommand on desktop + MobileSearchOverlay
+ * on mobile both call useSearch, which must NOT register its own listener).
+ */
+export function SearchKeyboardShortcut() {
+  useEffect(() => {
+    const down = (e: KeyboardEvent) => {
+      if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        useSearchDialogStore.getState().toggle();
+      }
+    };
+    document.addEventListener('keydown', down);
+    return () => document.removeEventListener('keydown', down);
+  }, []);
+
+  return null;
+}

--- a/apps/web-client/src/shared/components/header/search/use-search.ts
+++ b/apps/web-client/src/shared/components/header/search/use-search.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { useDebounce } from 'use-debounce';
@@ -11,6 +11,9 @@ import { useSearchDialogStore } from '@/shared/stores/search-dialog.store';
 
 /**
  * Hook for search dialog state and logic.
+ *
+ * Note: Cmd+K keyboard shortcut is registered once by SearchKeyboardShortcut
+ * rendered in the layout. Do not add it here to avoid duplicate listeners.
  */
 export function useSearch() {
   const open = useSearchDialogStore((s) => s.isOpen);
@@ -18,18 +21,6 @@ export function useSearch() {
   const [query, setQuery] = useState('');
   const [debouncedQuery] = useDebounce(query, 300);
   const router = useRouter();
-
-  // Keyboard shortcut: Cmd+K / Ctrl+K
-  useEffect(() => {
-    const down = (e: KeyboardEvent) => {
-      if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
-        e.preventDefault();
-        useSearchDialogStore.getState().toggle();
-      }
-    };
-    document.addEventListener('keydown', down);
-    return () => document.removeEventListener('keydown', down);
-  }, []);
 
   // Search query
   const { data, isLoading } = useQuery({


### PR DESCRIPTION
## Summary

- **Problem:** Vaul Drawer's keyboard handling uses JS transforms (`translateY(-2000px)`) that cause the search input to overlap the iOS status bar in PWA standalone mode. CSS solutions (`pt-[env(safe-area-inset-top)]`, `mt-[max(...)]`) are bypassed by Vaul's direct `style.height` manipulation.
- **Solution:** Replace the Vaul Drawer with a plain `fixed inset-0` overlay for mobile search. Full control over layout, proper safe-area-inset handling.
- Extract `MobileSearchOverlay` — rendered independently in layout (always available for MobileDock)
- Extract `SearchKeyboardShortcut` — single global Cmd+K listener (prevents double-toggle bug)
- `SearchCommand` now only handles desktop Dialog
- Add body scroll lock, `aria-modal`, auto-focus, slide-up animation

## Test plan

- [ ] Mobile: tap search in bottom dock → overlay opens with animation, input auto-focused
- [ ] Mobile: type query → results appear, select result → navigates, overlay closes
- [ ] Mobile: tap X button → overlay closes
- [ ] Mobile: press Escape → overlay closes
- [ ] Mobile PWA standalone: search input stays below status bar/notch
- [ ] Mobile PWA: keyboard open → content doesn't overlap safe area
- [ ] Desktop: Cmd+K opens dialog (not overlay)
- [ ] Desktop: search works as before
- [ ] Screen reader: overlay announced as modal dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Нові функції**
  * Додана мобільна повноекранна оверлей-панель пошуку.
  * Додано глобальну клавіатурну комбінацію (Cmd+K / Ctrl+K) для швидкого відкриття пошуку.

* **Покращення**
  * Покращена поведінка пошуку на мобільних: блокування прокрутки під час оверлею та краща фокусировка поля.
  * Спрощено поведінку десктопного пошуку для стабільнішого відображення діалогового вікна.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->