### PR TITLE
feat(import): add TMDB CSV import support

### DIFF
--- a/apps/api/src/modules/user-media/domain/constants/import.constants.ts
+++ b/apps/api/src/modules/user-media/domain/constants/import.constants.ts
@@ -1,6 +1,7 @@
 export const IMPORT_SOURCE = {
   KINOBAZA: 'kinobaza',
   IMDB: 'imdb',
+  TMDB: 'tmdb',
 } as const;
 export type ImportSource = (typeof IMPORT_SOURCE)[keyof typeof IMPORT_SOURCE];
 

--- a/apps/api/src/modules/user-media/domain/value-objects/external-rating.spec.ts
+++ b/apps/api/src/modules/user-media/domain/value-objects/external-rating.spec.ts
@@ -34,8 +34,16 @@ describe('normalizeExternalRating', () => {
     expect(normalizeExternalRating(-Infinity)).toBeNull();
   });
 
-  it('clamps negative values below 1 to 10', () => {
-    expect(normalizeExternalRating(-5)).toBe(10);
+  it('converts 0.5 → 5 (TMDB half-star minimum)', () => {
+    expect(normalizeExternalRating(0.5)).toBe(5);
+  });
+
+  it('clamps values below 0.5 to 5', () => {
+    expect(normalizeExternalRating(0.3)).toBe(5);
+  });
+
+  it('clamps negative values below 0.5 to 5', () => {
+    expect(normalizeExternalRating(-5)).toBe(5);
   });
 
   it('clamps values above 10 to 100', () => {

--- a/apps/api/src/modules/user-media/domain/value-objects/external-rating.ts
+++ b/apps/api/src/modules/user-media/domain/value-objects/external-rating.ts
@@ -1,11 +1,12 @@
-const EXTERNAL_RATING_MIN = 1;
+const EXTERNAL_RATING_MIN = 0.5;
 const EXTERNAL_RATING_MAX = 10;
 const EXTERNAL_RATING_SCALE_FACTOR = 10;
 
 /**
- * Converts a 1-10 external rating to the internal 0-100 scale.
- * Clamps the input to the valid 1-10 range before scaling, so out-of-range
+ * Converts a 0.5-10 external rating to the internal 0-100 scale.
+ * Clamps the input to the valid 0.5-10 range before scaling, so out-of-range
  * values are silently corrected rather than rejected.
+ * Zero is treated as a sentinel meaning "unset" and returns null.
  */
 export function normalizeExternalRating(rating: number | null | undefined): number | null {
   if (rating == null || !Number.isFinite(rating) || rating === 0) return null;

--- a/apps/api/src/modules/user-media/presentation/dto/import-media.dto.ts
+++ b/apps/api/src/modules/user-media/presentation/dto/import-media.dto.ts
@@ -7,6 +7,7 @@ import {
   IsBoolean,
   IsIn,
   IsInt,
+  IsNumber,
   IsOptional,
   IsString,
   Matches,
@@ -48,14 +49,14 @@ export class ImportItemDto {
   tmdbId?: number;
 
   /**
-   * Raw source rating on a 1-10 scale.
+   * Raw source rating on a 0.5-10 scale (supports half-star increments for TMDB).
    * The controller normalizes this to the internal 0-100 scale before passing
-   * to the service (e.g. Kinobaza 8 → internal 80).
+   * to the service (e.g. TMDB 7.5 → internal 75, Kinobaza 8 → internal 80).
    */
-  @ApiProperty({ example: 8, required: false, nullable: true, minimum: 1, maximum: 10 })
+  @ApiProperty({ example: 8, required: false, nullable: true, minimum: 0.5, maximum: 10 })
   @IsOptional()
-  @IsInt()
-  @Min(1)
+  @IsNumber({ maxDecimalPlaces: 1 })
+  @Min(0.5)
   @Max(10)
   rating?: number;
 

--- a/apps/web-client/src/core/api/user-media.client.ts
+++ b/apps/web-client/src/core/api/user-media.client.ts
@@ -15,7 +15,7 @@ export const userMediaApi = {
     return apiGet<ImportBatchStatus[]>('user-media/import/status');
   },
 
-  async cancelImportBatches(batchIds: string[]): Promise<void> {
-    return apiPost<void>('user-media/import/cancel', { batchIds });
+  async cancelImportBatches(batchIds: string[]): Promise<{ failedBatchIds: string[] }> {
+    return apiPost<{ failedBatchIds: string[] }>('user-media/import/cancel', { batchIds });
   },
 } as const;

--- a/apps/web-client/src/modules/settings/components/import/import-source-step.tsx
+++ b/apps/web-client/src/modules/settings/components/import/import-source-step.tsx
@@ -25,7 +25,7 @@ interface SourceConfig {
 const SOURCE_CONFIGS: SourceConfig[] = [
   { id: 'kinobaza', icon: Film, available: true },
   { id: 'imdb', icon: Clapperboard, available: true },
-  { id: 'tmdb', icon: Database, available: false },
+  { id: 'tmdb', icon: Database, available: true },
   { id: 'letterboxd', icon: Aperture, available: false },
 ];
 

--- a/apps/web-client/src/modules/settings/hooks/use-import-media.ts
+++ b/apps/web-client/src/modules/settings/hooks/use-import-media.ts
@@ -33,7 +33,7 @@ export function useImportMedia() {
 
 export function useCancelImportBatches() {
   const queryClient = useQueryClient();
-  return useMutation<void, Error, string[]>({
+  return useMutation<{ failedBatchIds: string[] }, Error, string[]>({
     mutationFn: (batchIds) => userMediaApi.cancelImportBatches(batchIds),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.userMedia.importBatchStatus });

--- a/apps/web-client/src/modules/settings/utils/__tests__/csv-parsers.test.ts
+++ b/apps/web-client/src/modules/settings/utils/__tests__/csv-parsers.test.ts
@@ -5,6 +5,9 @@ import {
   detectImdbFileType,
   parseImdbRatings,
   parseImdbWatchlist,
+  detectTmdbFileType,
+  parseTmdbRatings,
+  parseTmdbWatchlist,
 } from '../csv-parsers';
 
 const RATINGS_CSV = `kinobazaua_id,imdb_id,themoviedb_id,my_rating,name_uk,name_en,year,created_at
@@ -216,6 +219,10 @@ describe('detectImdbFileType', () => {
     expect(detectImdbFileType(RATINGS_CSV)).toBe('unknown');
   });
 
+  it('returns "unknown" for TMDB CSV', () => {
+    expect(detectImdbFileType(TMDB_RATINGS_CSV)).toBe('unknown');
+  });
+
   it('handles BOM prefix correctly', () => {
     expect(detectImdbFileType(IMDB_RATINGS_CSV_WITH_BOM)).toBe('ratings');
   });
@@ -413,5 +420,197 @@ describe('detectImdbFileType — Windows line endings', () => {
     const csv =
       'Position,Const,Created,Modified,Description,Title,URL,Title Type,IMDb Rating,Runtime (mins),Year,Genres,Num Votes,Release Date,Directors,Your Rating,Date Rated\r\n1,tt0111161,2023-01-01,2023-01-01,,Shawshank,url,movie,9.3,142,1994,Drama,2800000,1994-10-14,Darabont,10,2023-01-15';
     expect(detectImdbFileType(csv)).toBe('ratings');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TMDB parsers
+// ---------------------------------------------------------------------------
+
+const TMDB_RATINGS_CSV = `TMDb ID,IMDb ID,Type,Name,Release Date,Season Number,Episode Number,Rating,Your Rating,Date Rated
+550,tt0137523,movie,Fight Club,1999-10-15,,,,8.5,2024-01-15
+27205,tt1375666,movie,Inception,2010-07-16,,,8.8,9.0,2024-01-20
+680,,movie,Pulp Fiction,1994-10-14,,,8.9,7.5,2024-02-01`;
+
+const TMDB_WATCHLIST_CSV = `TMDb ID,IMDb ID,Type,Name,Release Date,Season Number,Episode Number,Rating,Your Rating,Date Rated
+120,tt0120737,movie,The Lord of the Rings: The Fellowship of the Ring,2001-12-18,,,8.9,,2024-03-01
+278,tt0111161,movie,The Shawshank Redemption,1994-09-23,,,8.7,,2024-03-02`;
+
+describe('detectTmdbFileType', () => {
+  it('returns "ratings" when first data row has Your Rating populated', () => {
+    expect(detectTmdbFileType(TMDB_RATINGS_CSV)).toBe('ratings');
+  });
+
+  it('returns "watchlist" when first data row has empty Your Rating', () => {
+    expect(detectTmdbFileType(TMDB_WATCHLIST_CSV)).toBe('watchlist');
+  });
+
+  it('returns "unknown" for non-TMDB CSV', () => {
+    expect(detectTmdbFileType(WRONG_CSV)).toBe('unknown');
+  });
+
+  it('returns "unknown" for IMDB CSV', () => {
+    expect(detectTmdbFileType(IMDB_RATINGS_CSV)).toBe('unknown');
+  });
+
+  it('handles BOM prefix correctly', () => {
+    const withBom = '\uFEFF' + TMDB_RATINGS_CSV;
+    expect(detectTmdbFileType(withBom)).toBe('ratings');
+  });
+
+  it('returns "unknown" when headers exist but no data rows', () => {
+    const headersOnly =
+      'TMDb ID,IMDb ID,Type,Name,Release Date,Season Number,Episode Number,Rating,Your Rating,Date Rated';
+    expect(detectTmdbFileType(headersOnly)).toBe('unknown');
+  });
+
+  it('returns "unknown" for Kinobaza CSV', () => {
+    expect(detectTmdbFileType(RATINGS_CSV)).toBe('unknown');
+  });
+});
+
+describe('parseTmdbRatings', () => {
+  it('parses valid ratings CSV with decimal ratings', async () => {
+    const { items, skippedRows } = await parseTmdbRatings(TMDB_RATINGS_CSV);
+
+    expect(skippedRows).toBe(0);
+    expect(items).toHaveLength(3);
+
+    expect(items[0]).toMatchObject({
+      tmdbId: 550,
+      imdbId: 'tt0137523',
+      rating: 8.5,
+      state: 'completed',
+      title: 'Fight Club',
+      year: 1999,
+    });
+
+    expect(items[1]).toMatchObject({
+      tmdbId: 27205,
+      imdbId: 'tt1375666',
+      rating: 9.0,
+      state: 'completed',
+      title: 'Inception',
+      year: 2010,
+    });
+  });
+
+  it('handles row with both tmdbId and imdbId', async () => {
+    const { items } = await parseTmdbRatings(TMDB_RATINGS_CSV);
+    expect(items[0].tmdbId).toBe(550);
+    expect(items[0].imdbId).toBe('tt0137523');
+  });
+
+  it('handles row with missing imdbId', async () => {
+    const { items } = await parseTmdbRatings(TMDB_RATINGS_CSV);
+    // Row 3: empty IMDb ID
+    expect(items[2].tmdbId).toBe(680);
+    expect(items[2].imdbId).toBeUndefined();
+  });
+
+  it('all items have state "completed"', async () => {
+    const { items } = await parseTmdbRatings(TMDB_RATINGS_CSV);
+    expect(items.every((item) => item.state === 'completed')).toBe(true);
+  });
+
+  it('handles BOM prefix correctly', async () => {
+    const withBom = '\uFEFF' + TMDB_RATINGS_CSV;
+    const { items, skippedRows } = await parseTmdbRatings(withBom);
+    expect(skippedRows).toBe(0);
+    expect(items[0].tmdbId).toBe(550);
+  });
+
+  it('throws descriptive error for wrong headers', async () => {
+    await expect(parseTmdbRatings(WRONG_CSV)).rejects.toThrow(
+      /Invalid TMDB ratings file: missing column/,
+    );
+  });
+
+  it('skips rows with neither tmdbId nor imdbId', async () => {
+    const csv = `TMDb ID,IMDb ID,Type,Name,Release Date,Season Number,Episode Number,Rating,Your Rating,Date Rated
+0,,movie,No IDs,2020-01-01,,,5.0,8.0,2024-01-01`;
+    const { items, skippedRows } = await parseTmdbRatings(csv);
+    expect(skippedRows).toBe(1);
+    expect(items).toHaveLength(0);
+  });
+});
+
+describe('parseTmdbWatchlist', () => {
+  it('parses valid watchlist CSV', async () => {
+    const { items, skippedRows } = await parseTmdbWatchlist(TMDB_WATCHLIST_CSV);
+
+    expect(skippedRows).toBe(0);
+    expect(items).toHaveLength(2);
+
+    expect(items[0]).toMatchObject({
+      tmdbId: 120,
+      imdbId: 'tt0120737',
+      state: 'planned',
+      title: 'The Lord of the Rings: The Fellowship of the Ring',
+      year: 2001,
+    });
+
+    expect(items[1]).toMatchObject({
+      tmdbId: 278,
+      imdbId: 'tt0111161',
+      state: 'planned',
+      title: 'The Shawshank Redemption',
+      year: 1994,
+    });
+  });
+
+  it('all items have state "planned"', async () => {
+    const { items } = await parseTmdbWatchlist(TMDB_WATCHLIST_CSV);
+    expect(items.every((item) => item.state === 'planned')).toBe(true);
+  });
+
+  it('no rating field in watchlist items', async () => {
+    const { items } = await parseTmdbWatchlist(TMDB_WATCHLIST_CSV);
+    expect(items.every((item) => item.rating === undefined)).toBe(true);
+  });
+
+  it('handles BOM prefix correctly', async () => {
+    const withBom = '\uFEFF' + TMDB_WATCHLIST_CSV;
+    const { items } = await parseTmdbWatchlist(withBom);
+    expect(items[0].tmdbId).toBe(120);
+    expect(items[0].imdbId).toBe('tt0120737');
+  });
+});
+
+describe('parseTmdbRatings — edge cases', () => {
+  it('handles minimum TMDB rating 0.5', async () => {
+    const csv = `TMDb ID,IMDb ID,Type,Name,Release Date,Season Number,Episode Number,Rating,Your Rating,Date Rated
+550,tt0137523,movie,Fight Club,1999-10-15,,,8.9,0.5,2024-01-15`;
+    const { items } = await parseTmdbRatings(csv);
+    expect(items[0].rating).toBe(0.5);
+  });
+
+  it('handles row with only imdbId (no tmdbId)', async () => {
+    const csv = `TMDb ID,IMDb ID,Type,Name,Release Date,Season Number,Episode Number,Rating,Your Rating,Date Rated
+,tt0137523,movie,Fight Club,1999-10-15,,,8.9,8.0,2024-01-15`;
+    const { items, skippedRows } = await parseTmdbRatings(csv);
+    expect(skippedRows).toBe(0);
+    expect(items).toHaveLength(1);
+    expect(items[0].imdbId).toBe('tt0137523');
+    expect(items[0].tmdbId).toBeUndefined();
+  });
+
+  it('handles empty file (headers only)', async () => {
+    const csv = 'TMDb ID,IMDb ID,Type,Name,Release Date,Season Number,Episode Number,Rating,Your Rating,Date Rated';
+    const { items, skippedRows } = await parseTmdbRatings(csv);
+    expect(items).toHaveLength(0);
+    expect(skippedRows).toBe(0);
+  });
+
+  it('handles Windows line endings (CRLF)', () => {
+    const csv = 'TMDb ID,IMDb ID,Type,Name,Release Date,Season Number,Episode Number,Rating,Your Rating,Date Rated\r\n550,tt0137523,movie,Fight Club,1999-10-15,,,8.9,8.5,2024-01-15';
+    expect(detectTmdbFileType(csv)).toBe('ratings');
+  });
+
+  it('handles non-numeric Your Rating gracefully', async () => {
+    const csv = `TMDb ID,IMDb ID,Type,Name,Release Date,Season Number,Episode Number,Rating,Your Rating,Date Rated
+550,tt0137523,movie,Fight Club,1999-10-15,,,8.9,abc,2024-01-15`;
+    const { items } = await parseTmdbRatings(csv);
+    expect(items[0].rating).toBeUndefined();
   });
 });

--- a/apps/web-client/src/modules/settings/utils/csv-parsers.ts
+++ b/apps/web-client/src/modules/settings/utils/csv-parsers.ts
@@ -1,18 +1,18 @@
 /**
- * CSV parsers for Kinobaza and IMDB export files.
+ * CSV parsers for external service export files.
  *
- * Kinobaza supports two export formats:
- * - Ratings CSV (has `my_rating` column)
- * - Watchlist CSV (no `my_rating` column)
+ * Supported sources:
+ * - Kinobaza (kinobaza.com.ua): ratings + watchlist CSVs
+ * - IMDB (imdb.com): V3 format, same headers for ratings and watchlist
+ * - TMDB (themoviedb.org): same headers for ratings, watchlist, and favorites
  *
- * IMDB V3 format uses identical headers for both ratings and watchlist exports.
- * Detection is based on whether the first data row has a non-empty `Your Rating` cell.
+ * IMDB and TMDB detection samples the first data row to check if `Your Rating` is populated.
  */
 
 export interface ParsedItem {
   imdbId?: string;
   tmdbId?: number;
-  rating?: number; // raw Kinobaza 1-10, backend will normalize
+  rating?: number; // raw source rating (0.5-10 scale), backend normalizes to 0-100
   state: 'completed' | 'planned';
   title?: string;
   year?: number;
@@ -334,6 +334,161 @@ export async function parseImdbWatchlist(csvText: string): Promise<ParseResult> 
   return { items, skippedRows };
 }
 
+// ---------------------------------------------------------------------------
+// TMDB parsers
+// ---------------------------------------------------------------------------
+
+const TMDB_REQUIRED_HEADERS = ['tmdb id', 'imdb id', 'your rating', 'name'] as const;
+
+/**
+ * Detects whether a TMDB CSV export is a ratings file or a watchlist file.
+ *
+ * TMDB uses identical column headers for both export types. Detection is based
+ * on whether the first data row has a non-empty `Your Rating` cell — the same
+ * pattern used for IMDB detection.
+ */
+export function detectTmdbFileType(csvText: string): 'ratings' | 'watchlist' | 'unknown' {
+  // Strip BOM if present
+  const text = csvText.replace(/^\uFEFF/, '');
+  const lines = text.split('\n');
+
+  const firstLine = lines[0] ?? '';
+  const headers = firstLine.split(',').map((h) => h.trim().toLowerCase().replace(/"/g, ''));
+
+  if (!headers.includes('tmdb id')) {
+    return 'unknown';
+  }
+
+  const secondLine = lines[1] ?? '';
+  if (!secondLine.trim()) {
+    // No data rows — cannot determine type; treat as unknown
+    return 'unknown';
+  }
+
+  const cells = splitCsvLine(secondLine);
+  const yourRatingIndex = headers.indexOf('your rating');
+
+  if (yourRatingIndex === -1) {
+    return 'unknown';
+  }
+
+  const yourRatingCell = cells[yourRatingIndex] ?? '';
+  return yourRatingCell !== '' ? 'ratings' : 'watchlist';
+}
+
+/** Lazy-loads papaparse for bundle efficiency. */
+export async function parseTmdbRatings(csvText: string): Promise<ParseResult> {
+  const Papa = (await import('papaparse')).default;
+
+  // Strip BOM if present
+  const text = csvText.replace(/^\uFEFF/, '');
+
+  const result = Papa.parse<Record<string, string>>(text, {
+    header: true,
+    skipEmptyLines: true,
+    transformHeader: (header: string) => header.trim().toLowerCase(),
+  });
+
+  const headers = result.meta.fields ?? [];
+  for (const required of TMDB_REQUIRED_HEADERS) {
+    if (!headers.includes(required)) {
+      throw new Error(
+        `Invalid TMDB ratings file: missing column "${required}". Found: ${headers.join(', ')}`,
+      );
+    }
+  }
+
+  const items: ParsedItem[] = [];
+  let skippedRows = 0;
+
+  for (const row of result.data) {
+    const tmdbRaw = row['tmdb id']?.trim() ?? '';
+    const imdbRaw = row['imdb id']?.trim() ?? '';
+    const ratingRaw = row['your rating']?.trim() ?? '';
+    const nameRaw = row['name']?.trim() ?? '';
+    const releaseDateRaw = row['release date']?.trim() ?? '';
+
+    const tmdbId = tmdbRaw ? parseInt(tmdbRaw, 10) : NaN;
+    const validTmdbId = !isNaN(tmdbId) && tmdbId !== 0 ? tmdbId : undefined;
+    const imdbId = imdbRaw.startsWith('tt') ? imdbRaw : undefined;
+
+    if (!validTmdbId && !imdbId) {
+      skippedRows++;
+      continue;
+    }
+
+    const rating = ratingRaw ? parseFloat(ratingRaw) : undefined;
+    const yearRaw = releaseDateRaw.slice(0, 4);
+    const year = yearRaw ? parseInt(yearRaw, 10) : undefined;
+
+    items.push({
+      imdbId,
+      tmdbId: validTmdbId,
+      rating: rating !== undefined && !isNaN(rating) && rating >= 0.5 && rating <= 10 ? rating : undefined,
+      state: 'completed',
+      title: nameRaw || undefined,
+      year: year !== undefined && !isNaN(year) ? year : undefined,
+    });
+  }
+
+  return { items, skippedRows };
+}
+
+/** Lazy-loads papaparse for bundle efficiency. */
+export async function parseTmdbWatchlist(csvText: string): Promise<ParseResult> {
+  const Papa = (await import('papaparse')).default;
+
+  // Strip BOM if present
+  const text = csvText.replace(/^\uFEFF/, '');
+
+  const result = Papa.parse<Record<string, string>>(text, {
+    header: true,
+    skipEmptyLines: true,
+    transformHeader: (header: string) => header.trim().toLowerCase(),
+  });
+
+  const headers = result.meta.fields ?? [];
+  for (const required of TMDB_REQUIRED_HEADERS) {
+    if (!headers.includes(required)) {
+      throw new Error(
+        `Invalid TMDB watchlist file: missing column "${required}". Found: ${headers.join(', ')}`,
+      );
+    }
+  }
+
+  const items: ParsedItem[] = [];
+  let skippedRows = 0;
+
+  for (const row of result.data) {
+    const tmdbRaw = row['tmdb id']?.trim() ?? '';
+    const imdbRaw = row['imdb id']?.trim() ?? '';
+    const nameRaw = row['name']?.trim() ?? '';
+    const releaseDateRaw = row['release date']?.trim() ?? '';
+
+    const tmdbId = tmdbRaw ? parseInt(tmdbRaw, 10) : NaN;
+    const validTmdbId = !isNaN(tmdbId) && tmdbId !== 0 ? tmdbId : undefined;
+    const imdbId = imdbRaw.startsWith('tt') ? imdbRaw : undefined;
+
+    if (!validTmdbId && !imdbId) {
+      skippedRows++;
+      continue;
+    }
+
+    const yearRaw = releaseDateRaw.slice(0, 4);
+    const year = yearRaw ? parseInt(yearRaw, 10) : undefined;
+
+    items.push({
+      imdbId,
+      tmdbId: validTmdbId,
+      state: 'planned',
+      title: nameRaw || undefined,
+      year: year !== undefined && !isNaN(year) ? year : undefined,
+    });
+  }
+
+  return { items, skippedRows };
+}
+
 export interface SourceParserConfig {
   /** Which file slots this source supports */
   slots: ('ratings' | 'watchlist')[];
@@ -354,5 +509,11 @@ export const SOURCE_PARSERS: Record<string, SourceParserConfig> = {
     detectFileType: detectImdbFileType,
     parseRatings: parseImdbRatings,
     parseWatchlist: parseImdbWatchlist,
+  },
+  tmdb: {
+    slots: ['ratings', 'watchlist'],
+    detectFileType: detectTmdbFileType,
+    parseRatings: parseTmdbRatings,
+    parseWatchlist: parseTmdbWatchlist,
   },
 };

--- a/apps/web-client/src/shared/i18n/locales/en.json
+++ b/apps/web-client/src/shared/i18n/locales/en.json
@@ -948,9 +948,15 @@
         },
         "tmdb": {
           "name": "TMDB",
-          "desc": "Ratings from themoviedb.org",
-          "howTo": "",
-          "howToSteps": []
+          "desc": "Ratings and watchlist from themoviedb.org",
+          "howTo": "How to export your data from TMDB?",
+          "howToSteps": [
+            "Go to themoviedb.org and sign in",
+            "Go to My Ratings (or My Watchlist)",
+            "Click ⋮ (three dots) → Export CSV",
+            "The CSV file will be sent to your email",
+            "Download and drag the file into the field below"
+          ]
         },
         "letterboxd": {
           "name": "Letterboxd",

--- a/apps/web-client/src/shared/i18n/locales/uk.json
+++ b/apps/web-client/src/shared/i18n/locales/uk.json
@@ -948,9 +948,15 @@
         },
         "tmdb": {
           "name": "TMDB",
-          "desc": "Оцінки з themoviedb.org",
-          "howTo": "",
-          "howToSteps": []
+          "desc": "Оцінки та список перегляду з themoviedb.org",
+          "howTo": "Як скачати файл з TMDB?",
+          "howToSteps": [
+            "Зайдіть на themoviedb.org та увійдіть в акаунт",
+            "Перейдіть до My Ratings (або My Watchlist)",
+            "Натисніть ⋮ (три крапки) → Export CSV",
+            "CSV файл буде надіслано на вашу email",
+            "Завантажте файл і перетягніть його у відповідне поле нижче"
+          ]
         },
         "letterboxd": {
           "name": "Letterboxd",

--- a/packages/api-contract/openapi.json
+++ b/packages/api-contract/openapi.json
@@ -1974,7 +1974,29 @@
         },
         "responses": {
           "200": {
-            "description": "Batches cancelled"
+            "description": "Cancel result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/CancelImportBatchesResponseDto"
+                    }
+                  }
+                }
+              }
+            }
           },
           "400": {
             "description": "Invalid request body"
@@ -10346,6 +10368,22 @@
           "batchIds"
         ]
       },
+      "CancelImportBatchesResponseDto": {
+        "type": "object",
+        "properties": {
+          "failedBatchIds": {
+            "description": "Batch IDs that failed to cancel (not found or already terminal)",
+            "example": [],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "failedBatchIds"
+        ]
+      },
       "SetUserMediaStateDto": {
         "type": "object",
         "properties": {
@@ -10409,7 +10447,7 @@
             "type": "number",
             "example": 8,
             "nullable": true,
-            "minimum": 1,
+            "minimum": 0.5,
             "maximum": 10
           },
           "state": {
@@ -10443,7 +10481,8 @@
             "type": "string",
             "enum": [
               "kinobaza",
-              "imdb"
+              "imdb",
+              "tmdb"
             ],
             "example": "kinobaza"
           },

--- a/packages/api-contract/src/api-types.ts
+++ b/packages/api-contract/src/api-types.ts
@@ -3246,6 +3246,13 @@ export interface components {
              */
             batchIds: string[];
         };
+        CancelImportBatchesResponseDto: {
+            /**
+             * @description Batch IDs that failed to cancel (not found or already terminal)
+             * @example []
+             */
+            failedBatchIds: string[];
+        };
         SetUserMediaStateDto: {
             /**
              * @description Watch state. When omitted, preserves existing state or defaults to "completed" for movies / "watching" for shows.
@@ -3294,7 +3301,7 @@ export interface components {
              * @example kinobaza
              * @enum {string}
              */
-            source: "kinobaza" | "imdb";
+            source: "kinobaza" | "imdb" | "tmdb";
             /** @description Items to import (1–10000) */
             items: components["schemas"]["ImportItemDto"][];
             /**
@@ -6786,12 +6793,18 @@ export interface operations {
             };
         };
         responses: {
-            /** @description Batches cancelled */
+            /** @description Cancel result */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": {
+                        /** @enum {boolean} */
+                        success: true;
+                        data: components["schemas"]["CancelImportBatchesResponseDto"];
+                    };
+                };
             };
             /** @description Invalid request body */
             400: {

--- a/test-data/tmdb_ratings_test.csv
+++ b/test-data/tmdb_ratings_test.csv
@@ -1,0 +1,26 @@
+TMDb ID,IMDb ID,Type,Name,Release Date,Season Number,Episode Number,Rating,Your Rating,Date Rated
+550,tt0137523,movie,Fight Club,1999-10-15,,,8.9,9.0,2024-03-01
+27205,tt1375666,movie,Inception,2010-07-16,,,8.8,8.5,2024-03-01
+155,tt0468569,movie,The Dark Knight,2008-07-18,,,9.0,9.5,2024-03-02
+680,tt0110912,movie,Pulp Fiction,1994-10-14,,,8.7,8.0,2024-03-02
+278,tt0111161,movie,The Shawshank Redemption,1994-09-23,,,8.7,10.0,2024-03-03
+238,tt0068646,movie,The Godfather,1972-03-24,,,8.7,9.0,2024-03-03
+13,tt0109830,movie,Forrest Gump,1994-07-06,,,8.5,7.5,2024-03-04
+122,tt0167260,movie,The Lord of the Rings: The Return of the King,2003-12-17,,,8.5,9.0,2024-03-04
+424,tt0108052,movie,Schindler's List,1993-12-15,,,8.6,10.0,2024-03-05
+389,tt0050083,movie,12 Angry Men,1957-04-10,,,8.5,8.0,2024-03-05
+603,tt0133093,movie,The Matrix,1999-03-31,,,8.2,7.5,2024-03-06
+120,tt0120737,movie,The Lord of the Rings: The Fellowship of the Ring,2001-12-18,,,8.4,8.5,2024-03-06
+11,tt0076759,movie,Star Wars,1977-05-25,,,8.2,7.0,2024-03-07
+157336,tt0816692,movie,Interstellar,2014-11-07,,,8.4,9.5,2024-03-07
+496243,tt6751668,movie,Parasite,2019-05-30,,,8.5,8.5,2024-03-08
+497,tt0114369,movie,The Green Mile,1999-12-10,,,8.5,7.5,2024-03-08
+429,tt0099685,movie,Goodfellas,1990-09-19,,,8.5,8.0,2024-03-09
+769,tt0047478,movie,Seven Samurai,1954-04-26,,,8.6,8.0,2024-03-09
+346,tt0073486,movie,One Flew Over the Cuckoo's Nest,1975-11-19,,,8.4,9.0,2024-03-10
+1891,tt0080684,movie,Star Wars: Episode V - The Empire Strikes Back,1980-05-21,,,8.4,8.0,2024-03-10
+745,tt0038650,movie,It's a Wonderful Life,1946-12-20,,,8.3,7.0,2024-03-11
+694,tt0047396,movie,Rear Window,1954-01-13,,,8.3,7.5,2024-03-11
+244786,tt2582802,movie,Whiplash,2014-10-10,,,8.4,9.0,2024-03-12
+637,tt0209144,movie,Memento,2000-10-11,,,8.2,8.0,2024-03-12
+1422,tt0910970,movie,WALL·E,2008-06-22,,,8.1,7.5,2024-03-13

--- a/test-data/tmdb_watchlist_test.csv
+++ b/test-data/tmdb_watchlist_test.csv
@@ -1,0 +1,16 @@
+TMDb ID,IMDb ID,Type,Name,Release Date,Season Number,Episode Number,Rating,Your Rating,Date Rated
+129,tt0245429,movie,Spirited Away,2001-07-20,,,8.5,,2024-04-01
+539,tt0054215,movie,Psycho,1960-06-16,,,8.4,,2024-04-01
+3170,tt0064116,movie,Once Upon a Time in the West,1968-12-21,,,8.3,,2024-04-02
+348,tt0253474,movie,The Pianist,2002-09-17,,,8.4,,2024-04-02
+194,tt0211915,movie,Amélie,2001-04-25,,,8.0,,2024-04-03
+1124,tt0482571,movie,The Prestige,2006-10-19,,,8.2,,2024-04-03
+629,tt0114814,movie,The Usual Suspects,1995-07-19,,,8.2,,2024-04-04
+935,tt0056058,movie,Harakiri,1962-09-16,,,8.4,,2024-04-04
+289,tt0034583,movie,Casablanca,1942-11-26,,,8.2,,2024-04-05
+3082,tt0043014,movie,Sunset Blvd.,1950-08-10,,,8.3,,2024-04-05
+72190,tt2084970,tv,The Witcher,2019-12-20,,,8.1,,2024-04-06
+1399,tt0944947,tv,Game of Thrones,2011-04-17,,,8.4,,2024-04-06
+1396,tt0903747,tv,Breaking Bad,2008-01-20,,,8.9,,2024-04-07
+60625,tt2861424,tv,Rick and Morty,2013-12-02,,,8.7,,2024-04-07
+100088,tt13443470,tv,Wednesday,2022-11-23,,,8.5,,2024-04-08


### PR DESCRIPTION
## Summary

- Add TMDB as a third import source (after Kinobaza and IMDB)
- TMDB uses 0.5-10 half-star rating scale (vs 1-10 integer for Kinobaza/IMDB)
- Same CSV format for ratings, watchlist, and favorites exports

## Changes

### Backend
- `TMDB: 'tmdb'` added to `IMPORT_SOURCE` enum
- `normalizeExternalRating` min lowered from 1 to 0.5 for TMDB half-star scale
- DTO: `@IsNumber({ maxDecimalPlaces: 1 }) @Min(0.5)` replaces `@IsInt() @Min(1)`

### Frontend
- TMDB CSV parser with detection (samples first data row), ratings, and watchlist parsing
- Client-side rating range guard (0.5-10)
- TMDB enabled in source selection cards
- TMDB-specific howTo export instructions (uk/en)
- 22 new TMDB parser tests + 2 cross-detection tests (68 total parser tests)

## Test plan
- [x] `npm run test:api` — 3815 tests pass
- [x] `npm run test:client` — 68 parser tests pass
- [x] Manual: TMDB ratings import — 2 imported, 38 already in library
- [ ] Manual: TMDB watchlist import
- [ ] Kinobaza + IMDB import regression check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Примітки випуску

* **Нові можливості**
  * Увімкнено імпорт з TMDB у UI та додано парсинг TMDB (рейтинги і список перегляду)
  * Рейтинги тепер підтримують шкалу 0.5–10 з половинними кроками; імпорт приймає десяткові значення (напр., 7.5)

* **Документація**
  * Оновлено довідки та покрокові інструкції експорту TMDB для англійської та української мов

* **Тести**
  * Додано тести для парсерів TMDB (рейтинги, watchlist)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->