### PR TITLE
fix(episode-progress): chunk batch requests to respect 200 limit

### DIFF
--- a/apps/web-client/src/core/api/episode-progress.client.ts
+++ b/apps/web-client/src/core/api/episode-progress.client.ts
@@ -16,6 +16,22 @@ export type ShowProgressDto = components['schemas']['ShowProgressDto'];
 type BatchEpisodeIdsDto = components['schemas']['BatchEpisodeIdsDto'];
 
 // ============================================================================
+// Helpers
+// ============================================================================
+
+/** Must match MAX_BATCH_EPISODE_IDS from apps/api/.../episode-progress.constants.ts */
+const BATCH_LIMIT = 200;
+
+/** Splits an array into chunks of at most `size` elements. */
+function chunk<T>(arr: T[], size: number): T[][] {
+  const result: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) {
+    result.push(arr.slice(i, i + size));
+  }
+  return result;
+}
+
+// ============================================================================
 // API Client
 // ============================================================================
 
@@ -47,7 +63,11 @@ export const episodeProgressApi = {
    * @returns void (204 No Content)
    */
   async markBatchWatched(episodeIds: string[]): Promise<void> {
-    return apiPost<void>('user-media/episodes/batch/watch', { episodeIds } satisfies BatchEpisodeIdsDto);
+    if (episodeIds.length === 0) return;
+    const chunks = chunk(episodeIds, BATCH_LIMIT);
+    for (const batch of chunks) {
+      await apiPost<void>('user-media/episodes/batch/watch', { episodeIds: batch } satisfies BatchEpisodeIdsDto);
+    }
   },
 
   /**
@@ -57,7 +77,11 @@ export const episodeProgressApi = {
    * @returns void (204 No Content)
    */
   async markBatchUnwatched(episodeIds: string[]): Promise<void> {
-    return apiPost<void>('user-media/episodes/batch/unwatch', { episodeIds } satisfies BatchEpisodeIdsDto);
+    if (episodeIds.length === 0) return;
+    const chunks = chunk(episodeIds, BATCH_LIMIT);
+    for (const batch of chunks) {
+      await apiPost<void>('user-media/episodes/batch/unwatch', { episodeIds: batch } satisfies BatchEpisodeIdsDto);
+    }
   },
 
   /**

--- a/apps/web-client/src/core/query/__tests__/episode-progress.test.tsx
+++ b/apps/web-client/src/core/query/__tests__/episode-progress.test.tsx
@@ -684,7 +684,7 @@ describe('useMarkAllEpisodesWatched', () => {
     });
   });
 
-  it('rolls back optimistic update on error', async () => {
+  it('invalidates cache on error instead of rolling back (partial chunks may have succeeded)', async () => {
     const initialProgress = buildProgress([
       buildSeason(1, 3, ['ep-1']),
       buildSeason(2, 2, []),
@@ -696,6 +696,7 @@ describe('useMarkAllEpisodesWatched', () => {
     );
 
     mockMarkBatchWatched.mockRejectedValue(new Error('server error'));
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
 
     renderWithClient(<MarkAllConsumer />, queryClient);
 
@@ -707,14 +708,13 @@ describe('useMarkAllEpisodesWatched', () => {
       expect(screen.getByTestId('mutation-status').textContent).toBe('error');
     });
 
-    const rolledBack = queryClient.getQueryData<ShowProgressDto>(
-      queryKeys.episodeProgress.showProgress(SHOW_ID),
+    // On error, cache is invalidated (not rolled back) because partial chunks
+    // may have already succeeded on the server.
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: queryKeys.episodeProgress.showProgress(SHOW_ID),
+      }),
     );
-
-    expect(rolledBack!.seasons[0].watchedEpisodeIds).toEqual(['ep-1']);
-    expect(rolledBack!.seasons[0].watchedCount).toBe(1);
-    expect(rolledBack!.seasons[1].watchedEpisodeIds).toEqual([]);
-    expect(rolledBack!.seasons[1].watchedCount).toBe(0);
   });
 
   it('invalidates all related caches on settled', async () => {

--- a/apps/web-client/src/core/query/episode-progress.ts
+++ b/apps/web-client/src/core/query/episode-progress.ts
@@ -244,13 +244,11 @@ export function useMarkAllEpisodesWatched(showId: string) {
       return { previousProgress };
     },
 
-    onError: (_error, _variables, context) => {
-      if (context?.previousProgress) {
-        queryClient.setQueryData(
-          queryKeys.episodeProgress.showProgress(showId),
-          context.previousProgress,
-        );
-      }
+    onError: () => {
+      // Partial chunks may have already succeeded on the server,
+      // so rolling back to a stale snapshot would show incorrect state.
+      // Force refetch to get the true server state instead.
+      invalidateEpisodeProgressCaches(queryClient, showId);
     },
 
     onSettled: () => {


### PR DESCRIPTION
## Summary
- Auto-chunk `markBatchWatched` and `markBatchUnwatched` into sequential requests of ≤200 IDs each
- Shows like Grey's Anatomy (500+ episodes) or One Piece (1000+) now work correctly
- On error, invalidate cache instead of rolling back stale snapshot (partial chunks may have succeeded)
- Add empty array guard to both batch methods

## Changes
- **Modified**: `episode-progress.client.ts` — chunk helper, BATCH_LIMIT constant, sequential batch loop
- **Modified**: `episode-progress.ts` — `useMarkAllEpisodesWatched` onError: invalidate instead of rollback
- **Modified**: `episode-progress.test.tsx` — updated test for new error behavior

## Test plan
- [x] `npm run build:client` — passes
- [x] `npm run test:client` — 783 tests pass
- [ ] Manual: catch-up on a show with 200+ aired episodes → verify multiple requests sent
- [ ] Manual: simulate network error mid-batch → verify cache invalidation (no stale rollback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Поправки та покращення

* **Виправлення помилок**
  * Поліпшена обробка помилок при позначенні епізодів — система тепер синхронізуватиме дані з сервером для забезпечення коректного стану.

* **Покращення продуктивності**
  * Оптимізована обробка великих партій позначень епізодів як переглянутих і не переглянутих для більшої надійності та стійкості системи.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->