### PR TITLE
fix(episode-progress): invalidate all me-lists tabs on progress change

### DIFF
--- a/apps/web-client/src/core/query/__tests__/episode-progress.test.tsx
+++ b/apps/web-client/src/core/query/__tests__/episode-progress.test.tsx
@@ -317,7 +317,7 @@ describe('useToggleEpisodeWatched', () => {
       expect.objectContaining({ queryKey: queryKeys.userMedia.all }),
     );
     expect(invalidateSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ queryKey: queryKeys.meLists.historyAll }),
+      expect.objectContaining({ queryKey: queryKeys.meLists.all }),
     );
     expect(invalidateSpy).toHaveBeenCalledWith(
       expect.objectContaining({ queryKey: queryKeys.userActions.savedItems.all }),
@@ -509,7 +509,7 @@ describe('useMarkMultipleWatched', () => {
       expect.objectContaining({ queryKey: queryKeys.userMedia.all }),
     );
     expect(invalidateSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ queryKey: queryKeys.meLists.historyAll }),
+      expect.objectContaining({ queryKey: queryKeys.meLists.all }),
     );
     expect(invalidateSpy).toHaveBeenCalledWith(
       expect.objectContaining({ queryKey: queryKeys.userActions.savedItems.all }),
@@ -741,7 +741,7 @@ describe('useMarkAllEpisodesWatched', () => {
       expect.objectContaining({ queryKey: queryKeys.userMedia.all }),
     );
     expect(invalidateSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ queryKey: queryKeys.meLists.historyAll }),
+      expect.objectContaining({ queryKey: queryKeys.meLists.all }),
     );
     expect(invalidateSpy).toHaveBeenCalledWith(
       expect.objectContaining({ queryKey: queryKeys.userActions.savedItems.all }),
@@ -841,7 +841,7 @@ describe('useUnmarkEpisodes', () => {
       expect.objectContaining({ queryKey: queryKeys.userMedia.all }),
     );
     expect(invalidateSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ queryKey: queryKeys.meLists.historyAll }),
+      expect.objectContaining({ queryKey: queryKeys.meLists.all }),
     );
     expect(invalidateSpy).toHaveBeenCalledWith(
       expect.objectContaining({ queryKey: queryKeys.userActions.savedItems.all }),
@@ -1077,7 +1077,7 @@ describe('useResetSeason', () => {
       expect.objectContaining({ queryKey: queryKeys.userMedia.all }),
     );
     expect(invalidateSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ queryKey: queryKeys.meLists.historyAll }),
+      expect.objectContaining({ queryKey: queryKeys.meLists.all }),
     );
     expect(invalidateSpy).toHaveBeenCalledWith(
       expect.objectContaining({ queryKey: queryKeys.userActions.savedItems.all }),

--- a/apps/web-client/src/core/query/episode-progress.ts
+++ b/apps/web-client/src/core/query/episode-progress.ts
@@ -24,7 +24,7 @@ function invalidateEpisodeProgressCaches(queryClient: QueryClient, showId: strin
     queryKey: queryKeys.userMedia.all,
   });
   queryClient.invalidateQueries({
-    queryKey: queryKeys.meLists.historyAll,
+    queryKey: queryKeys.meLists.all,
   });
   queryClient.invalidateQueries({
     queryKey: queryKeys.userActions.savedItems.all,


### PR DESCRIPTION
## Summary
- After catch-up or episode toggle, only `historyAll` query key was invalidated — shows stayed in Watching/Paused/Dropped tabs until page reload
- Replaced individual sub-key invalidations with `meLists.all` prefix key to cover all tabs (activity, history, paused, dropped, watchlist, ratings) in a single call
- Updated all 5 invalidation test assertions to match new prefix key

## Test plan
- [x] All 29 `episode-progress.test.tsx` tests pass
- [ ] Manual: open a show in "Watching" tab → catch up → verify it disappears from "Watching" and appears in "Watched"
- [ ] Manual: open a show in "Paused" tab → catch up → verify it disappears from "Paused"
- [ ] Manual: open a show in "Dropped" tab → catch up → verify it disappears from "Dropped"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Виправлення помилок

* Покращено механізм оновлення списків епізодів після позначення їх як переглянутих, непереглянутих або скидання прогресу сезону.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->