### PR TITLE
fix(history): completed tab queries history instead of ratings

### DIFF
--- a/apps/web-client/src/modules/saved/hooks/__tests__/use-me-lists.test.tsx
+++ b/apps/web-client/src/modules/saved/hooks/__tests__/use-me-lists.test.tsx
@@ -46,7 +46,7 @@ jest.mock('@/core/api/me-lists.client', () => ({
 import { meListsApi } from '@/core/api/me-lists.client';
 
 const mockGetActivity = meListsApi.getActivity as jest.Mock;
-const mockGetRatings = meListsApi.getRatings as jest.Mock;
+const mockGetHistory = meListsApi.getHistory as jest.Mock;
 const mockGetPaused = meListsApi.getPaused as jest.Mock;
 const mockGetDropped = meListsApi.getDropped as jest.Mock;
 const mockPauseMedia = meListsApi.pauseMedia as jest.Mock;
@@ -338,13 +338,13 @@ describe('useCompleted', () => {
     queryClient.clear();
   });
 
-  it('filters rated items to only completed state', async () => {
+  it('filters history items to only completed state', async () => {
     const items = [
-      makeHistoryItem({ mediaItemId: 'w1', state: 'watching', rating: 70 }),
-      makeHistoryItem({ mediaItemId: 'c1', state: 'completed', rating: 80 }),
-      makeHistoryItem({ mediaItemId: 'c2', state: 'completed', rating: 90 }),
+      makeHistoryItem({ mediaItemId: 'w1', state: 'watching' }),
+      makeHistoryItem({ mediaItemId: 'c1', state: 'completed' }),
+      makeHistoryItem({ mediaItemId: 'c2', state: 'completed' }),
     ];
-    mockGetRatings.mockResolvedValue(makeHistoryResponse(items));
+    mockGetHistory.mockResolvedValue(makeHistoryResponse(items));
 
     renderWithClient(<CompletedConsumer />, queryClient);
 
@@ -361,9 +361,9 @@ describe('useCompleted', () => {
 
   it('returns empty array when no completed items exist', async () => {
     const items = [
-      makeHistoryItem({ mediaItemId: 'w1', state: 'watching', rating: 70 }),
+      makeHistoryItem({ mediaItemId: 'w1', state: 'watching' }),
     ];
-    mockGetRatings.mockResolvedValue(makeHistoryResponse(items));
+    mockGetHistory.mockResolvedValue(makeHistoryResponse(items));
 
     renderWithClient(<CompletedConsumer />, queryClient);
 
@@ -375,7 +375,7 @@ describe('useCompleted', () => {
   });
 
   it('passes sort parameter to the API call', async () => {
-    mockGetRatings.mockResolvedValue(makeHistoryResponse([]));
+    mockGetHistory.mockResolvedValue(makeHistoryResponse([]));
 
     renderWithClient(<CompletedConsumer sort="releaseDate" />, queryClient);
 
@@ -383,7 +383,7 @@ describe('useCompleted', () => {
       expect(screen.getByTestId('status').textContent).toBe('success');
     });
 
-    expect(mockGetRatings).toHaveBeenCalledWith(expect.objectContaining({ sort: 'releaseDate' }));
+    expect(mockGetHistory).toHaveBeenCalledWith(expect.objectContaining({ sort: 'releaseDate' }));
   });
 
   it('does not fetch when enabled is false', async () => {
@@ -393,7 +393,7 @@ describe('useCompleted', () => {
       await new Promise((r) => setTimeout(r, 50));
     });
 
-    expect(mockGetRatings).not.toHaveBeenCalled();
+    expect(mockGetHistory).not.toHaveBeenCalled();
     expect(screen.getByTestId('status').textContent).toBe('pending');
   });
 });

--- a/apps/web-client/src/modules/saved/hooks/use-me-lists.ts
+++ b/apps/web-client/src/modules/saved/hooks/use-me-lists.ts
@@ -22,16 +22,6 @@ interface MeListOptions {
   enabled?: boolean;
 }
 
-function useHistoryBase({ sort, limit = PAGE_SIZE, enabled = true }: MeListOptions = {}) {
-  return useQuery({
-    queryKey: queryKeys.meLists.history(sort, limit),
-    queryFn: () => meListsApi.getHistory({ sort, limit }),
-    enabled,
-    staleTime: STALE_5_MIN,
-    placeholderData: keepPreviousData,
-  });
-}
-
 export function useWatching({ limit = PAGE_SIZE, enabled = true }: MeListOptions = {}) {
   return useQuery({
     queryKey: queryKeys.meLists.activity(limit),
@@ -44,8 +34,8 @@ export function useWatching({ limit = PAGE_SIZE, enabled = true }: MeListOptions
 
 export function useCompleted({ sort, limit = PAGE_SIZE, enabled = true }: MeListOptions = {}) {
   const query = useQuery({
-    queryKey: queryKeys.meLists.ratings(sort, limit),
-    queryFn: () => meListsApi.getRatings({ sort, limit }),
+    queryKey: queryKeys.meLists.history(sort, limit),
+    queryFn: () => meListsApi.getHistory({ sort, limit }),
     enabled,
     staleTime: STALE_5_MIN,
     placeholderData: keepPreviousData,
@@ -56,9 +46,6 @@ export function useCompleted({ sort, limit = PAGE_SIZE, enabled = true }: MeList
       query.data
         ? {
             ...query.data,
-            // Filter is intentional: /me/ratings returns ALL rated items including those
-            // still in WATCHING state (user gave a mid-watch rating). We only want
-            // fully COMPLETED items for the history list.
             data: query.data.data.filter((item) => item.state === USER_MEDIA_STATE.COMPLETED),
           }
         : undefined,


### PR DESCRIPTION
## Summary
- `useCompleted` fetched `/me/ratings` which only returns items with a user rating — shows marked as completed via episode progress (without a rating) never appeared in the "Completed" tab
- Switched to `/me/history` and filter client-side by `state === 'completed'` so all finished shows are visible
- Removed unused `useHistoryBase` hook

## Test plan
- [x] `useCompleted` tests updated and passing (43/43)
- [ ] Mark all episodes of a show as watched → verify it appears in the "Completed" tab without needing a rating
- [ ] Verify shows with both a rating and completed state still appear
- [ ] Verify watching/paused items are filtered out from the completed tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примітки до релізу

* **Вирішені проблеми**
  * Виправлено отримання даних про історію користувача, яке тепер використовує коректний API
  
* **Тести**
  * Оновлено тести для відповідності змінам в отриманні даних історії

<!-- end of auto-generated comment: release notes by coderabbit.ai -->