### PR TITLE
fix(activity): prevent false caught_up → watching transition on sync

### DIFF
--- a/apps/api/src/modules/user-actions/application/subscription-trigger.service.spec.ts
+++ b/apps/api/src/modules/user-actions/application/subscription-trigger.service.spec.ts
@@ -235,7 +235,7 @@ describe('SubscriptionTriggerService', () => {
       });
     });
 
-    it('should emit event even when no subscriptions are notified', async () => {
+    it('should NOT emit event when no subscriptions are notified (dedup — episode already processed)', async () => {
       const module = await Test.createTestingModule({
         providers: [
           SubscriptionTriggerService,
@@ -259,9 +259,7 @@ describe('SubscriptionTriggerService', () => {
 
       await triggerService.handleShowDiff(mockDiff);
 
-      expect(emitter.emit).toHaveBeenCalledWith('show.new-episode', {
-        mediaItemId: 'media-123',
-      });
+      expect(emitter.emit).not.toHaveBeenCalledWith('show.new-episode', expect.anything());
     });
 
     it('should NOT emit event when diff has no newEpisode', async () => {

--- a/apps/api/src/modules/user-actions/application/subscription-trigger.service.ts
+++ b/apps/api/src/modules/user-actions/application/subscription-trigger.service.ts
@@ -123,10 +123,11 @@ export class SubscriptionTriggerService {
 
     if (events.length > 0) {
       this.logger.log(`New episode ${newEpisode.key}: ${events.length} subscriptions notified`);
+      // Emit only when atomicNotifyNewEpisode confirmed a genuinely new episode.
+      // caught_up users always have subscriptions (auto-subscribed in syncStateAfterWatch),
+      // so events.length > 0 reliably indicates a new episode, not a repeated sync.
+      this.eventEmitter.emit(SHOW_EVENTS.NEW_EPISODE, { mediaItemId: diff.mediaItemId });
     }
-
-    // Always emit — caught_up users may not have subscriptions
-    this.eventEmitter.emit(SHOW_EVENTS.NEW_EPISODE, { mediaItemId: diff.mediaItemId });
 
     return events;
   }


### PR DESCRIPTION
## Summary
- Fixes bug where periodic ingestion sync falsely transitioned `caught_up` users back to `watching`
- The `show.new-episode` event was emitted unconditionally on every sync, even when no new episode aired
- Now emits only when `atomicNotifyNewEpisode` confirms the episode is genuinely new (dedup via `lastNotifiedEpisodeKey`)

## Root cause
`handleNewEpisode` reports the *current* last episode on every sync (not only when it changes). The `atomicNotifyNewEpisode` method deduplicates notifications correctly, but the event was emitted outside that guard.

## Test plan
- [x] Test: event emitted when subscriptions exist (new episode)
- [x] Test: event NOT emitted when no subscriptions notified (dedup)
- [x] Test: event NOT emitted for season-only diffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Виправлення помилок

* Оптимізовано логіку видання сповіщень про нові епізоди подій. Система тепер генерує сповіщення лише коли існують активні підписки для сповіщення користувачів. Раніше сповіщення видавались завжди, навіть при відсутності активних підписок. Це поліпшує коректність обробки та ефективність системи сповіщень.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->