### PR TITLE
fix(web-client): progressive loading for Activity page lists

### DIFF
--- a/apps/web-client/src/core/query/keys.ts
+++ b/apps/web-client/src/core/query/keys.ts
@@ -106,13 +106,13 @@ export const queryKeys = {
     activity: ['me-lists', 'activity'] as const,
     favoriteUpdates: ['me-lists', 'favorite-updates'] as const,
     historyAll: ['me-lists', 'history'] as const,
-    history: (sort?: string) => ['me-lists', 'history', sort ?? null] as const,
+    history: (sort?: string, limit?: number) => ['me-lists', 'history', sort ?? null, limit ?? null] as const,
     watchlistAll: ['me-lists', 'watchlist'] as const,
     watchlist: (sort?: string) => ['me-lists', 'watchlist', sort ?? null] as const,
     pausedAll: ['me-lists', 'paused'] as const,
-    paused: (sort?: string) => ['me-lists', 'paused', sort ?? null] as const,
+    paused: (sort?: string, limit?: number) => ['me-lists', 'paused', sort ?? null, limit ?? null] as const,
     droppedAll: ['me-lists', 'dropped'] as const,
-    dropped: (sort?: string) => ['me-lists', 'dropped', sort ?? null] as const,
+    dropped: (sort?: string, limit?: number) => ['me-lists', 'dropped', sort ?? null, limit ?? null] as const,
   },
 
   /** Public user queries. */

--- a/apps/web-client/src/modules/browse/components/index.ts
+++ b/apps/web-client/src/modules/browse/components/index.ts
@@ -1,6 +1,6 @@
 export { MediaGrid } from './media-grid';
 export { BrowseMediaGrid } from './browse-media-grid';
-export { InfiniteScrollLoader } from './infinite-scroll-loader';
+export { InfiniteScrollLoader } from '@/shared/components/infinite-scroll-loader';
 export { BrowsePageHeader } from './browse-page-header';
 export { BrowseFilters } from './browse-filters';
 export { PoolSelector } from './pool-selector';

--- a/apps/web-client/src/modules/saved/components/__tests__/dropped-list.spec.tsx
+++ b/apps/web-client/src/modules/saved/components/__tests__/dropped-list.spec.tsx
@@ -232,7 +232,7 @@ describe('DroppedList', () => {
 
     render(<DroppedList />);
 
-    expect(mockUseDropped).toHaveBeenCalledWith('recent');
+    expect(mockUseDropped).toHaveBeenCalledWith(expect.objectContaining({ sort: 'recent' }));
   });
 
   it('renders empty state when data is undefined (null response)', () => {

--- a/apps/web-client/src/modules/saved/components/dropped-list.tsx
+++ b/apps/web-client/src/modules/saved/components/dropped-list.tsx
@@ -19,6 +19,11 @@ export function DroppedList() {
   const [limit, setLimit] = useState(PAGE_SIZE);
   const { data, isLoading, isFetching } = useDropped(sort, limit);
 
+  const handleSortChange = useCallback((newSort: MeListSort) => {
+    setSort(newSort);
+    setLimit(PAGE_SIZE);
+  }, []);
+
   const handleLoadMore = useCallback(() => {
     setLimit((prev) => prev + PAGE_SIZE);
   }, []);
@@ -46,7 +51,7 @@ export function DroppedList() {
   return (
     <div className="space-y-4">
       <div className="flex justify-end">
-        <ListSortSelect value={sort} onChange={setSort} />
+        <ListSortSelect value={sort} onChange={handleSortChange} />
       </div>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
         {items.map((item) => (

--- a/apps/web-client/src/modules/saved/components/dropped-list.tsx
+++ b/apps/web-client/src/modules/saved/components/dropped-list.tsx
@@ -17,7 +17,7 @@ export function DroppedList() {
   const { dict } = useTranslation();
   const [sort, setSort] = useState<MeListSort>('recent');
   const [limit, setLimit] = useState(PAGE_SIZE);
-  const { data, isLoading, isFetching } = useDropped(sort, limit);
+  const { data, isLoading, isFetching } = useDropped({ sort, limit });
 
   const handleSortChange = useCallback((newSort: MeListSort) => {
     setSort(newSort);

--- a/apps/web-client/src/modules/saved/components/dropped-list.tsx
+++ b/apps/web-client/src/modules/saved/components/dropped-list.tsx
@@ -4,9 +4,10 @@
 
 'use client';
 
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { useTranslation } from '@/shared/i18n';
-import { useDropped, type MeListSort } from '../hooks/use-me-lists';
+import { InfiniteScrollLoader } from '@/shared/components/infinite-scroll-loader';
+import { useDropped, PAGE_SIZE, type MeListSort } from '../hooks/use-me-lists';
 import { MeListItemCard } from './me-list-item-card';
 import { EmptyState } from './empty-state';
 import { ListSortSelect } from './list-sort-select';
@@ -15,13 +16,19 @@ import { MeListSkeleton } from './me-list-skeleton';
 export function DroppedList() {
   const { dict } = useTranslation();
   const [sort, setSort] = useState<MeListSort>('recent');
-  const { data, isLoading } = useDropped(sort);
+  const [limit, setLimit] = useState(PAGE_SIZE);
+  const { data, isLoading, isFetching } = useDropped(sort, limit);
+
+  const handleLoadMore = useCallback(() => {
+    setLimit((prev) => prev + PAGE_SIZE);
+  }, []);
 
   if (isLoading) {
     return <MeListSkeleton />;
   }
 
   const items = data?.data ?? [];
+  const hasMore = data?.meta?.hasMore ?? false;
 
   if (items.length === 0) {
     return (
@@ -46,6 +53,12 @@ export function DroppedList() {
           <MeListItemCard key={item.id} item={item} />
         ))}
       </div>
+      <InfiniteScrollLoader
+        onLoadMore={handleLoadMore}
+        isLoading={isFetching && items.length > 0}
+        hasMore={hasMore}
+        loadingText={dict.common?.loading ?? 'Завантаження...'}
+      />
     </div>
   );
 }

--- a/apps/web-client/src/modules/saved/components/history-list.tsx
+++ b/apps/web-client/src/modules/saved/components/history-list.tsx
@@ -1,12 +1,13 @@
 /**
- * History list component displaying watched items (watching/completed).
+ * History list component displaying completed items.
  */
 
 'use client';
 
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { useTranslation } from '@/shared/i18n';
-import { useCompleted, type MeListSort } from '../hooks/use-me-lists';
+import { InfiniteScrollLoader } from '@/shared/components/infinite-scroll-loader';
+import { useCompleted, PAGE_SIZE, type MeListSort } from '../hooks/use-me-lists';
 import { MeListItemCard } from './me-list-item-card';
 import { EmptyState } from './empty-state';
 import { ListSortSelect } from './list-sort-select';
@@ -15,13 +16,19 @@ import { MeListSkeleton } from './me-list-skeleton';
 export function HistoryList() {
   const { dict } = useTranslation();
   const [sort, setSort] = useState<MeListSort>('recent');
-  const { data, isLoading } = useCompleted(sort);
+  const [limit, setLimit] = useState(PAGE_SIZE);
+  const { data, isLoading, isFetching } = useCompleted(sort, limit);
+
+  const handleLoadMore = useCallback(() => {
+    setLimit((prev) => prev + PAGE_SIZE);
+  }, []);
 
   if (isLoading) {
     return <MeListSkeleton />;
   }
 
   const items = data?.data ?? [];
+  const hasMore = data?.meta?.hasMore ?? false;
 
   if (items.length === 0) {
     return (
@@ -43,6 +50,12 @@ export function HistoryList() {
           <MeListItemCard key={item.id} item={item} />
         ))}
       </div>
+      <InfiniteScrollLoader
+        onLoadMore={handleLoadMore}
+        isLoading={isFetching && items.length > 0}
+        hasMore={hasMore}
+        loadingText={dict.common?.loading ?? 'Завантаження...'}
+      />
     </div>
   );
 }

--- a/apps/web-client/src/modules/saved/components/history-list.tsx
+++ b/apps/web-client/src/modules/saved/components/history-list.tsx
@@ -19,6 +19,11 @@ export function HistoryList() {
   const [limit, setLimit] = useState(PAGE_SIZE);
   const { data, isLoading, isFetching } = useCompleted(sort, limit);
 
+  const handleSortChange = useCallback((newSort: MeListSort) => {
+    setSort(newSort);
+    setLimit(PAGE_SIZE);
+  }, []);
+
   const handleLoadMore = useCallback(() => {
     setLimit((prev) => prev + PAGE_SIZE);
   }, []);
@@ -43,7 +48,7 @@ export function HistoryList() {
   return (
     <div className="space-y-4">
       <div className="flex justify-end">
-        <ListSortSelect value={sort} onChange={setSort} />
+        <ListSortSelect value={sort} onChange={handleSortChange} />
       </div>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
         {items.map((item) => (

--- a/apps/web-client/src/modules/saved/components/history-list.tsx
+++ b/apps/web-client/src/modules/saved/components/history-list.tsx
@@ -17,7 +17,7 @@ export function HistoryList() {
   const { dict } = useTranslation();
   const [sort, setSort] = useState<MeListSort>('recent');
   const [limit, setLimit] = useState(PAGE_SIZE);
-  const { data, isLoading, isFetching } = useCompleted(sort, limit);
+  const { data, isLoading, isFetching } = useCompleted({ sort, limit });
 
   const handleSortChange = useCallback((newSort: MeListSort) => {
     setSort(newSort);

--- a/apps/web-client/src/modules/saved/components/paused-list.tsx
+++ b/apps/web-client/src/modules/saved/components/paused-list.tsx
@@ -4,9 +4,10 @@
 
 'use client';
 
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { useTranslation } from '@/shared/i18n';
-import { usePaused, type MeListSort } from '../hooks/use-me-lists';
+import { InfiniteScrollLoader } from '@/shared/components/infinite-scroll-loader';
+import { usePaused, PAGE_SIZE, type MeListSort } from '../hooks/use-me-lists';
 import { MeListItemCard } from './me-list-item-card';
 import { EmptyState } from './empty-state';
 import { ListSortSelect } from './list-sort-select';
@@ -15,13 +16,19 @@ import { MeListSkeleton } from './me-list-skeleton';
 export function PausedList() {
   const { dict } = useTranslation();
   const [sort, setSort] = useState<MeListSort>('recent');
-  const { data, isLoading } = usePaused(sort);
+  const [limit, setLimit] = useState(PAGE_SIZE);
+  const { data, isLoading, isFetching } = usePaused(sort, limit);
+
+  const handleLoadMore = useCallback(() => {
+    setLimit((prev) => prev + PAGE_SIZE);
+  }, []);
 
   if (isLoading) {
     return <MeListSkeleton />;
   }
 
   const items = data?.data ?? [];
+  const hasMore = data?.meta?.hasMore ?? false;
 
   if (items.length === 0) {
     return (
@@ -46,6 +53,12 @@ export function PausedList() {
           <MeListItemCard key={item.id} item={item} />
         ))}
       </div>
+      <InfiniteScrollLoader
+        onLoadMore={handleLoadMore}
+        isLoading={isFetching && items.length > 0}
+        hasMore={hasMore}
+        loadingText={dict.common?.loading ?? 'Завантаження...'}
+      />
     </div>
   );
 }

--- a/apps/web-client/src/modules/saved/components/paused-list.tsx
+++ b/apps/web-client/src/modules/saved/components/paused-list.tsx
@@ -19,6 +19,11 @@ export function PausedList() {
   const [limit, setLimit] = useState(PAGE_SIZE);
   const { data, isLoading, isFetching } = usePaused(sort, limit);
 
+  const handleSortChange = useCallback((newSort: MeListSort) => {
+    setSort(newSort);
+    setLimit(PAGE_SIZE);
+  }, []);
+
   const handleLoadMore = useCallback(() => {
     setLimit((prev) => prev + PAGE_SIZE);
   }, []);
@@ -46,7 +51,7 @@ export function PausedList() {
   return (
     <div className="space-y-4">
       <div className="flex justify-end">
-        <ListSortSelect value={sort} onChange={setSort} />
+        <ListSortSelect value={sort} onChange={handleSortChange} />
       </div>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
         {items.map((item) => (

--- a/apps/web-client/src/modules/saved/components/paused-list.tsx
+++ b/apps/web-client/src/modules/saved/components/paused-list.tsx
@@ -17,7 +17,7 @@ export function PausedList() {
   const { dict } = useTranslation();
   const [sort, setSort] = useState<MeListSort>('recent');
   const [limit, setLimit] = useState(PAGE_SIZE);
-  const { data, isLoading, isFetching } = usePaused(sort, limit);
+  const { data, isLoading, isFetching } = usePaused({ sort, limit });
 
   const handleSortChange = useCallback((newSort: MeListSort) => {
     setSort(newSort);

--- a/apps/web-client/src/modules/saved/components/watchlist.tsx
+++ b/apps/web-client/src/modules/saved/components/watchlist.tsx
@@ -17,7 +17,7 @@ export function Watchlist() {
   const { dict } = useTranslation();
   const [sort, setSort] = useState<MeListSort>('recent');
   const [limit, setLimit] = useState(PAGE_SIZE);
-  const { data, isLoading, isFetching } = useWatching(sort, limit);
+  const { data, isLoading, isFetching } = useWatching({ sort, limit });
 
   const handleSortChange = useCallback((newSort: MeListSort) => {
     setSort(newSort);

--- a/apps/web-client/src/modules/saved/components/watchlist.tsx
+++ b/apps/web-client/src/modules/saved/components/watchlist.tsx
@@ -4,9 +4,10 @@
 
 'use client';
 
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { useTranslation } from '@/shared/i18n';
-import { useWatching, type MeListSort } from '../hooks/use-me-lists';
+import { InfiniteScrollLoader } from '@/shared/components/infinite-scroll-loader';
+import { useWatching, PAGE_SIZE, type MeListSort } from '../hooks/use-me-lists';
 import { MeListItemCard } from './me-list-item-card';
 import { EmptyState } from './empty-state';
 import { ListSortSelect } from './list-sort-select';
@@ -15,13 +16,19 @@ import { MeListSkeleton } from './me-list-skeleton';
 export function Watchlist() {
   const { dict } = useTranslation();
   const [sort, setSort] = useState<MeListSort>('recent');
-  const { data, isLoading } = useWatching(sort);
+  const [limit, setLimit] = useState(PAGE_SIZE);
+  const { data, isLoading, isFetching } = useWatching(sort, limit);
+
+  const handleLoadMore = useCallback(() => {
+    setLimit((prev) => prev + PAGE_SIZE);
+  }, []);
 
   if (isLoading) {
     return <MeListSkeleton />;
   }
 
   const items = data?.data ?? [];
+  const hasMore = data?.meta?.hasMore ?? false;
 
   if (items.length === 0) {
     return (
@@ -43,6 +50,12 @@ export function Watchlist() {
           <MeListItemCard key={item.id} item={item} />
         ))}
       </div>
+      <InfiniteScrollLoader
+        onLoadMore={handleLoadMore}
+        isLoading={isFetching && items.length > 0}
+        hasMore={hasMore}
+        loadingText={dict.common?.loading ?? 'Завантаження...'}
+      />
     </div>
   );
 }

--- a/apps/web-client/src/modules/saved/components/watchlist.tsx
+++ b/apps/web-client/src/modules/saved/components/watchlist.tsx
@@ -19,6 +19,11 @@ export function Watchlist() {
   const [limit, setLimit] = useState(PAGE_SIZE);
   const { data, isLoading, isFetching } = useWatching(sort, limit);
 
+  const handleSortChange = useCallback((newSort: MeListSort) => {
+    setSort(newSort);
+    setLimit(PAGE_SIZE);
+  }, []);
+
   const handleLoadMore = useCallback(() => {
     setLimit((prev) => prev + PAGE_SIZE);
   }, []);
@@ -43,7 +48,7 @@ export function Watchlist() {
   return (
     <div className="space-y-4">
       <div className="flex justify-end">
-        <ListSortSelect value={sort} onChange={setSort} />
+        <ListSortSelect value={sort} onChange={handleSortChange} />
       </div>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
         {items.map((item) => (

--- a/apps/web-client/src/modules/saved/hooks/__tests__/use-me-lists.test.tsx
+++ b/apps/web-client/src/modules/saved/hooks/__tests__/use-me-lists.test.tsx
@@ -90,7 +90,7 @@ function makeHistoryResponse(items: Record<string, unknown>[]) {
 // -- Consumer components -----------------------------------------------------
 
 function WatchingConsumer({ sort, enabled }: { sort?: 'recent' | 'rating' | 'releaseDate'; enabled?: boolean }) {
-  const query = useWatching(sort, enabled);
+  const query = useWatching({ sort, enabled });
 
   return (
     <div>
@@ -102,7 +102,7 @@ function WatchingConsumer({ sort, enabled }: { sort?: 'recent' | 'rating' | 'rel
 }
 
 function CompletedConsumer({ sort, enabled }: { sort?: 'recent' | 'rating' | 'releaseDate'; enabled?: boolean }) {
-  const query = useCompleted(sort, enabled);
+  const query = useCompleted({ sort, enabled });
 
   return (
     <div>
@@ -114,7 +114,7 @@ function CompletedConsumer({ sort, enabled }: { sort?: 'recent' | 'rating' | 're
 }
 
 function PausedConsumer({ sort, enabled }: { sort?: 'recent' | 'rating' | 'releaseDate'; enabled?: boolean }) {
-  const query = usePaused(sort, enabled);
+  const query = usePaused({ sort, enabled });
 
   return (
     <div>
@@ -125,7 +125,7 @@ function PausedConsumer({ sort, enabled }: { sort?: 'recent' | 'rating' | 'relea
 }
 
 function DroppedConsumer({ sort, enabled }: { sort?: 'recent' | 'rating' | 'releaseDate'; enabled?: boolean }) {
-  const query = useDropped(sort, enabled);
+  const query = useDropped({ sort, enabled });
 
   return (
     <div>
@@ -313,10 +313,10 @@ describe('useWatching', () => {
       expect(screen.getByTestId('status').textContent).toBe('success');
     });
 
-    expect(mockGetHistory).toHaveBeenCalledWith({ sort: 'rating' });
+    expect(mockGetHistory).toHaveBeenCalledWith(expect.objectContaining({ sort: 'rating' }));
   });
 
-  it('calls API without sort param when sort is undefined', async () => {
+  it('calls API with default limit when sort is undefined', async () => {
     mockGetHistory.mockResolvedValue(makeHistoryResponse([]));
 
     renderWithClient(<WatchingConsumer />, queryClient);
@@ -325,7 +325,7 @@ describe('useWatching', () => {
       expect(screen.getByTestId('status').textContent).toBe('success');
     });
 
-    expect(mockGetHistory).toHaveBeenCalledWith(undefined);
+    expect(mockGetHistory).toHaveBeenCalledWith(expect.objectContaining({ limit: 20 }));
   });
 
   it('does not fetch when enabled is false', async () => {
@@ -397,7 +397,7 @@ describe('useCompleted', () => {
       expect(screen.getByTestId('status').textContent).toBe('success');
     });
 
-    expect(mockGetHistory).toHaveBeenCalledWith({ sort: 'releaseDate' });
+    expect(mockGetHistory).toHaveBeenCalledWith(expect.objectContaining({ sort: 'releaseDate' }));
   });
 
   it('does not fetch when enabled is false', async () => {
@@ -492,10 +492,10 @@ describe('usePaused', () => {
       expect(screen.getByTestId('status').textContent).toBe('success');
     });
 
-    expect(mockGetPaused).toHaveBeenCalledWith({ sort: 'recent' });
+    expect(mockGetPaused).toHaveBeenCalledWith(expect.objectContaining({ sort: 'recent' }));
   });
 
-  it('calls API without sort param when sort is undefined', async () => {
+  it('calls API with default limit when sort is undefined', async () => {
     mockGetPaused.mockResolvedValue(makeHistoryResponse([]));
 
     renderWithClient(<PausedConsumer />, queryClient);
@@ -504,7 +504,7 @@ describe('usePaused', () => {
       expect(screen.getByTestId('status').textContent).toBe('success');
     });
 
-    expect(mockGetPaused).toHaveBeenCalledWith(undefined);
+    expect(mockGetPaused).toHaveBeenCalledWith(expect.objectContaining({ limit: 20 }));
   });
 
   it('does not fetch when enabled is false', async () => {
@@ -556,10 +556,10 @@ describe('useDropped', () => {
       expect(screen.getByTestId('status').textContent).toBe('success');
     });
 
-    expect(mockGetDropped).toHaveBeenCalledWith({ sort: 'recent' });
+    expect(mockGetDropped).toHaveBeenCalledWith(expect.objectContaining({ sort: 'recent' }));
   });
 
-  it('calls API without sort param when sort is undefined', async () => {
+  it('calls API with default limit when sort is undefined', async () => {
     mockGetDropped.mockResolvedValue(makeHistoryResponse([]));
 
     renderWithClient(<DroppedConsumer />, queryClient);
@@ -568,7 +568,7 @@ describe('useDropped', () => {
       expect(screen.getByTestId('status').textContent).toBe('success');
     });
 
-    expect(mockGetDropped).toHaveBeenCalledWith(undefined);
+    expect(mockGetDropped).toHaveBeenCalledWith(expect.objectContaining({ limit: 20 }));
   });
 
   it('does not fetch when enabled is false', async () => {

--- a/apps/web-client/src/modules/saved/hooks/use-me-lists.ts
+++ b/apps/web-client/src/modules/saved/hooks/use-me-lists.ts
@@ -10,18 +10,21 @@ export type { MeListSort } from '@/core/api/me-lists.client';
 
 const STALE_5_MIN = 1000 * 60 * 5;
 
-function useHistoryBase(sort?: MeListSort, enabled = true) {
+/** Page size for progressive loading in Activity lists. */
+export const PAGE_SIZE = 20;
+
+function useHistoryBase(sort?: MeListSort, limit = PAGE_SIZE, enabled = true) {
   return useQuery({
-    queryKey: queryKeys.meLists.history(sort),
-    queryFn: () => meListsApi.getHistory(sort ? { sort } : undefined),
+    queryKey: queryKeys.meLists.history(sort, limit),
+    queryFn: () => meListsApi.getHistory({ sort, limit }),
     enabled,
     staleTime: STALE_5_MIN,
     placeholderData: keepPreviousData,
   });
 }
 
-export function useWatching(sort?: MeListSort, enabled = true) {
-  const query = useHistoryBase(sort, enabled);
+export function useWatching(sort?: MeListSort, limit = PAGE_SIZE, enabled = true) {
+  const query = useHistoryBase(sort, limit, enabled);
 
   const data = useMemo(
     () =>
@@ -37,8 +40,8 @@ export function useWatching(sort?: MeListSort, enabled = true) {
   return { ...query, data };
 }
 
-export function useCompleted(sort?: MeListSort, enabled = true) {
-  const query = useHistoryBase(sort, enabled);
+export function useCompleted(sort?: MeListSort, limit = PAGE_SIZE, enabled = true) {
+  const query = useHistoryBase(sort, limit, enabled);
 
   const data = useMemo(
     () =>
@@ -54,20 +57,20 @@ export function useCompleted(sort?: MeListSort, enabled = true) {
   return { ...query, data };
 }
 
-export function usePaused(sort?: MeListSort, enabled = true) {
+export function usePaused(sort?: MeListSort, limit = PAGE_SIZE, enabled = true) {
   return useQuery({
-    queryKey: queryKeys.meLists.paused(sort),
-    queryFn: () => meListsApi.getPaused(sort ? { sort } : undefined),
+    queryKey: queryKeys.meLists.paused(sort, limit),
+    queryFn: () => meListsApi.getPaused({ sort, limit }),
     enabled,
     staleTime: STALE_5_MIN,
     placeholderData: keepPreviousData,
   });
 }
 
-export function useDropped(sort?: MeListSort, enabled = true) {
+export function useDropped(sort?: MeListSort, limit = PAGE_SIZE, enabled = true) {
   return useQuery({
-    queryKey: queryKeys.meLists.dropped(sort),
-    queryFn: () => meListsApi.getDropped(sort ? { sort } : undefined),
+    queryKey: queryKeys.meLists.dropped(sort, limit),
+    queryFn: () => meListsApi.getDropped({ sort, limit }),
     enabled,
     staleTime: STALE_5_MIN,
     placeholderData: keepPreviousData,

--- a/apps/web-client/src/modules/saved/hooks/use-me-lists.ts
+++ b/apps/web-client/src/modules/saved/hooks/use-me-lists.ts
@@ -13,7 +13,13 @@ const STALE_5_MIN = 1000 * 60 * 5;
 /** Page size for progressive loading in Activity lists. */
 export const PAGE_SIZE = 20;
 
-function useHistoryBase(sort?: MeListSort, limit = PAGE_SIZE, enabled = true) {
+interface MeListOptions {
+  sort?: MeListSort;
+  limit?: number;
+  enabled?: boolean;
+}
+
+function useHistoryBase({ sort, limit = PAGE_SIZE, enabled = true }: MeListOptions = {}) {
   return useQuery({
     queryKey: queryKeys.meLists.history(sort, limit),
     queryFn: () => meListsApi.getHistory({ sort, limit }),
@@ -23,8 +29,8 @@ function useHistoryBase(sort?: MeListSort, limit = PAGE_SIZE, enabled = true) {
   });
 }
 
-export function useWatching(sort?: MeListSort, limit = PAGE_SIZE, enabled = true) {
-  const query = useHistoryBase(sort, limit, enabled);
+export function useWatching(options: MeListOptions = {}) {
+  const query = useHistoryBase(options);
 
   const data = useMemo(
     () =>
@@ -40,8 +46,8 @@ export function useWatching(sort?: MeListSort, limit = PAGE_SIZE, enabled = true
   return { ...query, data };
 }
 
-export function useCompleted(sort?: MeListSort, limit = PAGE_SIZE, enabled = true) {
-  const query = useHistoryBase(sort, limit, enabled);
+export function useCompleted(options: MeListOptions = {}) {
+  const query = useHistoryBase(options);
 
   const data = useMemo(
     () =>
@@ -57,7 +63,7 @@ export function useCompleted(sort?: MeListSort, limit = PAGE_SIZE, enabled = tru
   return { ...query, data };
 }
 
-export function usePaused(sort?: MeListSort, limit = PAGE_SIZE, enabled = true) {
+export function usePaused({ sort, limit = PAGE_SIZE, enabled = true }: MeListOptions = {}) {
   return useQuery({
     queryKey: queryKeys.meLists.paused(sort, limit),
     queryFn: () => meListsApi.getPaused({ sort, limit }),
@@ -67,7 +73,7 @@ export function usePaused(sort?: MeListSort, limit = PAGE_SIZE, enabled = true) 
   });
 }
 
-export function useDropped(sort?: MeListSort, limit = PAGE_SIZE, enabled = true) {
+export function useDropped({ sort, limit = PAGE_SIZE, enabled = true }: MeListOptions = {}) {
   return useQuery({
     queryKey: queryKeys.meLists.dropped(sort, limit),
     queryFn: () => meListsApi.getDropped({ sort, limit }),

--- a/apps/web-client/src/shared/components/index.ts
+++ b/apps/web-client/src/shared/components/index.ts
@@ -8,3 +8,4 @@ export * from './footer';
 export * from './mobile-dock';
 export { PwaInstallListener } from './pwa-install-listener';
 export { NetworkStatusListener } from './network-status-listener';
+export { InfiniteScrollLoader } from './infinite-scroll-loader';

--- a/apps/web-client/src/shared/components/infinite-scroll-loader.tsx
+++ b/apps/web-client/src/shared/components/infinite-scroll-loader.tsx
@@ -27,31 +27,30 @@ export function InfiniteScrollLoader({
   onLoadMore,
   isLoading,
   hasMore,
-  loadingText = 'Завантаження...',
+  loadingText = 'Loading...',
 }: InfiniteScrollLoaderProps) {
   const loaderRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!hasMore || isLoading) return;
 
+    const currentRef = loaderRef.current;
+    if (!currentRef) return;
+
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries[0].isIntersecting) {
+          observer.unobserve(currentRef);
           onLoadMore();
         }
       },
       { threshold: 0.1, rootMargin: '100px' },
     );
 
-    const currentRef = loaderRef.current;
-    if (currentRef) {
-      observer.observe(currentRef);
-    }
+    observer.observe(currentRef);
 
     return () => {
-      if (currentRef) {
-        observer.unobserve(currentRef);
-      }
+      observer.unobserve(currentRef);
     };
   }, [hasMore, isLoading, onLoadMore]);
 

--- a/apps/web-client/src/shared/components/infinite-scroll-loader.tsx
+++ b/apps/web-client/src/shared/components/infinite-scroll-loader.tsx
@@ -1,0 +1,72 @@
+/**
+ * Infinite scroll loader component.
+ * Uses Intersection Observer to trigger loading more items.
+ */
+
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { Loader2 } from 'lucide-react';
+
+interface InfiniteScrollLoaderProps {
+  /** Callback when loader becomes visible */
+  onLoadMore: () => void;
+  /** Whether currently loading */
+  isLoading: boolean;
+  /** Whether there are more items to load */
+  hasMore: boolean;
+  /** Loading text */
+  loadingText?: string;
+}
+
+/**
+ * Infinite scroll trigger.
+ * Calls onLoadMore when element enters viewport.
+ */
+export function InfiniteScrollLoader({
+  onLoadMore,
+  isLoading,
+  hasMore,
+  loadingText = 'Завантаження...',
+}: InfiniteScrollLoaderProps) {
+  const loaderRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!hasMore || isLoading) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          onLoadMore();
+        }
+      },
+      { threshold: 0.1, rootMargin: '100px' },
+    );
+
+    const currentRef = loaderRef.current;
+    if (currentRef) {
+      observer.observe(currentRef);
+    }
+
+    return () => {
+      if (currentRef) {
+        observer.unobserve(currentRef);
+      }
+    };
+  }, [hasMore, isLoading, onLoadMore]);
+
+  if (!hasMore && !isLoading) {
+    return null;
+  }
+
+  return (
+    <div ref={loaderRef} className="flex items-center justify-center py-8">
+      {isLoading && (
+        <div className="flex items-center gap-2 text-cinema-text-muted">
+          <Loader2 className="w-5 h-5 animate-spin" />
+          <span>{loadingText}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web-client/src/shared/i18n/locales/en.json
+++ b/apps/web-client/src/shared/i18n/locales/en.json
@@ -10,7 +10,8 @@
     "showMore": "Show {count} more",
     "back": "Back",
     "home": "Go home",
-    "details": "Details"
+    "details": "Details",
+    "loadMore": "Load more"
   },
   "announcement": {
     "communityRating": {

--- a/apps/web-client/src/shared/i18n/locales/uk.json
+++ b/apps/web-client/src/shared/i18n/locales/uk.json
@@ -10,7 +10,8 @@
     "showMore": "Показати ще {count}",
     "back": "Назад",
     "home": "На головну",
-    "details": "Детальніше"
+    "details": "Детальніше",
+    "loadMore": "Завантажити ще"
   },
   "announcement": {
     "communityRating": {


### PR DESCRIPTION
## Summary
- Activity tabs were loading all items at once (limit=100), causing slow initial load and poor mobile UX with 50+ items
- Switch to progressive loading: initial 20 items with `InfiniteScrollLoader` for seamless infinite scroll pagination
- Move `InfiniteScrollLoader` from browse module to `shared/components/` for reuse across modules

## Changes
- **Hooks**: `PAGE_SIZE = 20` replaces `ACTIVITY_LIMIT = 100` — fast first paint, load more on scroll
- **4 list components** (watchlist, history, paused, dropped): `InfiniteScrollLoader` replaces "Load More" button
- **Query keys**: include `limit` param for proper cache management
- **i18n**: add `common.loadMore` key (uk/en)

## Test plan
- [ ] Watching tab loads 20 items initially, more appear on scroll
- [ ] History/Paused/Dropped tabs same behavior
- [ ] Mobile: smooth progressive loading, no long scroll wall
- [ ] Sort change resets to initial 20 items
- [ ] Pause/resume/drop mutations refresh lists correctly
- [ ] Browse page infinite scroll still works after component move

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Примітки до випуску

* **Нові можливості**
  * Додано прогресивне (інфініт) завантаження у списки збережених: історія, призупинені, видалені та список очікування.
  * Доданий компонент для автоматичного підвантаження під час прокрутки.
  * Паразитне завантаження тепер використовує розмір сторінки (PAGE_SIZE) і підтримує параметр ліміту.

* **Тестування**
  * Оновлено тести для нового виклику хуків із об’єктом опцій та поведінки за замовчуванням.

* **Локалізація**
  * Додано рядки для кнопки/повідомлення «Завантажити ще».
<!-- end of auto-generated comment: release notes by coderabbit.ai -->