### PR TITLE
feat(saved): auto-remove from saved list after rating

### DIFF
--- a/apps/web-client/src/modules/details/components/__tests__/rating-presets.spec.tsx
+++ b/apps/web-client/src/modules/details/components/__tests__/rating-presets.spec.tsx
@@ -22,6 +22,11 @@ let mockIsAuthenticated = true;
 let mockUserMediaState: { rating: number | null } | undefined = undefined;
 let mockIsPending = false;
 
+const mockTryAutoUnsave = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../hooks/use-auto-unsave-on-rating', () => ({
+  useAutoUnsaveOnRating: (_mediaItemId: string) => ({ tryAutoUnsave: mockTryAutoUnsave }),
+}));
+
 jest.mock('@/core/auth', () => ({
   useAuth: () => ({ isAuthenticated: mockIsAuthenticated }),
   useAuthModalStore: () => ({ openLogin: mockOpenLogin }),
@@ -154,6 +159,7 @@ describe('RatingPresets', () => {
     mockOpenLogin.mockReset();
     mockToastSuccess.mockReset();
     mockToastError.mockReset();
+    mockTryAutoUnsave.mockReset().mockResolvedValue(undefined);
   });
 
   afterEach(() => {

--- a/apps/web-client/src/modules/details/components/rating-presets.tsx
+++ b/apps/web-client/src/modules/details/components/rating-presets.tsx
@@ -12,6 +12,7 @@ import { useUserMediaState, useSetRating } from '@/modules/saved/hooks/use-me-li
 import { getRatingColor } from '@/modules/reviews';
 import { RATING_PRESETS, findPresetByScore, type RatingPresetId } from '../constants/rating-presets';
 import { useMutationGuard } from '../hooks/use-mutation-guard';
+import { useAutoUnsaveOnRating } from '../hooks/use-auto-unsave-on-rating';
 import { useAutoHideTimer } from '../hooks/use-auto-hide-timer';
 import {
   type RatingPreset,
@@ -54,6 +55,7 @@ export function RatingPresets({ mediaItemId, mediaType }: RatingPresetsProps) {
 
   const presetLabels = dict.userRating.presets as Record<RatingPresetId, string>;
   const { guard } = useMutationGuard(dict.userRating.toast.error);
+  const { tryAutoUnsave } = useAutoUnsaveOnRating(mediaItemId);
 
   const hideSlider = useCallback(() => setShowSlider(false), []);
   const { schedule: scheduleHide, cancel: cancelHide, isDraggingRef } = useAutoHideTimer(hideSlider);
@@ -107,6 +109,7 @@ export function RatingPresets({ mediaItemId, mediaType }: RatingPresetsProps) {
       await setRating({ rating: preset.score, mediaType });
       showRatingToast(preset.score, preset.id);
       setSliderOverride(null);
+      await tryAutoUnsave(preset.score, preset.emoji);
     });
   };
 
@@ -129,6 +132,8 @@ export function RatingPresets({ mediaItemId, mediaType }: RatingPresetsProps) {
       await setRating({ rating: score, mediaType });
       showRatingToast(score, committedPreset.id);
       setSliderOverride(null);
+      const presetData = RATING_PRESETS.find((p) => p.id === committedPreset.id)!;
+      await tryAutoUnsave(score, presetData.emoji);
     });
   };
 

--- a/apps/web-client/src/modules/details/components/rating-presets.tsx
+++ b/apps/web-client/src/modules/details/components/rating-presets.tsx
@@ -109,7 +109,7 @@ export function RatingPresets({ mediaItemId, mediaType }: RatingPresetsProps) {
       await setRating({ rating: preset.score, mediaType });
       showRatingToast(preset.score, preset.id);
       setSliderOverride(null);
-      await tryAutoUnsave(preset.score, preset.emoji);
+      await tryAutoUnsave(preset.score, preset.emoji, userMediaState?.state);
     });
   };
 
@@ -133,7 +133,7 @@ export function RatingPresets({ mediaItemId, mediaType }: RatingPresetsProps) {
       showRatingToast(score, committedPreset.id);
       setSliderOverride(null);
       const presetData = RATING_PRESETS.find((p) => p.id === committedPreset.id)!;
-      await tryAutoUnsave(score, presetData.emoji);
+      await tryAutoUnsave(score, presetData.emoji, userMediaState?.state);
     });
   };
 

--- a/apps/web-client/src/modules/details/hooks/__tests__/use-auto-unsave-on-rating.spec.ts
+++ b/apps/web-client/src/modules/details/hooks/__tests__/use-auto-unsave-on-rating.spec.ts
@@ -1,0 +1,294 @@
+import { renderHook, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement } from 'react';
+import { useAutoUnsaveOnRating } from '../use-auto-unsave-on-rating';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockUnsaveItem = jest.fn<Promise<any>, [any]>();
+const mockSaveItem = jest.fn<Promise<any>, [any]>();
+
+jest.mock('sonner', () => ({
+  toast: jest.fn(),
+}));
+
+jest.mock('@/shared/i18n', () => ({
+  useTranslation: () => ({
+    dict: {
+      userRating: {
+        toast: {
+          removedFromSaved: '{emoji} {score} · Removed from saved',
+          undo: 'Undo',
+        },
+      },
+    },
+  }),
+}));
+
+jest.mock('@/core/query', () => ({
+  useUnsaveItem: () => ({ mutateAsync: mockUnsaveItem }),
+  useSaveItem: () => ({ mutateAsync: mockSaveItem }),
+}));
+
+import { toast } from 'sonner';
+const mockToast = toast as unknown as jest.Mock;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const MEDIA_ID = 'media-42';
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
+function seedSaveStatus(
+  queryClient: QueryClient,
+  mediaItemId: string,
+  status: { isForLater: boolean; isConsidering: boolean },
+) {
+  const { queryKeys } = jest.requireActual('@/core/query/keys');
+  queryClient.setQueryData(
+    queryKeys.userActions.savedItems.status(mediaItemId),
+    status,
+  );
+}
+
+function seedUserMediaState(
+  queryClient: QueryClient,
+  mediaItemId: string,
+  state: string,
+) {
+  const { queryKeys } = jest.requireActual('@/core/query/keys');
+  queryClient.setQueryData(
+    queryKeys.userMedia.state(mediaItemId),
+    { state, rating: 85 },
+  );
+}
+
+function renderAutoUnsaveHook(mediaItemId: string, queryClient: QueryClient) {
+  return renderHook(() => useAutoUnsaveOnRating(mediaItemId), {
+    wrapper: ({ children }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useAutoUnsaveOnRating', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = createQueryClient();
+    jest.clearAllMocks();
+    mockUnsaveItem.mockResolvedValue({ status: { isForLater: false, isConsidering: false } });
+    mockSaveItem.mockResolvedValue({ status: { isForLater: true, isConsidering: false } });
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  // =========================================================================
+  // Completed / no active state — should unsave
+  // =========================================================================
+
+  it('unsaves from for_later when state is completed', async () => {
+    seedUserMediaState(queryClient, MEDIA_ID, 'completed');
+    seedSaveStatus(queryClient, MEDIA_ID, { isForLater: true, isConsidering: false });
+    const { result } = renderAutoUnsaveHook(MEDIA_ID, queryClient);
+
+    await act(async () => {
+      await result.current.tryAutoUnsave(85, '😍');
+    });
+
+    expect(mockUnsaveItem).toHaveBeenCalledWith({
+      mediaItemId: MEDIA_ID,
+      list: 'for_later',
+      context: 'auto_on_rate',
+    });
+
+    expect(mockToast).toHaveBeenCalledWith(
+      '😍 85 · Removed from saved',
+      expect.objectContaining({
+        duration: 5000,
+        action: expect.objectContaining({ label: 'Undo' }),
+      }),
+    );
+  });
+
+  it('unsaves from considering when state is dropped', async () => {
+    seedUserMediaState(queryClient, MEDIA_ID, 'dropped');
+    seedSaveStatus(queryClient, MEDIA_ID, { isForLater: false, isConsidering: true });
+    const { result } = renderAutoUnsaveHook(MEDIA_ID, queryClient);
+
+    await act(async () => {
+      await result.current.tryAutoUnsave(15, '😐');
+    });
+
+    expect(mockUnsaveItem).toHaveBeenCalledWith({
+      mediaItemId: MEDIA_ID,
+      list: 'considering',
+      context: 'auto_on_rate',
+    });
+  });
+
+  it('unsaves when state is planned', async () => {
+    seedUserMediaState(queryClient, MEDIA_ID, 'planned');
+    seedSaveStatus(queryClient, MEDIA_ID, { isForLater: true, isConsidering: false });
+    const { result } = renderAutoUnsaveHook(MEDIA_ID, queryClient);
+
+    await act(async () => {
+      await result.current.tryAutoUnsave(75, '😊');
+    });
+
+    expect(mockUnsaveItem).toHaveBeenCalled();
+  });
+
+  it('unsaves when no user media state in cache (e.g. first-time rating)', async () => {
+    // No userMediaState seeded — cache returns undefined
+    seedSaveStatus(queryClient, MEDIA_ID, { isForLater: true, isConsidering: false });
+    const { result } = renderAutoUnsaveHook(MEDIA_ID, queryClient);
+
+    await act(async () => {
+      await result.current.tryAutoUnsave(85, '😍');
+    });
+
+    expect(mockUnsaveItem).toHaveBeenCalled();
+  });
+
+  // =========================================================================
+  // Active states — should NOT unsave
+  // =========================================================================
+
+  it('does NOT unsave when state is watching', async () => {
+    seedUserMediaState(queryClient, MEDIA_ID, 'watching');
+    seedSaveStatus(queryClient, MEDIA_ID, { isForLater: true, isConsidering: false });
+    const { result } = renderAutoUnsaveHook(MEDIA_ID, queryClient);
+
+    await act(async () => {
+      await result.current.tryAutoUnsave(85, '😍');
+    });
+
+    expect(mockUnsaveItem).not.toHaveBeenCalled();
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  it('does NOT unsave when state is paused', async () => {
+    seedUserMediaState(queryClient, MEDIA_ID, 'paused');
+    seedSaveStatus(queryClient, MEDIA_ID, { isForLater: true, isConsidering: false });
+    const { result } = renderAutoUnsaveHook(MEDIA_ID, queryClient);
+
+    await act(async () => {
+      await result.current.tryAutoUnsave(85, '😍');
+    });
+
+    expect(mockUnsaveItem).not.toHaveBeenCalled();
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  // =========================================================================
+  // Not saved — no-op
+  // =========================================================================
+
+  it('does NOT unsave when not in any saved list', async () => {
+    seedUserMediaState(queryClient, MEDIA_ID, 'completed');
+    seedSaveStatus(queryClient, MEDIA_ID, { isForLater: false, isConsidering: false });
+    const { result } = renderAutoUnsaveHook(MEDIA_ID, queryClient);
+
+    await act(async () => {
+      await result.current.tryAutoUnsave(75, '😊');
+    });
+
+    expect(mockUnsaveItem).not.toHaveBeenCalled();
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  // =========================================================================
+  // No save status cache — no-op
+  // =========================================================================
+
+  it('does NOT unsave when save status is not in cache', async () => {
+    seedUserMediaState(queryClient, MEDIA_ID, 'completed');
+    // No save status seeded
+    const { result } = renderAutoUnsaveHook(MEDIA_ID, queryClient);
+
+    await act(async () => {
+      await result.current.tryAutoUnsave(75, '😊');
+    });
+
+    expect(mockUnsaveItem).not.toHaveBeenCalled();
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  // =========================================================================
+  // Undo action re-saves to original list
+  // =========================================================================
+
+  it('undo action re-saves to the original list', async () => {
+    seedUserMediaState(queryClient, MEDIA_ID, 'completed');
+    seedSaveStatus(queryClient, MEDIA_ID, { isForLater: true, isConsidering: false });
+    const { result } = renderAutoUnsaveHook(MEDIA_ID, queryClient);
+
+    await act(async () => {
+      await result.current.tryAutoUnsave(85, '😍');
+    });
+
+    const toastCall = mockToast.mock.calls[0];
+    const undoOnClick = toastCall[1].action.onClick;
+
+    await act(async () => {
+      undoOnClick();
+    });
+
+    expect(mockSaveItem).toHaveBeenCalledWith({
+      mediaItemId: MEDIA_ID,
+      list: 'for_later',
+      context: 'undo_auto_on_rate',
+    });
+  });
+
+  // =========================================================================
+  // Unsave failure — silent, no toast
+  // =========================================================================
+
+  it('silently catches unsave errors without showing toast', async () => {
+    seedUserMediaState(queryClient, MEDIA_ID, 'completed');
+    seedSaveStatus(queryClient, MEDIA_ID, { isForLater: true, isConsidering: false });
+    mockUnsaveItem.mockRejectedValueOnce(new Error('Network error'));
+
+    const { result } = renderAutoUnsaveHook(MEDIA_ID, queryClient);
+
+    await act(async () => {
+      await result.current.tryAutoUnsave(85, '😍');
+    });
+
+    expect(mockUnsaveItem).toHaveBeenCalled();
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  // =========================================================================
+  // Prefers for_later over considering when both are true
+  // =========================================================================
+
+  it('prefers for_later when both lists are active', async () => {
+    seedUserMediaState(queryClient, MEDIA_ID, 'completed');
+    seedSaveStatus(queryClient, MEDIA_ID, { isForLater: true, isConsidering: true });
+    const { result } = renderAutoUnsaveHook(MEDIA_ID, queryClient);
+
+    await act(async () => {
+      await result.current.tryAutoUnsave(85, '😍');
+    });
+
+    expect(mockUnsaveItem).toHaveBeenCalledWith(
+      expect.objectContaining({ list: 'for_later' }),
+    );
+  });
+});

--- a/apps/web-client/src/modules/details/hooks/__tests__/use-auto-unsave-on-rating.spec.ts
+++ b/apps/web-client/src/modules/details/hooks/__tests__/use-auto-unsave-on-rating.spec.ts
@@ -59,18 +59,6 @@ function seedSaveStatus(
   );
 }
 
-function seedUserMediaState(
-  queryClient: QueryClient,
-  mediaItemId: string,
-  state: string,
-) {
-  const { queryKeys } = jest.requireActual('@/core/query/keys');
-  queryClient.setQueryData(
-    queryKeys.userMedia.state(mediaItemId),
-    { state, rating: 85 },
-  );
-}
-
 function renderAutoUnsaveHook(mediaItemId: string, queryClient: QueryClient) {
   return renderHook(() => useAutoUnsaveOnRating(mediaItemId), {
     wrapper: ({ children }) =>
@@ -100,13 +88,12 @@ describe('useAutoUnsaveOnRating', () => {
   // Completed / no active state — should unsave
   // =========================================================================
 
-  it('unsaves from for_later when state is completed', async () => {
-    seedUserMediaState(queryClient, MEDIA_ID, 'completed');
+  it('unsaves from for_later when pre-rating state is completed', async () => {
     seedSaveStatus(queryClient, MEDIA_ID, { isForLater: true, isConsidering: false });
     const { result } = renderAutoUnsaveHook(MEDIA_ID, queryClient);
 
     await act(async () => {
-      await result.current.tryAutoUnsave(85, '😍');
+      await result.current.tryAutoUnsave(85, '😍', 'completed');
     });
 
     expect(mockUnsaveItem).toHaveBeenCalledWith({
@@ -124,13 +111,12 @@ describe('useAutoUnsaveOnRating', () => {
     );
   });
 
-  it('unsaves from considering when state is dropped', async () => {
-    seedUserMediaState(queryClient, MEDIA_ID, 'dropped');
+  it('unsaves from considering when pre-rating state is dropped', async () => {
     seedSaveStatus(queryClient, MEDIA_ID, { isForLater: false, isConsidering: true });
     const { result } = renderAutoUnsaveHook(MEDIA_ID, queryClient);
 
     await act(async () => {
-      await result.current.tryAutoUnsave(15, '😐');
+      await result.current.tryAutoUnsave(15, '😐', 'dropped');
     });
 
     expect(mockUnsaveItem).toHaveBeenCalledWith({
@@ -140,25 +126,34 @@ describe('useAutoUnsaveOnRating', () => {
     });
   });
 
-  it('unsaves when state is planned', async () => {
-    seedUserMediaState(queryClient, MEDIA_ID, 'planned');
+  it('unsaves when pre-rating state is planned', async () => {
     seedSaveStatus(queryClient, MEDIA_ID, { isForLater: true, isConsidering: false });
     const { result } = renderAutoUnsaveHook(MEDIA_ID, queryClient);
 
     await act(async () => {
-      await result.current.tryAutoUnsave(75, '😊');
+      await result.current.tryAutoUnsave(75, '😊', 'planned');
     });
 
     expect(mockUnsaveItem).toHaveBeenCalled();
   });
 
-  it('unsaves when no user media state in cache (e.g. first-time rating)', async () => {
-    // No userMediaState seeded — cache returns undefined
+  it('unsaves when pre-rating state is undefined (first-time rating)', async () => {
     seedSaveStatus(queryClient, MEDIA_ID, { isForLater: true, isConsidering: false });
     const { result } = renderAutoUnsaveHook(MEDIA_ID, queryClient);
 
     await act(async () => {
-      await result.current.tryAutoUnsave(85, '😍');
+      await result.current.tryAutoUnsave(85, '😍', undefined);
+    });
+
+    expect(mockUnsaveItem).toHaveBeenCalled();
+  });
+
+  it('unsaves when pre-rating state is null (no prior entry)', async () => {
+    seedSaveStatus(queryClient, MEDIA_ID, { isForLater: true, isConsidering: false });
+    const { result } = renderAutoUnsaveHook(MEDIA_ID, queryClient);
+
+    await act(async () => {
+      await result.current.tryAutoUnsave(85, '😍', null);
     });
 
     expect(mockUnsaveItem).toHaveBeenCalled();
@@ -168,26 +163,24 @@ describe('useAutoUnsaveOnRating', () => {
   // Active states — should NOT unsave
   // =========================================================================
 
-  it('does NOT unsave when state is watching', async () => {
-    seedUserMediaState(queryClient, MEDIA_ID, 'watching');
+  it('does NOT unsave when pre-rating state is watching', async () => {
     seedSaveStatus(queryClient, MEDIA_ID, { isForLater: true, isConsidering: false });
     const { result } = renderAutoUnsaveHook(MEDIA_ID, queryClient);
 
     await act(async () => {
-      await result.current.tryAutoUnsave(85, '😍');
+      await result.current.tryAutoUnsave(85, '😍', 'watching');
     });
 
     expect(mockUnsaveItem).not.toHaveBeenCalled();
     expect(mockToast).not.toHaveBeenCalled();
   });
 
-  it('does NOT unsave when state is paused', async () => {
-    seedUserMediaState(queryClient, MEDIA_ID, 'paused');
+  it('does NOT unsave when pre-rating state is paused', async () => {
     seedSaveStatus(queryClient, MEDIA_ID, { isForLater: true, isConsidering: false });
     const { result } = renderAutoUnsaveHook(MEDIA_ID, queryClient);
 
     await act(async () => {
-      await result.current.tryAutoUnsave(85, '😍');
+      await result.current.tryAutoUnsave(85, '😍', 'paused');
     });
 
     expect(mockUnsaveItem).not.toHaveBeenCalled();
@@ -199,12 +192,11 @@ describe('useAutoUnsaveOnRating', () => {
   // =========================================================================
 
   it('does NOT unsave when not in any saved list', async () => {
-    seedUserMediaState(queryClient, MEDIA_ID, 'completed');
     seedSaveStatus(queryClient, MEDIA_ID, { isForLater: false, isConsidering: false });
     const { result } = renderAutoUnsaveHook(MEDIA_ID, queryClient);
 
     await act(async () => {
-      await result.current.tryAutoUnsave(75, '😊');
+      await result.current.tryAutoUnsave(75, '😊', 'completed');
     });
 
     expect(mockUnsaveItem).not.toHaveBeenCalled();
@@ -216,12 +208,10 @@ describe('useAutoUnsaveOnRating', () => {
   // =========================================================================
 
   it('does NOT unsave when save status is not in cache', async () => {
-    seedUserMediaState(queryClient, MEDIA_ID, 'completed');
-    // No save status seeded
     const { result } = renderAutoUnsaveHook(MEDIA_ID, queryClient);
 
     await act(async () => {
-      await result.current.tryAutoUnsave(75, '😊');
+      await result.current.tryAutoUnsave(75, '😊', 'completed');
     });
 
     expect(mockUnsaveItem).not.toHaveBeenCalled();
@@ -233,12 +223,11 @@ describe('useAutoUnsaveOnRating', () => {
   // =========================================================================
 
   it('undo action re-saves to the original list', async () => {
-    seedUserMediaState(queryClient, MEDIA_ID, 'completed');
     seedSaveStatus(queryClient, MEDIA_ID, { isForLater: true, isConsidering: false });
     const { result } = renderAutoUnsaveHook(MEDIA_ID, queryClient);
 
     await act(async () => {
-      await result.current.tryAutoUnsave(85, '😍');
+      await result.current.tryAutoUnsave(85, '😍', 'completed');
     });
 
     const toastCall = mockToast.mock.calls[0];
@@ -260,14 +249,13 @@ describe('useAutoUnsaveOnRating', () => {
   // =========================================================================
 
   it('silently catches unsave errors without showing toast', async () => {
-    seedUserMediaState(queryClient, MEDIA_ID, 'completed');
     seedSaveStatus(queryClient, MEDIA_ID, { isForLater: true, isConsidering: false });
     mockUnsaveItem.mockRejectedValueOnce(new Error('Network error'));
 
     const { result } = renderAutoUnsaveHook(MEDIA_ID, queryClient);
 
     await act(async () => {
-      await result.current.tryAutoUnsave(85, '😍');
+      await result.current.tryAutoUnsave(85, '😍', 'completed');
     });
 
     expect(mockUnsaveItem).toHaveBeenCalled();
@@ -279,12 +267,11 @@ describe('useAutoUnsaveOnRating', () => {
   // =========================================================================
 
   it('prefers for_later when both lists are active', async () => {
-    seedUserMediaState(queryClient, MEDIA_ID, 'completed');
     seedSaveStatus(queryClient, MEDIA_ID, { isForLater: true, isConsidering: true });
     const { result } = renderAutoUnsaveHook(MEDIA_ID, queryClient);
 
     await act(async () => {
-      await result.current.tryAutoUnsave(85, '😍');
+      await result.current.tryAutoUnsave(85, '😍', 'completed');
     });
 
     expect(mockUnsaveItem).toHaveBeenCalledWith(

--- a/apps/web-client/src/modules/details/hooks/use-auto-unsave-on-rating.ts
+++ b/apps/web-client/src/modules/details/hooks/use-auto-unsave-on-rating.ts
@@ -1,0 +1,59 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { queryKeys } from '@/core/query/keys';
+import { useSaveItem, useUnsaveItem } from '@/core/query';
+import { useTranslation } from '@/shared/i18n';
+import type { MediaSaveStatusDto, SavedItemList } from '@/core/api';
+import type { MeUserMediaListItemDto } from '@/core/api/me-lists.client';
+
+/** States where the user is still actively engaged — don't auto-remove. */
+const ACTIVE_STATES = new Set(['watching', 'paused']);
+
+export function useAutoUnsaveOnRating(mediaItemId: string) {
+  const queryClient = useQueryClient();
+  const { dict } = useTranslation();
+  const { mutateAsync: unsaveItem } = useUnsaveItem();
+  const { mutateAsync: saveItem } = useSaveItem();
+
+  async function tryAutoUnsave(score: number, emoji: string) {
+    // Check user media state (already updated by setRating's onSuccess)
+    const userMediaState = queryClient.getQueryData<MeUserMediaListItemDto>(
+      queryKeys.userMedia.state(mediaItemId),
+    );
+    if (userMediaState && ACTIVE_STATES.has(userMediaState.state)) return;
+
+    const saveStatus = queryClient.getQueryData<MediaSaveStatusDto>(
+      queryKeys.userActions.savedItems.status(mediaItemId),
+    );
+    if (!saveStatus) return;
+
+    let list: SavedItemList | null = null;
+    if (saveStatus.isForLater) list = 'for_later';
+    else if (saveStatus.isConsidering) list = 'considering';
+    if (!list) return;
+
+    const savedList = list;
+
+    try {
+      await unsaveItem({ mediaItemId, list: savedList, context: 'auto_on_rate' });
+
+      const message = dict.userRating.toast.removedFromSaved
+        .replace('{emoji}', emoji)
+        .replace('{score}', String(score));
+
+      toast(message, {
+        duration: 5000,
+        action: {
+          label: dict.userRating.toast.undo,
+          onClick: () => {
+            saveItem({ mediaItemId, list: savedList, context: 'undo_auto_on_rate' });
+          },
+        },
+      });
+    } catch {
+      // Rating already succeeded — silently skip unsave failure
+    }
+  }
+
+  return { tryAutoUnsave };
+}

--- a/apps/web-client/src/modules/details/hooks/use-auto-unsave-on-rating.ts
+++ b/apps/web-client/src/modules/details/hooks/use-auto-unsave-on-rating.ts
@@ -4,10 +4,10 @@ import { queryKeys } from '@/core/query/keys';
 import { useSaveItem, useUnsaveItem } from '@/core/query';
 import { useTranslation } from '@/shared/i18n';
 import type { MediaSaveStatusDto, SavedItemList } from '@/core/api';
-import type { MeUserMediaListItemDto } from '@/core/api/me-lists.client';
+import type { UserMediaState } from '@/core/api/me-lists.client';
 
 /** States where the user is still actively engaged — don't auto-remove. */
-const ACTIVE_STATES = new Set(['watching', 'paused']);
+const ACTIVE_STATES: ReadonlySet<UserMediaState> = new Set(['watching', 'paused']);
 
 export function useAutoUnsaveOnRating(mediaItemId: string) {
   const queryClient = useQueryClient();
@@ -15,12 +15,16 @@ export function useAutoUnsaveOnRating(mediaItemId: string) {
   const { mutateAsync: unsaveItem } = useUnsaveItem();
   const { mutateAsync: saveItem } = useSaveItem();
 
-  async function tryAutoUnsave(score: number, emoji: string) {
-    // Check user media state (already updated by setRating's onSuccess)
-    const userMediaState = queryClient.getQueryData<MeUserMediaListItemDto>(
-      queryKeys.userMedia.state(mediaItemId),
-    );
-    if (userMediaState && ACTIVE_STATES.has(userMediaState.state)) return;
+  /**
+   * @param preRatingState - user media state captured BEFORE the rating mutation,
+   *   so we see the real state, not the backend default assigned on first rating.
+   */
+  async function tryAutoUnsave(
+    score: number,
+    emoji: string,
+    preRatingState?: UserMediaState | null,
+  ) {
+    if (preRatingState && ACTIVE_STATES.has(preRatingState)) return;
 
     const saveStatus = queryClient.getQueryData<MediaSaveStatusDto>(
       queryKeys.userActions.savedItems.status(mediaItemId),

--- a/apps/web-client/src/shared/i18n/locales/en.json
+++ b/apps/web-client/src/shared/i18n/locales/en.json
@@ -1701,7 +1701,9 @@
     "toast": {
       "saved": "{emoji} {label} — {score}",
       "cleared": "Rating cleared",
-      "error": "Failed to save rating"
+      "error": "Failed to save rating",
+      "removedFromSaved": "{emoji} {score} · Removed from saved",
+      "undo": "Undo"
     },
     "presets": {
       "bad": "Bad",

--- a/apps/web-client/src/shared/i18n/locales/uk.json
+++ b/apps/web-client/src/shared/i18n/locales/uk.json
@@ -1701,7 +1701,9 @@
     "toast": {
       "saved": "{emoji} {label} — {score}",
       "cleared": "Оцінку прибрано",
-      "error": "Не вдалося зберегти оцінку"
+      "error": "Не вдалося зберегти оцінку",
+      "removedFromSaved": "{emoji} {score} · Видалено зі збереженого",
+      "undo": "Скасувати"
     },
     "presets": {
       "bad": "Фігня",


### PR DESCRIPTION
## Summary
- Auto-removes content from saved list when rated, unless state is `watching` or `paused`
- Shows toast with undo button (5 sec) so the user can revert
- Works for both movies and shows — uses backend `state` instead of media type to decide

Closes #83

## Test plan
- [x] 11 unit tests for `useAutoUnsaveOnRating` hook (all states covered)
- [x] 38 existing `RatingPresets` tests pass
- [x] Manual: save a movie → rate it → verify toast + removed from /saved → click undo → re-appears
- [x] Manual: save a show, start watching episodes → rate it → verify it stays in saved
- [x] Manual: save a show, mark completed → rate it → verify auto-removed
- [x] Manual: rate content not in saved → verify no extra toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Нові можливості**
  * Автоматичне видалення збережених елементів при оцінюванні, з відображенням сповіщення.
  * Сповіщення містить Emoji/оцінку та кнопку "Скасувати" для відновлення.
  * Не виконується для активних станів перегляду (наприклад, переглядаю/паузa).

* **Тести**
  * Додано покриття для різних сценаріїв автоматичного видалення та відновлення.

* **Локалізація**
  * Додано тексти для сповіщення та кнопки "Скасувати".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->