### PR TITLE
feat(images): proxy TMDB images through own domain for edge caching

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,18 @@
+# Environment variables for API
+# Copy this file to .env and fill in the values
+
+# Database
+DATABASE_URL=postgresql://ratingo:ratingo_dev_password@localhost:5434/ratingo_v2
+
+# Redis
+REDIS_URL=redis://localhost:6379
+
+# TMDB API
+TMDB_API_KEY=your_tmdb_api_key
+
+# Auth JWT Secrets (min 32 chars)
+ACCESS_TOKEN_SECRET=your-access-secret-min-32-chars-long
+REFRESH_TOKEN_SECRET=your-refresh-secret-min-32-chars-long
+
+# Image proxy base URL (Cloudflare Worker) — optional, defaults to TMDB direct
+# IMAGE_PROXY_BASE_URL=https://img.ratingo.top/tmdb

--- a/apps/api/src/common/mappers/image.mapper.spec.ts
+++ b/apps/api/src/common/mappers/image.mapper.spec.ts
@@ -1,5 +1,10 @@
 import { ImageMapper } from './image.mapper';
 
+// Guard: ensure env var doesn't leak into tests and change expected URLs
+beforeAll(() => {
+  delete process.env.IMAGE_PROXY_BASE_URL;
+});
+
 describe('ImageMapper', () => {
   describe('toPoster', () => {
     it('should map poster path to ImageData with correct URLs', () => {

--- a/apps/api/src/common/mappers/image.mapper.ts
+++ b/apps/api/src/common/mappers/image.mapper.ts
@@ -1,6 +1,6 @@
 import type { ImageData } from '../types';
 
-const TMDB_BASE_URL = 'https://image.tmdb.org/t/p';
+const TMDB_BASE_URL = process.env.IMAGE_PROXY_BASE_URL || 'https://image.tmdb.org/t/p';
 
 /**
  * Maps TMDB image paths to full URLs with multiple sizes.

--- a/apps/web-client/.env.example
+++ b/apps/web-client/.env.example
@@ -10,5 +10,5 @@ NEXT_PUBLIC_SITE_URL=http://localhost:3002
 # Google Analytics 4 Measurement ID (optional)
 # NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX
 
-# Image proxy base URL (Cloudflare Worker)
-# NEXT_PUBLIC_IMAGE_BASE_URL=https://img.ratingo.top/tmdb
+# Image proxy origin (Cloudflare Worker) — enables TMDB + TVMaze proxying
+# NEXT_PUBLIC_IMAGE_PROXY_ORIGIN=https://img.ratingo.top

--- a/apps/web-client/.env.example
+++ b/apps/web-client/.env.example
@@ -9,3 +9,6 @@ NEXT_PUBLIC_SITE_URL=http://localhost:3002
 
 # Google Analytics 4 Measurement ID (optional)
 # NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX
+
+# Image proxy base URL (Cloudflare Worker)
+# NEXT_PUBLIC_IMAGE_BASE_URL=https://img.ratingo.top/tmdb

--- a/apps/web-client/next.config.ts
+++ b/apps/web-client/next.config.ts
@@ -28,7 +28,7 @@ const nextConfig: NextConfig = {
       {
         protocol: 'https',
         hostname: 'img.ratingo.top',
-        pathname: '/tmdb/**',
+        pathname: '/**',
       },
       {
         protocol: 'https',

--- a/apps/web-client/next.config.ts
+++ b/apps/web-client/next.config.ts
@@ -27,6 +27,11 @@ const nextConfig: NextConfig = {
       },
       {
         protocol: 'https',
+        hostname: 'img.ratingo.top',
+        pathname: '/tmdb/**',
+      },
+      {
+        protocol: 'https',
         hostname: 'static.tvmaze.com',
         pathname: '/uploads/**',
       },

--- a/apps/web-client/src/app/sw.ts
+++ b/apps/web-client/src/app/sw.ts
@@ -20,7 +20,7 @@ const serwist = new Serwist({
   navigationPreload: true,
   runtimeCaching: [
     {
-      matcher: /^https:\/\/image\.tmdb\.org\/t\/p\/.*/i,
+      matcher: /^https:\/\/(image\.tmdb\.org\/t\/p|img\.ratingo\.top\/tmdb)\/.*/i,
       handler: new CacheFirst({
         cacheName: 'tmdb-images',
         plugins: [
@@ -33,7 +33,7 @@ const serwist = new Serwist({
       }),
     },
     {
-      matcher: /^https:\/\/static\.tvmaze\.com\/.*/i,
+      matcher: /^https:\/\/(static\.tvmaze\.com|img\.ratingo\.top\/tvmaze)\/.*/i,
       handler: new CacheFirst({
         cacheName: 'tvmaze-images',
         plugins: [

--- a/apps/web-client/src/modules/details/components/cast-carousel.tsx
+++ b/apps/web-client/src/modules/details/components/cast-carousel.tsx
@@ -8,6 +8,7 @@
 import { Carousel } from '@/shared/components/carousel';
 import { useTranslation } from '@/shared/i18n';
 import { Avatar, AvatarImage, AvatarFallback } from '@/shared/ui';
+import { resolveMediaImageUrl, IMAGE_SIZES } from '@/shared/utils/image';
 import type { CastMember, CrewMember } from '../types';
 
 export interface CastCarouselProps {
@@ -24,8 +25,7 @@ function PersonAvatar({
   role: string;
 }) {
   const getProfileUrl = (path: string | null) => {
-    if (!path) return null;
-    return `https://image.tmdb.org/t/p/w185${path}`;
+    return resolveMediaImageUrl(path, IMAGE_SIZES.W185);
   };
 
   const getInitials = (name: string) => {

--- a/apps/web-client/src/modules/home/components/new-episode-card.tsx
+++ b/apps/web-client/src/modules/home/components/new-episode-card.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import type { NewEpisodeItem } from '@/core/api/catalog.client';
+import { resolveMediaImageUrl, IMAGE_SIZES } from '@/shared/utils/image';
 
 interface NewEpisodeCardProps {
   item: NewEpisodeItem;
@@ -68,7 +69,7 @@ export function NewEpisodeCard({ item, locale = 'uk' }: NewEpisodeCardProps) {
       <div className="relative w-16 h-24 flex-shrink-0 rounded-md overflow-hidden bg-cinema-elevated">
         {item.posterPath ? (
           <Image
-            src={`https://image.tmdb.org/t/p/w154${item.posterPath}`}
+            src={resolveMediaImageUrl(item.posterPath, IMAGE_SIZES.W154)!}
             alt={item.title}
             fill
             className="object-cover"

--- a/apps/web-client/src/modules/home/components/new-episode-card.tsx
+++ b/apps/web-client/src/modules/home/components/new-episode-card.tsx
@@ -69,7 +69,7 @@ export function NewEpisodeCard({ item, locale = 'uk' }: NewEpisodeCardProps) {
       <div className="relative w-16 h-24 flex-shrink-0 rounded-md overflow-hidden bg-cinema-elevated">
         {item.posterPath ? (
           <Image
-            src={resolveMediaImageUrl(item.posterPath, IMAGE_SIZES.W154)!}
+            src={resolveMediaImageUrl(item.posterPath, IMAGE_SIZES.W154) ?? ''}
             alt={item.title}
             fill
             className="object-cover"

--- a/apps/web-client/src/shared/utils/__tests__/image.spec.ts
+++ b/apps/web-client/src/shared/utils/__tests__/image.spec.ts
@@ -1,0 +1,45 @@
+import { resolveMediaImageUrl, IMAGE_SIZES, MEDIA_IMAGE_BASE } from '../image';
+
+describe('resolveMediaImageUrl', () => {
+  describe('without proxy (default)', () => {
+    it('returns null for null/undefined path', () => {
+      expect(resolveMediaImageUrl(null)).toBeNull();
+      expect(resolveMediaImageUrl(undefined)).toBeNull();
+    });
+
+    it('returns null for empty string', () => {
+      expect(resolveMediaImageUrl('')).toBeNull();
+    });
+
+    it('builds TMDB URL from relative path', () => {
+      expect(resolveMediaImageUrl('/abc.jpg')).toBe(`${MEDIA_IMAGE_BASE}/w342/abc.jpg`);
+    });
+
+    it('uses specified size for TMDB path', () => {
+      expect(resolveMediaImageUrl('/abc.jpg', IMAGE_SIZES.W185)).toBe(
+        `${MEDIA_IMAGE_BASE}/w185/abc.jpg`,
+      );
+    });
+
+    it('returns TVMaze full URL as-is when proxy not configured', () => {
+      const tvmazeUrl = 'https://static.tvmaze.com/uploads/images/original_untouched/603/1509946.jpg';
+      expect(resolveMediaImageUrl(tvmazeUrl)).toBe(tvmazeUrl);
+    });
+
+    it('returns Railway full URL as-is', () => {
+      const railwayUrl = 'https://storage.railway.app/some/image.jpg';
+      expect(resolveMediaImageUrl(railwayUrl)).toBe(railwayUrl);
+    });
+
+    it('returns any full http URL as-is', () => {
+      const url = 'https://example.com/image.jpg';
+      expect(resolveMediaImageUrl(url)).toBe(url);
+    });
+  });
+
+  describe('MEDIA_IMAGE_BASE', () => {
+    it('defaults to TMDB when no env var set', () => {
+      expect(MEDIA_IMAGE_BASE).toBe('https://image.tmdb.org/t/p');
+    });
+  });
+});

--- a/apps/web-client/src/shared/utils/image.ts
+++ b/apps/web-client/src/shared/utils/image.ts
@@ -6,6 +6,12 @@
 /** TMDB image base URL */
 export const MEDIA_IMAGE_BASE = process.env.NEXT_PUBLIC_IMAGE_BASE_URL || 'https://image.tmdb.org/t/p';
 
+/** TVMaze image proxy (derived from TMDB proxy base) */
+const TVMAZE_IMAGE_ORIGIN = 'https://static.tvmaze.com/uploads/images/';
+const TVMAZE_IMAGE_PROXY = process.env.NEXT_PUBLIC_IMAGE_BASE_URL
+  ? process.env.NEXT_PUBLIC_IMAGE_BASE_URL.replace('/tmdb', '/tvmaze/')
+  : null;
+
 /** Common image sizes */
 export const IMAGE_SIZES = {
   /** 92px - tiny thumbnails */
@@ -40,7 +46,11 @@ export function resolveMediaImageUrl(
   size: string = IMAGE_SIZES.W342,
 ): string | null {
   if (!path) return null;
-  // Full URL (TVMaze, Railway, etc.) - return as-is
+  // TVMaze full URL - rewrite to proxy if configured
+  if (TVMAZE_IMAGE_PROXY && path.startsWith(TVMAZE_IMAGE_ORIGIN)) {
+    return path.replace(TVMAZE_IMAGE_ORIGIN, TVMAZE_IMAGE_PROXY);
+  }
+  // Other full URLs (Railway, etc.) - return as-is
   if (path.startsWith('http')) return path;
   // TMDB path - build full URL
   return `${MEDIA_IMAGE_BASE}/${size}${path}`;

--- a/apps/web-client/src/shared/utils/image.ts
+++ b/apps/web-client/src/shared/utils/image.ts
@@ -1,18 +1,28 @@
 /**
  * Media image URL utilities.
  * Handles images from different sources (TMDB, TVMaze, etc.)
+ *
+ * Proxy: when NEXT_PUBLIC_IMAGE_PROXY_ORIGIN is set (e.g. https://img.ratingo.top),
+ * TMDB images route through {origin}/tmdb/ and TVMaze through {origin}/tvmaze/.
+ * Backend handles TMDB proxy via IMAGE_PROXY_BASE_URL env var separately.
+ * TVMaze URLs are stored as full URLs in DB and rewritten client-side only.
  */
 
-/** TMDB image base URL */
-export const MEDIA_IMAGE_BASE = process.env.NEXT_PUBLIC_IMAGE_BASE_URL || 'https://image.tmdb.org/t/p';
+/** Image proxy origin (e.g. https://img.ratingo.top) */
+const IMAGE_PROXY_ORIGIN = process.env.NEXT_PUBLIC_IMAGE_PROXY_ORIGIN || null;
 
-/** TVMaze image proxy (derived from TMDB proxy base) */
+/** TMDB image base URL */
+export const MEDIA_IMAGE_BASE = IMAGE_PROXY_ORIGIN
+  ? `${IMAGE_PROXY_ORIGIN}/tmdb`
+  : 'https://image.tmdb.org/t/p';
+
+/** TVMaze image proxy */
 const TVMAZE_IMAGE_ORIGIN = 'https://static.tvmaze.com/uploads/images/';
-const TVMAZE_IMAGE_PROXY = process.env.NEXT_PUBLIC_IMAGE_BASE_URL
-  ? process.env.NEXT_PUBLIC_IMAGE_BASE_URL.replace('/tmdb', '/tvmaze/')
+const TVMAZE_IMAGE_PROXY = IMAGE_PROXY_ORIGIN
+  ? `${IMAGE_PROXY_ORIGIN}/tvmaze/`
   : null;
 
-/** Common image sizes */
+/** Common image sizes (TMDB-specific, TVMaze images don't use size prefixes) */
 export const IMAGE_SIZES = {
   /** 92px - tiny thumbnails */
   W92: 'w92',
@@ -34,7 +44,8 @@ export const IMAGE_SIZES = {
 
 /**
  * Resolves media image URL from different sources.
- * - Full URLs (TVMaze, etc.) - returned as-is
+ * - TVMaze full URLs - rewritten to proxy if configured
+ * - Other full URLs (Railway, etc.) - returned as-is
  * - TMDB paths - prepends TMDB base URL with size
  *
  * @param path - Image path or full URL

--- a/apps/web-client/src/shared/utils/image.ts
+++ b/apps/web-client/src/shared/utils/image.ts
@@ -4,7 +4,7 @@
  */
 
 /** TMDB image base URL */
-export const MEDIA_IMAGE_BASE = 'https://image.tmdb.org/t/p';
+export const MEDIA_IMAGE_BASE = process.env.NEXT_PUBLIC_IMAGE_BASE_URL || 'https://image.tmdb.org/t/p';
 
 /** Common image sizes */
 export const IMAGE_SIZES = {


### PR DESCRIPTION
## Summary
- Route TMDB image URLs through `img.ratingo.top` instead of directly hitting `image.tmdb.org`, enabling Cloudflare Cache Rules on our proxied domain
- Backend and frontend image base URLs are now env-var driven (`IMAGE_PROXY_BASE_URL` / `NEXT_PUBLIC_IMAGE_BASE_URL`) with TMDB fallback for local dev
- Replaced hardcoded TMDB URLs in `cast-carousel` and `new-episode-card` with shared `resolveMediaImageUrl` utility

## Test plan
- [x] `npm run test:api` — 267 suites, 3679 tests pass
- [x] `npm run test:client` — 54 suites, 650 tests pass
- [x] `npm run lint:api` — clean
- [ ] Manual: verify images load on localhost (fallback to `image.tmdb.org`)
- [ ] Deploy with env vars set to `https://img.ratingo.top/tmdb` and verify images load through proxy
- [ ] Confirm `Cf-Cache-Status: HIT` on repeated image requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примітки до випуску

* **Chores**
  * Оновлена конфігурація обслуговування зображень з підтримкою налаштовуваних джерел.
  * Додана підтримка альтернативних сервісів доставки зображень.

* **Refactor**
  * Уніфіковано обробку URL-адрес зображень в компонентах застосунку для покращеної гнучкості та консистентності.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->