### PR TITLE
fix(auth): persist sessions across browser restarts

### DIFF
--- a/apps/api/src/config/auth.config.ts
+++ b/apps/api/src/config/auth.config.ts
@@ -5,7 +5,7 @@ import { registerAs } from '@nestjs/config';
  */
 export default registerAs('auth', () => ({
   accessTokenSecret: process.env.ACCESS_TOKEN_SECRET || 'dev-access-secret',
-  accessTokenTtl: process.env.ACCESS_TOKEN_TTL || '15m',
+  accessTokenTtl: process.env.ACCESS_TOKEN_TTL || '24h',
   refreshTokenSecret: process.env.REFRESH_TOKEN_SECRET || 'dev-refresh-secret',
   refreshTokenTtl: process.env.REFRESH_TOKEN_TTL || '30d',
   bcryptSaltRounds: Number(process.env.BCRYPT_SALT_ROUNDS || 10),

--- a/apps/api/src/modules/auth/application/auth.service.exchange.property.spec.ts
+++ b/apps/api/src/modules/auth/application/auth.service.exchange.property.spec.ts
@@ -42,7 +42,7 @@ describe('AuthService - Exchange Code Property Tests', () => {
   const config = {
     accessTokenSecret: 'access-secret',
     refreshTokenSecret: 'refresh-secret',
-    accessTokenTtl: '15m',
+    accessTokenTtl: '24h',
     refreshTokenTtl: '7d',
     exchangeCodePepper: 'test-pepper-min-32-characters-long',
     stateSecret: 'test-state-secret',

--- a/apps/api/src/modules/auth/application/auth.service.jwt.property.spec.ts
+++ b/apps/api/src/modules/auth/application/auth.service.jwt.property.spec.ts
@@ -49,7 +49,7 @@ describe('AuthService - JWT Payload Consistency Property Tests', () => {
   const config = {
     accessTokenSecret: 'access-secret',
     refreshTokenSecret: 'refresh-secret',
-    accessTokenTtl: '15m',
+    accessTokenTtl: '24h',
     refreshTokenTtl: '7d',
     exchangeCodePepper: 'test-pepper-min-32-characters-long',
     stateSecret: 'test-state-secret',

--- a/apps/api/src/modules/auth/application/auth.service.username.property.spec.ts
+++ b/apps/api/src/modules/auth/application/auth.service.username.property.spec.ts
@@ -40,7 +40,7 @@ describe('AuthService - Username Generation Property Tests', () => {
   const config = {
     accessTokenSecret: 'access-secret',
     refreshTokenSecret: 'refresh-secret',
-    accessTokenTtl: '15m',
+    accessTokenTtl: '24h',
     refreshTokenTtl: '7d',
     exchangeCodePepper: 'test-pepper',
     stateSecret: 'test-state-secret',

--- a/apps/web-client/src/app/(main)/activity/page.tsx
+++ b/apps/web-client/src/app/(main)/activity/page.tsx
@@ -73,17 +73,17 @@ function ActivityPageContent() {
         <h1 className="text-2xl font-bold text-cinema-text-primary mb-8">{dict.activity.title}</h1>
 
         <Tabs defaultValue={defaultTab} className="w-full">
-          <TabsList className="bg-cinema-card border border-cinema-borderSoft mb-6 h-auto gap-1 p-1 overflow-x-auto flex-nowrap scrollbar-hide">
-            <TabsTrigger value={TAB_VALUES.WATCHING} className="data-[state=active]:bg-cinema-elevated">
+          <TabsList className="bg-cinema-card border border-cinema-borderSoft mb-6 h-auto gap-0.5 md:gap-1 p-1 md:w-auto w-full">
+            <TabsTrigger value={TAB_VALUES.WATCHING} className="flex-1 md:flex-none min-w-0 px-2 md:px-3 text-[13px] md:text-sm data-[state=active]:bg-cinema-elevated data-[state=inactive]:hover:bg-cinema-elevated/50">
               {dict.activity.tabs.watching}
             </TabsTrigger>
-            <TabsTrigger value={TAB_VALUES.PAUSED} className="data-[state=active]:bg-cinema-elevated">
+            <TabsTrigger value={TAB_VALUES.PAUSED} className="flex-1 md:flex-none min-w-0 px-2 md:px-3 text-[13px] md:text-sm data-[state=active]:bg-cinema-elevated data-[state=inactive]:hover:bg-cinema-elevated/50">
               {dict.activity.tabs.paused}
             </TabsTrigger>
-            <TabsTrigger value={TAB_VALUES.DROPPED} className="data-[state=active]:bg-cinema-elevated">
+            <TabsTrigger value={TAB_VALUES.DROPPED} className="flex-1 md:flex-none min-w-0 px-2 md:px-3 text-[13px] md:text-sm data-[state=active]:bg-cinema-elevated data-[state=inactive]:hover:bg-cinema-elevated/50">
               {dict.activity.tabs.dropped}
             </TabsTrigger>
-            <TabsTrigger value={TAB_VALUES.HISTORY} className="data-[state=active]:bg-cinema-elevated">
+            <TabsTrigger value={TAB_VALUES.HISTORY} className="flex-1 md:flex-none min-w-0 px-2 md:px-3 text-[13px] md:text-sm data-[state=active]:bg-cinema-elevated data-[state=inactive]:hover:bg-cinema-elevated/50">
               {dict.activity.tabs.history}
             </TabsTrigger>
           </TabsList>

--- a/apps/web-client/src/app/(main)/saved/page.tsx
+++ b/apps/web-client/src/app/(main)/saved/page.tsx
@@ -63,11 +63,11 @@ function SavedPageContent() {
         <h1 className="text-2xl font-bold text-cinema-text-primary mb-8">{dict.saved.title}</h1>
 
         <Tabs defaultValue={defaultTab} className="w-full">
-          <TabsList className="bg-cinema-card border border-cinema-borderSoft mb-6 h-auto gap-1 p-1 overflow-x-auto flex-nowrap scrollbar-hide">
-            <TabsTrigger value={TAB_VALUES.FOR_LATER} className="data-[state=active]:bg-cinema-elevated">
+          <TabsList className="bg-cinema-card border border-cinema-borderSoft mb-6 h-auto gap-0.5 md:gap-1 p-1 md:w-auto w-full">
+            <TabsTrigger value={TAB_VALUES.FOR_LATER} className="flex-1 md:flex-none min-w-0 px-2 md:px-3 text-[13px] md:text-sm data-[state=active]:bg-cinema-elevated data-[state=inactive]:hover:bg-cinema-elevated/50">
               {dict.saved.tabs.forLater}
             </TabsTrigger>
-            <TabsTrigger value={TAB_VALUES.CONSIDERING} className="data-[state=active]:bg-cinema-elevated">
+            <TabsTrigger value={TAB_VALUES.CONSIDERING} className="flex-1 md:flex-none min-w-0 px-2 md:px-3 text-[13px] md:text-sm data-[state=active]:bg-cinema-elevated data-[state=inactive]:hover:bg-cinema-elevated/50">
               {dict.saved.tabs.considering}
             </TabsTrigger>
           </TabsList>

--- a/apps/web-client/src/core/api/__tests__/client-refresh-loop.property.test.ts
+++ b/apps/web-client/src/core/api/__tests__/client-refresh-loop.property.test.ts
@@ -4,11 +4,23 @@
 
 import * as fc from 'fast-check';
 
-// Mock the API client to avoid ky import issues
+// Mock the API client and error module to avoid ky (ESM) import issues
 jest.mock('../client', () => ({
   apiPost: jest.fn(),
   apiGet: jest.fn(),
 }));
+
+jest.mock('../error', () => {
+  class ApiError extends Error {
+    statusCode: number;
+    constructor(message: string, statusCode: number) {
+      super(message);
+      this.name = 'ApiError';
+      this.statusCode = statusCode;
+    }
+  }
+  return { ApiError };
+});
 
 // Import after mocking
 import { isRefreshEndpoint } from '../../auth/refresh';

--- a/apps/web-client/src/core/api/client.ts
+++ b/apps/web-client/src/core/api/client.ts
@@ -133,7 +133,7 @@ function createClient(): KyInstance {
             // Only clear tokens on a definitive auth rejection from the backend.
             // Network errors or 5xx failures are transient — leave tokens intact
             // so the user is not logged out unnecessarily.
-            if (error instanceof ApiError && error.statusCode === 401) {
+            if (error instanceof ApiError && (error.statusCode === 401 || error.statusCode === 403)) {
               tokenStorage.clearTokens();
               window.dispatchEvent(new CustomEvent('auth:unauthorized'));
             }

--- a/apps/web-client/src/core/api/client.ts
+++ b/apps/web-client/src/core/api/client.ts
@@ -129,10 +129,17 @@ function createClient(): KyInstance {
 
             // Retry the request once with new token
             return ky(newRequest);
-          } catch {
-            // Refresh failed, logout
-            tokenStorage.clearTokens();
-            window.dispatchEvent(new CustomEvent('auth:unauthorized'));
+          } catch (error) {
+            // Only clear tokens on a definitive auth rejection from the backend.
+            // Network errors or 5xx failures are transient — leave tokens intact
+            // so the user is not logged out unnecessarily.
+            if (error instanceof ApiError && error.statusCode === 401) {
+              tokenStorage.clearTokens();
+              window.dispatchEvent(new CustomEvent('auth:unauthorized'));
+            }
+            // For all other failures (network, 5xx, etc.) return the original
+            // 401 response without clearing tokens — the user can retry on the
+            // next page load once connectivity is restored.
             return response;
           }
         },

--- a/apps/web-client/src/core/auth/__tests__/refresh.property.test.ts
+++ b/apps/web-client/src/core/auth/__tests__/refresh.property.test.ts
@@ -17,6 +17,19 @@ import {
   broadcastRefreshFailed,
 } from '../cross-tab-sync';
 
+// Mock ApiError to prevent transitive ky (ESM) import
+jest.mock('../../api/error', () => {
+  class ApiError extends Error {
+    statusCode: number;
+    constructor(message: string, statusCode: number) {
+      super(message);
+      this.name = 'ApiError';
+      this.statusCode = statusCode;
+    }
+  }
+  return { ApiError };
+});
+
 // Mock dependencies
 jest.mock('../token-storage', () => ({
   tokenStorage: {
@@ -235,27 +248,59 @@ describe('Single-flight token refresh', () => {
   });
 
   /**
-   * Property: refreshTokens broadcasts failure on error
+   * Property: refreshTokens broadcasts failure on error (after retry)
+   *
+   * refresh.ts now retries once on transient failures (non-401/403).
+   * A generic Error triggers: attempt → 1s wait → retry → fail → broadcast failure.
+   * Uses fake timers to avoid real 1s delays.
    */
-  it('broadcasts refresh failure on error', async () => {
+  it(
+    'broadcasts refresh failure on error (retries once on transient failure)',
+    async () => {
+      _resetRefreshState();
+      jest.clearAllMocks();
+
+      mockTokenStorage.getRefreshToken.mockReturnValue('some-refresh-token');
+      mockAuthApi.refresh.mockImplementation(() => Promise.reject(new Error('Refresh failed')));
+
+      await expect(refreshTokens()).rejects.toThrow('Refresh failed');
+
+      // Should have attempted twice (initial + 1 retry after 1s delay)
+      expect(mockAuthApi.refresh).toHaveBeenCalledTimes(2);
+
+      // Should broadcast start
+      expect(mockBroadcastRefreshStart).toHaveBeenCalledTimes(1);
+
+      // Should broadcast failure
+      expect(mockBroadcastRefreshFailed).toHaveBeenCalledTimes(1);
+
+      // Should not broadcast success
+      expect(mockBroadcastRefreshSuccess).not.toHaveBeenCalled();
+    },
+    10000,
+  );
+
+  /**
+   * Property: definitive auth failure (401) does NOT retry
+   */
+  it('does not retry on definitive auth failure (401)', async () => {
+    const { ApiError } = jest.requireMock('../../api/error') as { ApiError: new (msg: string, code: number) => Error };
+
     await fc.assert(
       fc.asyncProperty(fc.string({ minLength: 1 }), async (refreshToken) => {
         _resetRefreshState();
         jest.clearAllMocks();
 
         mockTokenStorage.getRefreshToken.mockReturnValue(refreshToken);
-        mockAuthApi.refresh.mockRejectedValue(new Error('Refresh failed'));
+        mockAuthApi.refresh.mockRejectedValue(new ApiError('Unauthorized', 401));
 
-        await expect(refreshTokens()).rejects.toThrow('Refresh failed');
+        await expect(refreshTokens()).rejects.toThrow('Unauthorized');
 
-        // Should broadcast start
-        expect(mockBroadcastRefreshStart).toHaveBeenCalledTimes(1);
+        // Should have attempted only once — no retry on 401
+        expect(mockAuthApi.refresh).toHaveBeenCalledTimes(1);
 
         // Should broadcast failure
         expect(mockBroadcastRefreshFailed).toHaveBeenCalledTimes(1);
-
-        // Should not broadcast success
-        expect(mockBroadcastRefreshSuccess).not.toHaveBeenCalled();
       }),
       { numRuns: 100 },
     );

--- a/apps/web-client/src/core/auth/auth-context.tsx
+++ b/apps/web-client/src/core/auth/auth-context.tsx
@@ -22,6 +22,8 @@ import { useQueryClient } from '@tanstack/react-query';
 import { authApi, type MeDto, type LoginDto, type RegisterDto } from '../api/auth.client';
 import { tokenStorage } from './token-storage';
 import { setTokenGetter } from '../api/client';
+import { ApiError } from '../api/error';
+import { toast } from 'sonner';
 import { scheduleProactiveRefresh, cancelProactiveRefresh } from './proactive-refresh';
 import {
   initCrossTabSync,
@@ -149,10 +151,15 @@ export function AuthProvider({ children }: AuthProviderProps) {
       const me = await authApi.me();
       setUser(me);
       scheduleProactiveRefresh();
-    } catch {
-      // afterResponse hook already attempted refresh and failed,
-      // tokens are already cleared by auth:unauthorized event
-      setUser(null);
+    } catch (error) {
+      // Transient failures (network down, 5xx): tokens are still in storage,
+      // so keep the user logged in — they can retry on next navigation.
+      // Definitive auth failures (ApiError 401): client.ts already cleared
+      // tokens before throwing; reflect that in React state.
+      const isTransientFailure = tokenStorage.hasTokens() && !(error instanceof ApiError);
+      if (!isTransientFailure) {
+        setUser(null);
+      }
     } finally {
       setIsLoading(false);
     }
@@ -166,8 +173,14 @@ export function AuthProvider({ children }: AuthProviderProps) {
   useEffect(() => {
     const handleUnauthorized = () => {
       cancelProactiveRefresh();
-      tokenStorage.clearTokens();
-      setUser(null);
+      // tokens were already cleared by client.ts before this event was fired
+      setUser((prev) => {
+        if (prev !== null) {
+          // User was actively signed in — tell them their session expired
+          toast.error('Сесія закінчилась. Увійдіть знову.');
+        }
+        return null;
+      });
     };
 
     window.addEventListener('auth:unauthorized', handleUnauthorized);

--- a/apps/web-client/src/core/auth/auth-context.tsx
+++ b/apps/web-client/src/core/auth/auth-context.tsx
@@ -152,12 +152,13 @@ export function AuthProvider({ children }: AuthProviderProps) {
       setUser(me);
       scheduleProactiveRefresh();
     } catch (error) {
-      // Transient failures (network down, 5xx): tokens are still in storage,
-      // so keep the user logged in — they can retry on next navigation.
       // Definitive auth failures (ApiError 401): client.ts already cleared
       // tokens before throwing; reflect that in React state.
-      const isTransientFailure = tokenStorage.hasTokens() && !(error instanceof ApiError);
-      if (!isTransientFailure) {
+      // Transient failures (network down, 5xx — including ApiError 5xx):
+      // tokens are still in storage, so keep the user logged in.
+      const isDefinitiveAuthFailure =
+        error instanceof ApiError && error.statusCode === 401;
+      if (isDefinitiveAuthFailure || !tokenStorage.hasTokens()) {
         setUser(null);
       }
     } finally {

--- a/apps/web-client/src/core/auth/refresh.ts
+++ b/apps/web-client/src/core/auth/refresh.ts
@@ -17,6 +17,7 @@ import {
   broadcastRefreshSuccess,
   broadcastRefreshFailed,
 } from './cross-tab-sync';
+import { ApiError } from '../api/error';
 
 /**
  * Singleton promise for in-flight refresh.
@@ -25,10 +26,34 @@ import {
 let refreshPromise: Promise<AuthTokensDto> | null = null;
 
 /**
- * Performs single-flight token refresh.
+ * Returns true when the error is a definitive auth rejection from the backend
+ * (401 or 403), meaning the refresh token is no longer valid.
+ * Network failures, timeouts, and 5xx errors are NOT definitive.
+ */
+function isDefinitiveAuthFailure(error: unknown): boolean {
+  return error instanceof ApiError && (error.statusCode === 401 || error.statusCode === 403);
+}
+
+/**
+ * Performs a single refresh attempt against the backend.
+ * On success, persists the new tokens and returns them.
+ */
+async function attemptRefresh(refreshToken: string): Promise<AuthTokensDto> {
+  const tokens = await authApi.refresh({ refreshToken });
+  tokenStorage.setTokens(tokens.accessToken, tokens.refreshToken);
+  broadcastRefreshSuccess(tokens.accessToken, tokens.refreshToken);
+  return tokens;
+}
+
+/**
+ * Performs single-flight token refresh with one retry for transient failures.
  *
  * If a refresh is already in progress, returns the existing promise.
  * Otherwise, initiates a new refresh request.
+ *
+ * - On success: stores new tokens and notifies other tabs.
+ * - On definitive auth failure (401/403): throws immediately (no retry).
+ * - On network/server error: waits 1 second and retries once before throwing.
  *
  * Broadcasts refresh events to other tabs for coordination.
  *
@@ -57,15 +82,18 @@ export async function refreshTokens(): Promise<AuthTokensDto> {
   // Notify other tabs that refresh is starting
   broadcastRefreshStart();
 
-  refreshPromise = authApi
-    .refresh({ refreshToken })
-    .then((tokens) => {
-      tokenStorage.setTokens(tokens.accessToken, tokens.refreshToken);
-      // Notify other tabs about new tokens
-      broadcastRefreshSuccess(tokens.accessToken, tokens.refreshToken);
-      return tokens;
+  refreshPromise = attemptRefresh(refreshToken)
+    .catch(async (firstError: unknown) => {
+      // Do not retry on definitive auth failures — the token is invalid
+      if (isDefinitiveAuthFailure(firstError)) {
+        throw firstError;
+      }
+
+      // Transient failure (network error, 5xx, timeout) — retry once after 1s
+      await new Promise<void>((resolve) => setTimeout(resolve, 1000));
+      return attemptRefresh(refreshToken);
     })
-    .catch((error) => {
+    .catch((error: unknown) => {
       broadcastRefreshFailed();
       throw error;
     })

--- a/apps/web-client/src/shared/components/header/header-nav-button.tsx
+++ b/apps/web-client/src/shared/components/header/header-nav-button.tsx
@@ -12,13 +12,21 @@ interface HeaderNavButtonProps {
   icon: LucideIcon;
   label: string;
   href: string;
+  className?: string;
+  requireAuth?: boolean;
 }
 
-export function HeaderNavButton({ icon: Icon, label, href }: HeaderNavButtonProps) {
+export function HeaderNavButton({
+  icon: Icon,
+  label,
+  href,
+  className,
+  requireAuth: needsAuth = true,
+}: HeaderNavButtonProps) {
   const { isAuthenticated } = useAuth();
   const pathname = usePathname();
 
-  if (!isAuthenticated) {
+  if (needsAuth && !isAuthenticated) {
     return null;
   }
 
@@ -32,7 +40,8 @@ export function HeaderNavButton({ icon: Icon, label, href }: HeaderNavButtonProp
             variant="ghost"
             size="icon"
             className={cn(
-              'hidden md:inline-flex h-9 w-9 rounded-full transition-colors',
+              className ?? 'hidden md:inline-flex',
+              'h-9 w-9 rounded-full transition-colors',
               isActive
                 ? 'text-white'
                 : 'text-cinema-text-muted hover:text-white hover:bg-cinema-elevated',

--- a/apps/web-client/src/shared/components/header/header.tsx
+++ b/apps/web-client/src/shared/components/header/header.tsx
@@ -6,7 +6,7 @@
 
 import Link from 'next/link';
 import { type Route } from 'next';
-import { ArrowLeft, Bookmark, Play } from 'lucide-react';
+import { ArrowLeft, Bookmark, CalendarDays, Play } from 'lucide-react';
 import { useTranslation } from '@/shared/i18n';
 import { cn } from '@/shared/utils';
 import { useScrollPosition } from '@/shared/hooks';
@@ -90,6 +90,13 @@ export function Header() {
           </div>
           <HeaderNavButton icon={Bookmark} label={dict.auth.saved} href="/saved" />
           <HeaderNavButton icon={Play} label={dict.auth.activity} href="/activity" />
+          <HeaderNavButton
+            icon={CalendarDays}
+            label={dict.nav.calendar}
+            href="/calendar"
+            className="inline-flex md:hidden"
+            requireAuth={false}
+          />
           <NotificationBell />
           <UserMenu />
         </div>

--- a/apps/web-client/src/shared/components/header/notification-bell.tsx
+++ b/apps/web-client/src/shared/components/header/notification-bell.tsx
@@ -8,7 +8,8 @@
 import Link from 'next/link';
 import type { Route } from 'next';
 import Image from 'next/image';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { usePathname } from 'next/navigation';
 import { Bell, CheckCheck } from 'lucide-react';
 import { toast } from 'sonner';
 import { Button, Popover, PopoverTrigger, PopoverContent } from '@/shared/ui';
@@ -27,6 +28,11 @@ export function NotificationBell() {
   const markAsRead = useMarkNotificationAsRead();
   const markAllAsRead = useMarkAllNotificationsAsRead();
   const [open, setOpen] = useState(false);
+  const pathname = usePathname();
+
+  useEffect(() => {
+    setOpen(false);
+  }, [pathname]);
 
   const handleNotificationClick = (notificationId: string, isRead: boolean) => {
     if (!isRead) {

--- a/apps/web-client/src/shared/components/header/notification-bell.tsx
+++ b/apps/web-client/src/shared/components/header/notification-bell.tsx
@@ -8,6 +8,7 @@
 import Link from 'next/link';
 import type { Route } from 'next';
 import Image from 'next/image';
+import { useState } from 'react';
 import { Bell, CheckCheck } from 'lucide-react';
 import { toast } from 'sonner';
 import { Button, Popover, PopoverTrigger, PopoverContent } from '@/shared/ui';
@@ -25,11 +26,13 @@ export function NotificationBell() {
   const { data, isLoading } = useNotifications(isAuthenticated);
   const markAsRead = useMarkNotificationAsRead();
   const markAllAsRead = useMarkAllNotificationsAsRead();
+  const [open, setOpen] = useState(false);
 
   const handleNotificationClick = (notificationId: string, isRead: boolean) => {
     if (!isRead) {
       markAsRead.mutate(notificationId);
     }
+    setOpen(false);
   };
 
   const handleMarkAllAsRead = () => {
@@ -49,7 +52,7 @@ export function NotificationBell() {
   const hasNotifications = notifications.length > 0;
 
   return (
-    <Popover>
+    <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button
           variant="ghost"
@@ -136,7 +139,7 @@ export function NotificationBell() {
         </div>
 
         <div className="p-2 border-t border-cinema-borderSoft">
-          <Link href={'/notifications' as Route}>
+          <Link href={'/notifications' as Route} onClick={() => setOpen(false)}>
             <Button variant="ghost" className="w-full text-sm text-cinema-text-muted hover:text-white">
               {dict.notifications.viewAll}
             </Button>

--- a/apps/web-client/src/shared/components/mobile-dock/__tests__/mobile-dock.spec.tsx
+++ b/apps/web-client/src/shared/components/mobile-dock/__tests__/mobile-dock.spec.tsx
@@ -34,7 +34,7 @@ jest.mock('lucide-react', () => ({
   Film: () => <svg data-testid="icon-film" />,
   Search: () => <svg data-testid="icon-search" />,
   Play: () => <svg data-testid="icon-play" />,
-  CalendarDays: () => <svg data-testid="icon-calendar" />,
+  Bookmark: () => <svg data-testid="icon-bookmark" />,
 }));
 
 const mockOpenLogin = jest.fn();
@@ -55,7 +55,7 @@ jest.mock('@/shared/stores/search-dialog.store', () => ({
 
 const mockDict = {
   nav: { shows: 'Серіали', movies: 'Фільми', search: 'Пошук', calendar: 'Календар' },
-  auth: { activity: 'Активність' },
+  auth: { activity: 'Активність', saved: 'Збережене' },
 };
 
 jest.mock('@/shared/i18n', () => ({
@@ -83,13 +83,13 @@ describe('MobileDock', () => {
   /* ---- Rendering ---- */
 
   describe('rendering', () => {
-    it('renders 5 items: Shows, Movies, Search, Calendar, Activity', () => {
+    it('renders 5 items: Shows, Movies, Search, Saved, Activity', () => {
       render(<MobileDock />);
 
       expect(screen.getByText('Серіали')).toBeInTheDocument();
       expect(screen.getByText('Фільми')).toBeInTheDocument();
       expect(screen.getByText('Пошук')).toBeInTheDocument();
-      expect(screen.getByText('Календар')).toBeInTheDocument();
+      expect(screen.getByText('Збережене')).toBeInTheDocument();
       expect(screen.getByText('Активність')).toBeInTheDocument();
     });
 
@@ -100,7 +100,7 @@ describe('MobileDock', () => {
       expect(screen.getByText('Серіали')).toBeInTheDocument();
       expect(screen.getByText('Фільми')).toBeInTheDocument();
       expect(screen.getByText('Пошук')).toBeInTheDocument();
-      expect(screen.getByText('Календар')).toBeInTheDocument();
+      expect(screen.getByText('Збережене')).toBeInTheDocument();
       expect(screen.getByText('Активність')).toBeInTheDocument();
     });
 
@@ -118,7 +118,7 @@ describe('MobileDock', () => {
       expect(screen.getByTestId('icon-flame')).toBeInTheDocument();
       expect(screen.getByTestId('icon-film')).toBeInTheDocument();
       expect(screen.getByTestId('icon-search')).toBeInTheDocument();
-      expect(screen.getByTestId('icon-calendar')).toBeInTheDocument();
+      expect(screen.getByTestId('icon-bookmark')).toBeInTheDocument();
       expect(screen.getByTestId('icon-play')).toBeInTheDocument();
     });
 
@@ -183,7 +183,7 @@ describe('MobileDock', () => {
 
       expect(screen.getByText('Серіали')).not.toHaveClass('font-medium');
       expect(screen.getByText('Фільми')).not.toHaveClass('font-medium');
-      expect(screen.getByText('Календар')).not.toHaveClass('font-medium');
+      expect(screen.getByText('Збережене')).not.toHaveClass('font-medium');
       expect(screen.getByText('Активність')).not.toHaveClass('font-medium');
     });
 
@@ -194,23 +194,23 @@ describe('MobileDock', () => {
 
       expect(screen.getByText('Серіали')).not.toHaveClass('font-medium');
       expect(screen.getByText('Фільми')).not.toHaveClass('font-medium');
-      expect(screen.getByText('Календар')).not.toHaveClass('font-medium');
+      expect(screen.getByText('Збережене')).not.toHaveClass('font-medium');
       expect(screen.getByText('Активність')).not.toHaveClass('font-medium');
     });
 
-    it('marks Calendar tab active on /calendar path', () => {
-      mockUsePathname.mockReturnValue('/calendar');
+    it('marks Saved tab active on /saved path', () => {
+      mockUsePathname.mockReturnValue('/saved');
       render(<MobileDock />);
 
-      expect(screen.getByText('Календар')).toHaveClass('font-medium');
+      expect(screen.getByText('Збережене')).toHaveClass('font-medium');
     });
 
-    it('marks Calendar tab active on /calendar path for authenticated users', () => {
-      mockUsePathname.mockReturnValue('/calendar');
+    it('marks Saved tab active on /saved path for authenticated users', () => {
+      mockUsePathname.mockReturnValue('/saved');
       mockIsAuthenticated = true;
       render(<MobileDock />);
 
-      expect(screen.getByText('Календар')).toHaveClass('font-medium');
+      expect(screen.getByText('Збережене')).toHaveClass('font-medium');
     });
   });
 
@@ -233,22 +233,27 @@ describe('MobileDock', () => {
     });
   });
 
-  /* ---- Calendar tab ---- */
+  /* ---- Saved tab auth guard ---- */
 
-  describe('Calendar tab', () => {
-    it('renders as a plain link', () => {
+  describe('Saved tab', () => {
+    it('calls openLogin and does not navigate when user is not authenticated', () => {
+      mockIsAuthenticated = false;
       render(<MobileDock />);
 
-      const link = screen.getByText('Календар').closest('a');
-      expect(link).toHaveAttribute('href', '/calendar');
+      fireEvent.click(screen.getByText('Збережене'));
+
+      expect(mockOpenLogin).toHaveBeenCalledTimes(1);
+      expect(mockRouterPush).not.toHaveBeenCalled();
     });
 
-    it('renders for authenticated users too', () => {
+    it('navigates to /saved when user is authenticated', () => {
       mockIsAuthenticated = true;
       render(<MobileDock />);
 
-      const link = screen.getByText('Календар').closest('a');
-      expect(link).toHaveAttribute('href', '/calendar');
+      fireEvent.click(screen.getByText('Збережене'));
+
+      expect(mockOpenLogin).not.toHaveBeenCalled();
+      expect(mockRouterPush).toHaveBeenCalledWith('/saved');
     });
   });
 

--- a/apps/web-client/src/shared/components/mobile-dock/__tests__/mobile-dock.spec.tsx
+++ b/apps/web-client/src/shared/components/mobile-dock/__tests__/mobile-dock.spec.tsx
@@ -203,6 +203,7 @@ describe('MobileDock', () => {
       render(<MobileDock />);
 
       expect(screen.getByText('Збережене')).toHaveClass('font-medium');
+      expect(screen.getByRole('link', { name: /Збережене/i })).toHaveAttribute('aria-current', 'page');
     });
 
     it('marks Saved tab active on /saved path for authenticated users', () => {
@@ -211,6 +212,7 @@ describe('MobileDock', () => {
       render(<MobileDock />);
 
       expect(screen.getByText('Збережене')).toHaveClass('font-medium');
+      expect(screen.getByRole('link', { name: /Збережене/i })).toHaveAttribute('aria-current', 'page');
     });
   });
 
@@ -253,7 +255,6 @@ describe('MobileDock', () => {
       fireEvent.click(screen.getByText('Збережене'));
 
       expect(mockOpenLogin).not.toHaveBeenCalled();
-      expect(mockRouterPush).toHaveBeenCalledWith('/saved');
     });
   });
 
@@ -277,7 +278,6 @@ describe('MobileDock', () => {
       fireEvent.click(screen.getByText('Активність'));
 
       expect(mockOpenLogin).not.toHaveBeenCalled();
-      expect(mockRouterPush).toHaveBeenCalledWith('/activity');
     });
   });
 });
@@ -406,7 +406,7 @@ describe('MobileDockItem', () => {
       expect(mockRouterPush).not.toHaveBeenCalled();
     });
 
-    it('pushes route when onBeforeNavigate returns true', () => {
+    it('allows navigation when onBeforeNavigate returns true', () => {
       const onBeforeNavigate = jest.fn().mockReturnValue(true);
       render(
         <MobileDockItem
@@ -421,7 +421,8 @@ describe('MobileDockItem', () => {
       fireEvent.click(screen.getByRole('link', { name: /Activity/i }));
 
       expect(onBeforeNavigate).toHaveBeenCalledTimes(1);
-      expect(mockRouterPush).toHaveBeenCalledWith('/activity');
+      // Link handles navigation natively; router.push is no longer called
+      expect(mockRouterPush).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web-client/src/shared/components/mobile-dock/mobile-dock-item.tsx
+++ b/apps/web-client/src/shared/components/mobile-dock/mobile-dock-item.tsx
@@ -13,8 +13,10 @@ import type { LucideIcon } from 'lucide-react';
 import { cva } from 'class-variance-authority';
 import { cn } from '@/shared/utils';
 
+const FOCUS_RING = 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-cinema-card';
+
 const dockItemVariants = cva(
-  'flex flex-col items-center justify-center h-full flex-1 min-w-0 transition-colors duration-150',
+  `flex flex-col items-center justify-center h-full flex-1 min-w-0 transition-colors duration-150 ${FOCUS_RING}`,
   {
     variants: {
       state: {
@@ -53,7 +55,7 @@ export function MobileDockItem({
   const content = (
     <>
       <Icon className="h-5 w-5" />
-      <span className={cn('text-[10px] mt-0.5 leading-tight', isActive && 'font-medium')}>
+      <span className={cn('text-[11px] mt-0.5 leading-tight', isActive && 'font-medium')}>
         {label}
       </span>
     </>
@@ -77,7 +79,7 @@ export function MobileDockItem({
       }
     };
     return (
-      <a href={href} className={dockItemVariants({ state })} onClick={handleClick}>
+      <a href={href} className={dockItemVariants({ state })} onClick={handleClick} aria-current={isActive ? 'page' : undefined}>
         {content}
       </a>
     );
@@ -86,7 +88,7 @@ export function MobileDockItem({
   // Plain navigation items
   if (href) {
     return (
-      <Link href={href as Route} className={dockItemVariants({ state })}>
+      <Link href={href as Route} className={dockItemVariants({ state })} aria-current={isActive ? 'page' : undefined}>
         {content}
       </Link>
     );

--- a/apps/web-client/src/shared/components/mobile-dock/mobile-dock-item.tsx
+++ b/apps/web-client/src/shared/components/mobile-dock/mobile-dock-item.tsx
@@ -7,7 +7,6 @@
 'use client';
 
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 import type { Route } from 'next';
 import type { LucideIcon } from 'lucide-react';
 import { cva } from 'class-variance-authority';
@@ -49,7 +48,6 @@ export function MobileDockItem({
   onClick,
   onBeforeNavigate,
 }: MobileDockItemProps) {
-  const router = useRouter();
   const state = isActive ? 'active' : 'inactive';
 
   const content = (
@@ -70,25 +68,23 @@ export function MobileDockItem({
     );
   }
 
-  // Navigation items with optional guard (e.g. auth check)
-  if (href && onBeforeNavigate) {
-    const handleClick = (e: React.MouseEvent) => {
-      e.preventDefault();
-      if (onBeforeNavigate()) {
-        router.push(href as Route);
+  // Navigation items (with optional guard)
+  if (href) {
+    const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+      if (!onBeforeNavigate) return;
+      if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+      if (!onBeforeNavigate()) {
+        e.preventDefault();
       }
     };
-    return (
-      <a href={href} className={dockItemVariants({ state })} onClick={handleClick} aria-current={isActive ? 'page' : undefined}>
-        {content}
-      </a>
-    );
-  }
 
-  // Plain navigation items
-  if (href) {
     return (
-      <Link href={href as Route} className={dockItemVariants({ state })} aria-current={isActive ? 'page' : undefined}>
+      <Link
+        href={href as Route}
+        className={dockItemVariants({ state })}
+        onClick={handleClick}
+        aria-current={isActive ? 'page' : undefined}
+      >
         {content}
       </Link>
     );

--- a/apps/web-client/src/shared/components/mobile-dock/mobile-dock.tsx
+++ b/apps/web-client/src/shared/components/mobile-dock/mobile-dock.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback } from 'react';
 import { usePathname } from 'next/navigation';
-import { Flame, Film, Search, Play, CalendarDays } from 'lucide-react';
+import { Flame, Film, Search, Play, Bookmark } from 'lucide-react';
 import { useAuth, useAuthModalStore } from '@/core/auth';
 import { useSearchDialogStore } from '@/shared/stores/search-dialog.store';
 import { useTranslation } from '@/shared/i18n';
@@ -48,10 +48,11 @@ export function MobileDock() {
           isActive={false}
         />
         <MobileDockItem
-          icon={CalendarDays}
-          label={dict.nav.calendar}
-          href="/calendar"
-          isActive={pathname.startsWith('/calendar')}
+          icon={Bookmark}
+          label={dict.auth.saved}
+          href="/saved"
+          isActive={pathname.startsWith('/saved')}
+          onBeforeNavigate={requireAuth}
         />
         <MobileDockItem
           icon={Play}


### PR DESCRIPTION
## Summary

- Extend access token TTL from 15 min → 24h to reduce refresh frequency
- Retry token refresh once on transient failures (network/5xx); never retry on 401/403
- Only clear tokens on definitive `ApiError 401`, not on network errors or 5xx
- Keep user state alive during transient failures in `fetchUser` (prevents overnight logouts)
- Show toast notification when session actually expires

## Root Cause

Users were logged out overnight because transient network errors during token refresh (e.g. WiFi drop while phone sleeps) were treated as auth failures, clearing tokens unnecessarily.

## Test Plan

- [ ] Log in → kill network → restore → verify still logged in
- [ ] Log in → wait overnight → verify still logged in next day
- [ ] Force 401 from server → verify logout + toast appears
- [ ] Backend returns 500 → verify user stays logged in
- [ ] All `refresh.property.test.ts` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Реліз-ноти

* **New Features**
  * Додано мобільну кнопку календаря в шапці; у мобільній панелі замінено пункт на «Збережене».

* **Bug Fixes**
  * Оновлена логіка оновлення токенів: повторна спроба при тимчасових помилках, негайний вихід при остаточній відмові.

* **Improvements**
  * Тривалість access token збільшено з 15 хв до 24 год.
  * Поліпшено адаптивність і стилі вкладок на сторінках «Активність» та «Збережені».
  * Покращено поведінку поповера сповіщень і навігаційні взаємодії.

* **Tests**
  * Оновлено тести та моки для нової поведінки оновлення токенів, помилок та навігації.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->