### PR TITLE
feat(seo): comprehensive SEO optimization

### DIFF
--- a/apps/api/src/modules/catalog/application/services/catalog-sitemap.service.ts
+++ b/apps/api/src/modules/catalog/application/services/catalog-sitemap.service.ts
@@ -1,0 +1,80 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+
+import { isNull, asc } from 'drizzle-orm';
+import { eq, and } from 'drizzle-orm';
+import { type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+
+import { IngestionStatus } from '../../../../common/enums/ingestion-status.enum';
+import { MediaType } from '../../../../common/enums/media-type.enum';
+import { withDbError } from '../../../../common/utils/db-error.utils';
+import { DATABASE_CONNECTION } from '../../../../database/database.module';
+import * as schema from '../../../../database/schema';
+import { type SitemapItemDto } from '../../presentation/dtos/sitemap-item.dto';
+
+/**
+ * Provides lightweight slug + updatedAt lists for sitemap generation.
+ * Returns all non-deleted, fully-ingested items of the requested type.
+ */
+@Injectable()
+export class CatalogSitemapService {
+  private readonly logger = new Logger(CatalogSitemapService.name);
+
+  constructor(
+    @Inject(DATABASE_CONNECTION)
+    private readonly db: PostgresJsDatabase<typeof schema>,
+  ) {}
+
+  /**
+   * Returns slug and updatedAt for all active movies.
+   */
+  async getMovieSitemapItems(): Promise<SitemapItemDto[]> {
+    return withDbError('fetch movie sitemap items', this.logger, async () => {
+      const rows = await this.db
+        .select({
+          slug: schema.mediaItems.slug,
+          updatedAt: schema.mediaItems.updatedAt,
+        })
+        .from(schema.mediaItems)
+        .where(
+          and(
+            eq(schema.mediaItems.type, MediaType.MOVIE),
+            eq(schema.mediaItems.ingestionStatus, IngestionStatus.READY),
+            isNull(schema.mediaItems.deletedAt),
+          ),
+        )
+        .orderBy(asc(schema.mediaItems.slug));
+
+      return rows.map((row) => ({
+        slug: row.slug,
+        updatedAt: row.updatedAt.toISOString(),
+      }));
+    });
+  }
+
+  /**
+   * Returns slug and updatedAt for all active shows.
+   */
+  async getShowSitemapItems(): Promise<SitemapItemDto[]> {
+    return withDbError('fetch show sitemap items', this.logger, async () => {
+      const rows = await this.db
+        .select({
+          slug: schema.mediaItems.slug,
+          updatedAt: schema.mediaItems.updatedAt,
+        })
+        .from(schema.mediaItems)
+        .where(
+          and(
+            eq(schema.mediaItems.type, MediaType.SHOW),
+            eq(schema.mediaItems.ingestionStatus, IngestionStatus.READY),
+            isNull(schema.mediaItems.deletedAt),
+          ),
+        )
+        .orderBy(asc(schema.mediaItems.slug));
+
+      return rows.map((row) => ({
+        slug: row.slug,
+        updatedAt: row.updatedAt.toISOString(),
+      }));
+    });
+  }
+}

--- a/apps/api/src/modules/catalog/catalog.module.ts
+++ b/apps/api/src/modules/catalog/catalog.module.ts
@@ -10,6 +10,7 @@ import { UserMediaModule } from '../user-media/user-media.module';
 
 import { CatalogImportService } from './application/services/catalog-import.service';
 import { CatalogSearchService } from './application/services/catalog-search.service';
+import { CatalogSitemapService } from './application/services/catalog-sitemap.service';
 import { CatalogUserStateEnricher } from './application/services/catalog-userstate-enricher.service';
 import { MovieDetailsService } from './application/services/movie-details.service';
 import { ShowDetailsService } from './application/services/show-details.service';
@@ -50,6 +51,7 @@ import { CatalogMoviesController } from './presentation/controllers/catalog.movi
 import { CatalogProvidersController } from './presentation/controllers/catalog.providers.controller';
 import { CatalogSearchController } from './presentation/controllers/catalog.search.controller';
 import { CatalogShowsController } from './presentation/controllers/catalog.shows.controller';
+import { CatalogSitemapController } from './presentation/controllers/catalog.sitemap.controller';
 
 /**
  * Catalog module.
@@ -67,10 +69,12 @@ import { CatalogShowsController } from './presentation/controllers/catalog.shows
     CatalogShowsController,
     CatalogSearchController,
     CatalogProvidersController,
+    CatalogSitemapController,
   ],
   providers: [
     CatalogSearchService,
     CatalogImportService,
+    CatalogSitemapService,
     CatalogUserStateEnricher,
     MovieDetailsService,
     ShowDetailsService,

--- a/apps/api/src/modules/catalog/presentation/controllers/catalog.sitemap.controller.ts
+++ b/apps/api/src/modules/catalog/presentation/controllers/catalog.sitemap.controller.ts
@@ -1,0 +1,41 @@
+import { Controller, Get, UseFilters } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+
+import { CatalogSitemapService } from '../../application/services/catalog-sitemap.service';
+import { SitemapResponseDto } from '../dtos/sitemap-item.dto';
+import { CatalogDomainExceptionFilter } from '../filters';
+
+/**
+ * Public sitemap endpoints for movies and shows.
+ * No authentication required — consumed by the Next.js sitemap.ts generator.
+ */
+@ApiTags('Public: Catalog')
+@UseFilters(CatalogDomainExceptionFilter)
+@Controller('catalog/sitemap')
+export class CatalogSitemapController {
+  constructor(private readonly sitemapService: CatalogSitemapService) {}
+
+  @Get('movies')
+  @ApiOperation({
+    summary: 'Movie sitemap data',
+    description:
+      'Returns slug and updatedAt for all active movies. Intended for sitemap generation.',
+  })
+  @ApiOkResponse({ type: SitemapResponseDto })
+  async getMovieSitemap(): Promise<SitemapResponseDto> {
+    const items = await this.sitemapService.getMovieSitemapItems();
+    return { items };
+  }
+
+  @Get('shows')
+  @ApiOperation({
+    summary: 'Show sitemap data',
+    description:
+      'Returns slug and updatedAt for all active shows. Intended for sitemap generation.',
+  })
+  @ApiOkResponse({ type: SitemapResponseDto })
+  async getShowSitemap(): Promise<SitemapResponseDto> {
+    const items = await this.sitemapService.getShowSitemapItems();
+    return { items };
+  }
+}

--- a/apps/api/src/modules/catalog/presentation/dtos/sitemap-item.dto.ts
+++ b/apps/api/src/modules/catalog/presentation/dtos/sitemap-item.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * A single item in the sitemap response, containing slug and last-modified timestamp.
+ */
+export class SitemapItemDto {
+  @ApiProperty({ description: 'URL-friendly identifier for the media item' })
+  slug: string;
+
+  @ApiProperty({ description: 'ISO 8601 timestamp of when the item was last updated' })
+  updatedAt: string;
+}
+
+/**
+ * Sitemap response wrapping a flat list of slugs and their last-modified timestamps.
+ */
+export class SitemapResponseDto {
+  @ApiProperty({ type: [SitemapItemDto] })
+  items: SitemapItemDto[];
+}

--- a/apps/web-client/src/app/(main)/about/page.tsx
+++ b/apps/web-client/src/app/(main)/about/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { getDictionary } from '@/shared/i18n';
+import { createCanonical } from '@/shared/utils/seo';
 
 const dict = getDictionary('uk');
 
@@ -8,6 +9,7 @@ const GITHUB_URL = 'https://github.com/eurusik/ratingo';
 export const metadata: Metadata = {
   title: dict.about.meta.title,
   description: dict.about.meta.description,
+  ...createCanonical('/about'),
 };
 
 export default function AboutPage() {

--- a/apps/web-client/src/app/(main)/browse/[category]/page.tsx
+++ b/apps/web-client/src/app/(main)/browse/[category]/page.tsx
@@ -8,6 +8,7 @@ import type { Route } from 'next';
 import { notFound } from 'next/navigation';
 import { getDictionary, getByPath } from '@/shared/i18n';
 import { catalogApi } from '@/core/api';
+import { JsonLd, createCanonical } from '@/shared/utils/seo';
 import {
   getCategoryConfig,
   getSortOptions,
@@ -48,6 +49,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   return {
     title,
     description,
+    ...createCanonical(`/browse/${category}`),
     openGraph: {
       title: `${title} | Ratingo`,
       description,
@@ -143,8 +145,30 @@ export default async function BrowsePage({ params, searchParams }: PageProps) {
   // Check if this category has pool selector
   const hasPoolSelector = categoryHasPoolSelector(config);
 
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'https://ratingo.top';
+
+  const breadcrumbJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      {
+        '@type': 'ListItem',
+        position: 1,
+        name: 'Головна',
+        item: baseUrl,
+      },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: title,
+        item: `${baseUrl}/browse/${category}`,
+      },
+    ],
+  };
+
   return (
     <main className="min-h-screen bg-cinema-page">
+      <JsonLd data={breadcrumbJsonLd} />
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-8">
           <BrowsePageHeader

--- a/apps/web-client/src/app/(main)/journal/[slug]/page.tsx
+++ b/apps/web-client/src/app/(main)/journal/[slug]/page.tsx
@@ -7,6 +7,7 @@ import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { getDictionary } from '@/shared/i18n';
 import { getJournalPost } from '@/core/api/journal.server';
+import { JsonLd, createCanonical, SEO_BASE_URL } from '@/shared/utils/seo';
 import { JournalPostPageClient } from './client';
 
 // ISR: Revalidate every 10 minutes
@@ -36,6 +37,7 @@ export async function generateMetadata({ params }: PageParams): Promise<Metadata
   return {
     title: `${title} | ${dict.journal.title}`,
     description,
+    ...createCanonical(`/journal/${post.slug}`),
     openGraph: {
       title,
       description,
@@ -54,8 +56,44 @@ export default async function JournalPostPage({ params }: PageParams) {
     notFound();
   }
 
+  const breadcrumbJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Головна', item: SEO_BASE_URL },
+      { '@type': 'ListItem', position: 2, name: 'Журнал', item: `${SEO_BASE_URL}/journal` },
+      { '@type': 'ListItem', position: 3, name: post.title, item: `${SEO_BASE_URL}/journal/${post.slug}` },
+    ],
+  };
+
+  const articleJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: post.title,
+    description: post.metaDescription ?? post.excerpt ?? undefined,
+    image: post.featuredImageUrl ?? undefined,
+    datePublished: post.publishedAt,
+    dateModified: post.updatedAt ?? post.publishedAt,
+    author: {
+      '@type': 'Organization',
+      name: 'Ratingo',
+      url: SEO_BASE_URL,
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: 'Ratingo',
+      logo: { '@type': 'ImageObject', url: `${SEO_BASE_URL}/icon.png` },
+    },
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': `${SEO_BASE_URL}/journal/${post.slug}`,
+    },
+  };
+
   return (
     <div className="min-h-screen bg-cinema-page">
+      <JsonLd data={breadcrumbJsonLd} />
+      <JsonLd data={articleJsonLd} />
       <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <JournalPostPageClient post={post} />
       </div>

--- a/apps/web-client/src/app/(main)/journal/page.tsx
+++ b/apps/web-client/src/app/(main)/journal/page.tsx
@@ -7,6 +7,7 @@
 import type { Metadata } from 'next';
 import { getDictionary } from '@/shared/i18n';
 import { getJournalPosts } from '@/core/api/journal.server';
+import { createCanonical } from '@/shared/utils/seo';
 import { JournalPageClient } from './client';
 
 const dict = getDictionary('uk');
@@ -14,6 +15,7 @@ const dict = getDictionary('uk');
 export const metadata: Metadata = {
   title: dict.journal.title,
   description: dict.journal.description,
+  ...createCanonical('/journal'),
 };
 
 // ISR: Revalidate every 60 seconds

--- a/apps/web-client/src/app/(main)/movies/[slug]/page.tsx
+++ b/apps/web-client/src/app/(main)/movies/[slug]/page.tsx
@@ -6,7 +6,7 @@
 import type { Metadata } from 'next';
 import { Film } from 'lucide-react';
 import { getDictionary } from '@/shared/i18n';
-import { createMediaMetadata, createNotFoundMetadata } from '@/shared/utils';
+import { createMediaMetadata, createNotFoundMetadata, JsonLd } from '@/shared/utils';
 import { catalogApi, type MovieDetailsDto } from '@/core/api';
 import { getReviewsForMedia } from '@/core/api/reviews.server';
 import {
@@ -43,7 +43,7 @@ export async function generateMetadata({ params }: PageParams): Promise<Metadata
 
   try {
     const movie = await catalogApi.getMovieBySlug(slug);
-    return createMediaMetadata(movie, { type: 'movie' });
+    return createMediaMetadata(movie, { type: 'movie', slug });
   } catch {
     return createNotFoundMetadata('movie');
   }
@@ -137,8 +137,35 @@ export default async function MovieDetailsPage({ params }: MovieDetailsPageProps
     ? dict.details.verdict.movie[verdict.messageKey as MovieVerdictMessageKey]
     : null;
 
+  const movieJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Movie',
+    name: movie.title,
+    description: movie.overview ?? undefined,
+    image: movie.poster?.medium ?? movie.backdrop?.large ?? undefined,
+    datePublished: movie.releaseDate || undefined,
+    genre: movie.genres?.map((g) => g.name) ?? undefined,
+    ...(movie.stats?.ratingoScore != null &&
+      movie.stats.communityRatingCount != null &&
+      movie.stats.communityRatingCount > 0 && {
+        aggregateRating: {
+          '@type': 'AggregateRating',
+          ratingValue: movie.stats.ratingoScore,
+          bestRating: 100,
+          ratingCount: movie.stats.communityRatingCount,
+        },
+      }),
+    director: movie.credits?.crew
+      ?.filter((c) => c.job === 'Director')
+      .map((c) => ({ '@type': 'Person', name: c.name })) ?? undefined,
+    actor: movie.credits?.cast
+      ?.slice(0, 5)
+      .map((c) => ({ '@type': 'Person', name: c.name })) ?? undefined,
+  };
+
   return (
     <DetailsPageClient breadcrumb={dict.browse.movies.title} backUrl="/browse/movies">
+      <JsonLd data={movieJsonLd} />
       <main className="min-h-screen">
         <DetailsHero
           title={movie.title}

--- a/apps/web-client/src/app/(main)/page.tsx
+++ b/apps/web-client/src/app/(main)/page.tsx
@@ -5,6 +5,7 @@
 // Revalidate every 60 seconds to keep trending data fresh
 export const revalidate = 60;
 
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import {
   MediaCardServer,
@@ -20,6 +21,15 @@ import { getDictionary } from '@/shared/i18n';
 import { LazySection } from '@/shared/components';
 import { catalogApi, type HeroData, type WatchingNowData } from '@/core/api';
 import { TrendingUp, Clapperboard, Sparkles, Film } from 'lucide-react';
+
+const _dict = getDictionary('uk');
+const _baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'https://ratingo.top';
+
+export const metadata: Metadata = {
+  title: _dict.meta.defaultTitle,
+  description: _dict.meta.defaultDescription,
+  alternates: { canonical: _baseUrl },
+};
 
 export default async function HomePage() {
   const dict = getDictionary('uk');

--- a/apps/web-client/src/app/(main)/shows/[slug]/page.tsx
+++ b/apps/web-client/src/app/(main)/shows/[slug]/page.tsx
@@ -6,7 +6,7 @@ import { cache } from 'react';
 import type { Metadata } from 'next';
 import { Tv } from 'lucide-react';
 import { getDictionary } from '@/shared/i18n';
-import { createMediaMetadata, createNotFoundMetadata } from '@/shared/utils';
+import { createMediaMetadata, createNotFoundMetadata, JsonLd } from '@/shared/utils';
 import { catalogApi, type ShowDetailsDto } from '@/core/api';
 import { getReviewsForMedia } from '@/core/api/reviews.server';
 import {
@@ -55,7 +55,7 @@ export async function generateMetadata({ params }: PageParams): Promise<Metadata
   if (!show) {
     return createNotFoundMetadata('show');
   }
-  return createMediaMetadata(show, { type: 'show' });
+  return createMediaMetadata(show, { type: 'show', slug });
 }
 
 interface ShowDetailsPageProps {
@@ -150,8 +150,32 @@ export default async function ShowDetailsPage({ params }: ShowDetailsPageProps) 
       ]
     : apiShow.verdict?.context || undefined;
 
+  const showJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'TVSeries',
+    name: show.title,
+    description: show.overview ?? undefined,
+    image: show.poster?.medium ?? undefined,
+    startDate: show.releaseDate || undefined,
+    endDate: show.lastAirDate ?? undefined,
+    numberOfSeasons: show.totalSeasons ?? undefined,
+    numberOfEpisodes: show.totalEpisodes ?? undefined,
+    genre: show.genres?.map((g) => g.name) ?? undefined,
+    ...(show.stats?.ratingoScore != null &&
+      show.stats.communityRatingCount != null &&
+      show.stats.communityRatingCount > 0 && {
+        aggregateRating: {
+          '@type': 'AggregateRating',
+          ratingValue: show.stats.ratingoScore,
+          bestRating: 100,
+          ratingCount: show.stats.communityRatingCount,
+        },
+      }),
+  };
+
   return (
     <DetailsPageClient breadcrumb={dict.browse.shows.title} backUrl="/browse/shows">
+      <JsonLd data={showJsonLd} />
       <main className="min-h-screen">
         <DetailsHero
           title={show.title}

--- a/apps/web-client/src/app/layout.tsx
+++ b/apps/web-client/src/app/layout.tsx
@@ -11,6 +11,7 @@ import { SpeedInsights } from '@vercel/speed-insights/next';
 import { AppProviders } from '@/core/providers';
 import { GoogleAnalytics } from '@/shared/components';
 import { getDictionary } from '@/shared/i18n';
+import { JsonLd, buildOrganizationJsonLd, SEO_BASE_URL } from '@/shared/utils/seo';
 import './globals.css';
 
 const inter = Inter({
@@ -40,7 +41,7 @@ export const metadata: Metadata = {
   authors: [{ name: 'Ratingo' }],
   creator: 'Ratingo',
   publisher: 'Ratingo',
-  metadataBase: new URL(process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3002'),
+  metadataBase: new URL(process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3002'),
   openGraph: {
     type: 'website',
     locale: 'uk_UA',
@@ -90,6 +91,7 @@ interface RootLayoutProps {
 }
 
 export default function RootLayout({ children }: RootLayoutProps) {
+  const baseUrl = SEO_BASE_URL;
   return (
     <html lang="uk" className={inter.variable} suppressHydrationWarning>
       <body className="min-h-screen bg-cinema-page font-sans antialiased" suppressHydrationWarning>
@@ -99,6 +101,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
             __html: `window.__pwaPrompt=null;window.addEventListener("beforeinstallprompt",function(e){e.preventDefault();window.__pwaPrompt=e})`,
           }}
         />
+        <JsonLd data={buildOrganizationJsonLd(baseUrl)} />
         <AppProviders>
           {children}
         </AppProviders>

--- a/apps/web-client/src/app/layout.tsx
+++ b/apps/web-client/src/app/layout.tsx
@@ -41,7 +41,7 @@ export const metadata: Metadata = {
   authors: [{ name: 'Ratingo' }],
   creator: 'Ratingo',
   publisher: 'Ratingo',
-  metadataBase: new URL(process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3002'),
+  metadataBase: new URL(SEO_BASE_URL),
   openGraph: {
     type: 'website',
     locale: 'uk_UA',

--- a/apps/web-client/src/app/not-found.tsx
+++ b/apps/web-client/src/app/not-found.tsx
@@ -2,8 +2,14 @@
  * Custom 404 page.
  */
 
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { Button } from '@/shared/ui';
+
+export const metadata: Metadata = {
+  title: 'Сторінку не знайдено',
+  robots: { index: false, follow: false },
+};
 
 export default function NotFound() {
   return (

--- a/apps/web-client/src/app/robots.ts
+++ b/apps/web-client/src/app/robots.ts
@@ -1,0 +1,25 @@
+import type { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'https://ratingo.top';
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: [
+          '/admin',
+          '/auth',
+          '/settings',
+          '/api',
+          '/~offline',
+          '/activity',
+          '/calendar',
+          '/saved',
+          '/notifications',
+        ],
+      },
+    ],
+    sitemap: `${baseUrl}/sitemap.xml`,
+  };
+}

--- a/apps/web-client/src/app/sitemap.ts
+++ b/apps/web-client/src/app/sitemap.ts
@@ -1,10 +1,50 @@
 /**
  * Dynamic sitemap generation.
- * Includes static pages and dynamic journal posts.
+ * Includes static pages, dynamic journal posts, movies, and shows.
  */
 
 import type { MetadataRoute } from 'next';
 import { journalApi } from '@/core/api/journal.client';
+import { apiGet } from '@/core/api/client';
+
+/** Single entry returned by the catalog sitemap endpoints. */
+interface SitemapItem {
+  slug: string;
+  updatedAt: string;
+}
+
+/** Response shape from GET /catalog/sitemap/movies and GET /catalog/sitemap/shows. */
+interface CatalogSitemapResponse {
+  items: SitemapItem[];
+}
+
+/**
+ * Fetches movie slugs for sitemap generation.
+ * Returns an empty array on failure so the sitemap remains valid.
+ */
+async function fetchMoviesSitemap(): Promise<SitemapItem[]> {
+  try {
+    const response = await apiGet<CatalogSitemapResponse>('catalog/sitemap/movies');
+    return response.items;
+  } catch {
+    console.error('Failed to fetch movies sitemap');
+    return [];
+  }
+}
+
+/**
+ * Fetches show slugs for sitemap generation.
+ * Returns an empty array on failure so the sitemap remains valid.
+ */
+async function fetchShowsSitemap(): Promise<SitemapItem[]> {
+  try {
+    const response = await apiGet<CatalogSitemapResponse>('catalog/sitemap/shows');
+    return response.items;
+  } catch {
+    console.error('Failed to fetch shows sitemap');
+    return [];
+  }
+}
 
 const BASE_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://ratingo.top';
 
@@ -36,20 +76,40 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: page.priority,
   }));
 
-  // Journal posts
+  // Fetch journal posts, movies, and shows in parallel
   let journalEntries: MetadataRoute.Sitemap = [];
-  try {
-    const response = await journalApi.getPosts({ limit: 100 });
-    journalEntries = response.posts.map((post) => ({
-      url: `${BASE_URL}/journal/${post.slug}`,
-      lastModified: new Date(post.publishedAt),
-      changeFrequency: 'weekly' as const,
-      priority: 0.7,
-    }));
-  } catch {
-    // If API fails, continue without journal entries
-    console.error('Failed to fetch journal posts for sitemap');
-  }
+  const [movieItems, showItems] = await Promise.all([
+    fetchMoviesSitemap(),
+    fetchShowsSitemap(),
+    // Journal posts fetched separately to preserve its own error handling pattern
+    journalApi
+      .getPosts({ limit: 100 })
+      .then((response) => {
+        journalEntries = response.posts.map((post) => ({
+          url: `${BASE_URL}/journal/${post.slug}`,
+          lastModified: new Date(post.publishedAt),
+          changeFrequency: 'weekly' as const,
+          priority: 0.7,
+        }));
+      })
+      .catch(() => {
+        console.error('Failed to fetch journal posts for sitemap');
+      }),
+  ]);
 
-  return [...staticEntries, ...journalEntries];
+  const movieEntries: MetadataRoute.Sitemap = movieItems.map(({ slug, updatedAt }) => ({
+    url: `${BASE_URL}/movies/${slug}`,
+    lastModified: new Date(updatedAt),
+    changeFrequency: 'weekly' as const,
+    priority: 0.7,
+  }));
+
+  const showEntries: MetadataRoute.Sitemap = showItems.map(({ slug, updatedAt }) => ({
+    url: `${BASE_URL}/shows/${slug}`,
+    lastModified: new Date(updatedAt),
+    changeFrequency: 'weekly' as const,
+    priority: 0.7,
+  }));
+
+  return [...staticEntries, ...journalEntries, ...movieEntries, ...showEntries];
 }

--- a/apps/web-client/src/app/sitemap.ts
+++ b/apps/web-client/src/app/sitemap.ts
@@ -46,6 +46,28 @@ async function fetchShowsSitemap(): Promise<SitemapItem[]> {
   }
 }
 
+/**
+ * Fetches all journal posts across all pages for sitemap generation.
+ * Paginates through all available posts (max 50 per page).
+ */
+async function fetchAllJournalPosts() {
+  const PAGE_SIZE = 50;
+  const firstPage = await journalApi.getPosts({ limit: PAGE_SIZE, page: 1 });
+  const allPosts = [...firstPage.posts];
+  const totalPages = Math.ceil(firstPage.meta.total / PAGE_SIZE);
+
+  if (totalPages > 1) {
+    const remaining = await Promise.all(
+      Array.from({ length: totalPages - 1 }, (_, i) =>
+        journalApi.getPosts({ limit: PAGE_SIZE, page: i + 2 }).then((r) => r.posts),
+      ),
+    );
+    allPosts.push(...remaining.flat());
+  }
+
+  return allPosts;
+}
+
 const BASE_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://ratingo.top';
 
 /**
@@ -82,10 +104,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     fetchMoviesSitemap(),
     fetchShowsSitemap(),
     // Journal posts fetched separately to preserve its own error handling pattern
-    journalApi
-      .getPosts({ limit: 100 })
-      .then((response) => {
-        journalEntries = response.posts.map((post) => ({
+    fetchAllJournalPosts()
+      .then((posts) => {
+        journalEntries = posts.map((post) => ({
           url: `${BASE_URL}/journal/${post.slug}`,
           lastModified: new Date(post.publishedAt),
           changeFrequency: 'weekly' as const,

--- a/apps/web-client/src/app/sitemap.ts
+++ b/apps/web-client/src/app/sitemap.ts
@@ -4,19 +4,12 @@
  */
 
 import type { MetadataRoute } from 'next';
+import type { components } from '@ratingo/api-contract';
 import { journalApi } from '@/core/api/journal.client';
 import { apiGet } from '@/core/api/client';
 
-/** Single entry returned by the catalog sitemap endpoints. */
-interface SitemapItem {
-  slug: string;
-  updatedAt: string;
-}
-
-/** Response shape from GET /catalog/sitemap/movies and GET /catalog/sitemap/shows. */
-interface CatalogSitemapResponse {
-  items: SitemapItem[];
-}
+type SitemapItem = components['schemas']['SitemapItemDto'];
+type CatalogSitemapResponse = components['schemas']['SitemapResponseDto'];
 
 /**
  * Fetches movie slugs for sitemap generation.

--- a/apps/web-client/src/shared/utils/index.ts
+++ b/apps/web-client/src/shared/utils/index.ts
@@ -11,4 +11,13 @@ export {
 } from './format';
 export { resolveMediaImageUrl, IMAGE_SIZES, MEDIA_IMAGE_BASE } from './image';
 export { pluralize } from './pluralize';
-export { createMediaMetadata, createNotFoundMetadata, type SeoMediaItem } from './seo';
+export {
+  SEO_BASE_URL,
+  createMediaMetadata,
+  createNotFoundMetadata,
+  createCanonical,
+  JsonLd,
+  buildOrganizationJsonLd,
+  type SeoMediaItem,
+  type CreateMetadataOptions,
+} from './seo';

--- a/apps/web-client/src/shared/utils/seo.tsx
+++ b/apps/web-client/src/shared/utils/seo.tsx
@@ -21,6 +21,8 @@ export interface CreateMetadataOptions {
   fallbackTitle?: string;
   /** Fallback description if media not found. */
   fallbackDescription?: string;
+  /** URL slug for canonical link generation (e.g. "breaking-bad-2008"). */
+  slug?: string;
 }
 
 /**
@@ -56,9 +58,13 @@ export function createMediaMetadata(
   // Prefer backdrop for OG image, fallback to poster
   const ogImage = backdropUrl || posterUrl;
 
+  // Build canonical URL when slug is provided
+  const canonical = options.slug ? createCanonical(`/${options.type === 'show' ? 'shows' : 'movies'}/${options.slug}`) : undefined;
+
   return {
     title,
     description,
+    ...(canonical ?? {}),
     openGraph: {
       title: `${title} | Ratingo`,
       description,
@@ -88,5 +94,60 @@ export function createNotFoundMetadata(type: 'show' | 'movie'): Metadata {
   return {
     title,
     description: title,
+  };
+}
+
+/**
+ * Canonical base URL for the site.
+ * Centralised here so all SEO helpers use the same env var.
+ */
+export const SEO_BASE_URL = process.env.NEXT_PUBLIC_APP_URL ?? 'https://ratingo.top';
+
+/**
+ * Returns an `alternates.canonical` object for use in Next.js Metadata.
+ *
+ * @param path - Absolute path starting with `/` (e.g. `/shows/breaking-bad-2008`)
+ * @returns Object with `alternates.canonical` set to the full URL
+ *
+ * @example
+ * export const metadata: Metadata = {
+ *   ...createCanonical('/shows/breaking-bad-2008'),
+ * };
+ */
+export function createCanonical(path: string): { alternates: { canonical: string } } {
+  return { alternates: { canonical: `${SEO_BASE_URL}${path}` } };
+}
+
+/**
+ * Inline JSON-LD script component for structured data.
+ * Safe to use in Server Components — dangerouslySetInnerHTML is serialized on the server.
+ *
+ * `<` is escaped to `\u003c` to prevent premature `</script>` tag closure
+ * if user-generated content contains that sequence.
+ */
+export function JsonLd({ data }: { data: Record<string, unknown> }) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data).replace(/</g, '\\u003c') }}
+    />
+  );
+}
+
+/**
+ * Builds an Organization schema.org JSON-LD object for the root layout.
+ *
+ * @param baseUrl - The canonical base URL of the site
+ * @returns Schema.org Organization object
+ */
+export function buildOrganizationJsonLd(baseUrl: string): Record<string, unknown> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    name: 'Ratingo',
+    url: baseUrl,
+    logo: `${baseUrl}/icon.png`,
+    description: 'Український сервіс для відкриття стрімінгового контенту — серіали та фільми',
+    sameAs: ['https://github.com/ratingo'],
   };
 }

--- a/apps/web-client/src/shared/utils/seo.tsx
+++ b/apps/web-client/src/shared/utils/seo.tsx
@@ -101,7 +101,7 @@ export function createNotFoundMetadata(type: 'show' | 'movie'): Metadata {
  * Canonical base URL for the site.
  * Centralised here so all SEO helpers use the same env var.
  */
-export const SEO_BASE_URL = process.env.NEXT_PUBLIC_APP_URL ?? 'https://ratingo.top';
+export const SEO_BASE_URL = (process.env.NEXT_PUBLIC_APP_URL ?? 'https://ratingo.top').trim().replace(/\/$/, '');
 
 /**
  * Returns an `alternates.canonical` object for use in Next.js Metadata.

--- a/packages/api-contract/src/api-types.ts
+++ b/packages/api-contract/src/api-types.ts
@@ -312,6 +312,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/catalog/sitemap/movies": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Movie sitemap data
+         * @description Returns slug and updatedAt for all active movies. Intended for sitemap generation.
+         */
+        get: operations["CatalogSitemapController_getMovieSitemap"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/catalog/sitemap/shows": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Show sitemap data
+         * @description Returns slug and updatedAt for all active shows. Intended for sitemap generation.
+         */
+        get: operations["CatalogSitemapController_getShowSitemap"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/user-media/batch-ratings": {
         parameters: {
             query?: never;
@@ -3086,6 +3126,15 @@ export interface components {
         ProvidersListDto: {
             data: components["schemas"]["ProviderDto"][];
             meta: components["schemas"]["OffsetPaginationMetaDto"];
+        };
+        SitemapItemDto: {
+            /** @description URL-friendly identifier for the media item */
+            slug: string;
+            /** @description ISO 8601 timestamp of when the item was last updated */
+            updatedAt: string;
+        };
+        SitemapResponseDto: {
+            items: components["schemas"]["SitemapItemDto"][];
         };
         BatchRatingsResponseDto: {
             /**
@@ -6368,6 +6417,52 @@ export interface operations {
                         /** @enum {boolean} */
                         success: true;
                         data: components["schemas"]["ProvidersListDto"];
+                    };
+                };
+            };
+        };
+    };
+    CatalogSitemapController_getMovieSitemap: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {boolean} */
+                        success: true;
+                        data: components["schemas"]["SitemapResponseDto"];
+                    };
+                };
+            };
+        };
+    };
+    CatalogSitemapController_getShowSitemap: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {boolean} */
+                        success: true;
+                        data: components["schemas"]["SitemapResponseDto"];
                     };
                 };
             };


### PR DESCRIPTION
## Summary

- **robots.ts** — crawl rules (disallow admin/auth/settings/api/calendar/saved)
- **sitemap.ts** — dynamic sitemap with movies, shows, journal posts + static pages
- **JSON-LD structured data** — Organization (root), Movie, TVSeries, Article, BreadcrumbList
- **Canonical URLs** — всі публічні сторінки
- **API endpoints** — `GET /catalog/sitemap/movies|shows` для sitemap генерації
- **SEO utils** — `JsonLd` (XSS-safe), `SEO_BASE_URL`, `createCanonical`, `buildOrganizationJsonLd`
- **Fixes** — `aggregateRating` guard (no fake ratingCount=1), уніфікований `NEXT_PUBLIC_APP_URL`

## Test plan

- [ ] `curl https://ratingo.top/robots.txt` — перевірити disallow rules
- [ ] `curl https://ratingo.top/sitemap.xml` — перевірити наявність movies/shows/journal
- [ ] Google Rich Results Test на `/movies/[slug]` та `/shows/[slug]` — Movie/TVSeries schema
- [ ] Chrome DevTools → View Source → `application/ld+json` на journal post
- [ ] `npm run build:client` — чистий білд без помилок ✅
- [ ] `npm test` — 267 suites, 3679 тестів ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Нові функції**
  * Додано публічні API‑ендпоїнти для карти сайту фільмів і серіалів.
  * Розширено клієнтський sitemap: тепер включає фільми, серіали та записи журналу, завантаження виконане паралельно.
  * Покращено SEO: канонічні URL для сторінок, JSON‑LD для статей, хлібних крихт, медіа та організації.
  * Додано маршрут для robots.txt із переліком заборонених шляхів та посиланням на sitemap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->