### PR TITLE
feat(me-lists): tab-count badges + /me/lists/counts endpoint

### DIFF
--- a/apps/api/src/modules/user-actions/application/saved-items.service.ts
+++ b/apps/api/src/modules/user-actions/application/saved-items.service.ts
@@ -146,6 +146,17 @@ export class SavedItemsService {
   }
 
   /**
+   * Counts saved items in a given list for the user.
+   *
+   * @param {string} userId - User identifier
+   * @param {SavedItemList} list - List type
+   * @returns {Promise<number>} Count of saved items
+   */
+  async countByList(userId: string, list: SavedItemList): Promise<number> {
+    return this.savedItemRepo.count(userId, list);
+  }
+
+  /**
    * Gets save status for multiple media items in batch.
    *
    * @param {string} userId - User identifier

--- a/apps/api/src/modules/user-actions/public/index.ts
+++ b/apps/api/src/modules/user-actions/public/index.ts
@@ -13,6 +13,7 @@
 
 // Services (for cross-module use)
 export { SubscriptionTriggerService } from '../application/subscription-trigger.service';
+export { SavedItemsService } from '../application/saved-items.service';
 
 // Domain constants
 export { SHOW_EVENTS } from '../domain/constants/events.constants';
@@ -26,6 +27,8 @@ export {
 // Entity types
 export type { SubscriptionTrigger } from '../domain/entities/user-subscription.entity';
 export { SUBSCRIPTION_TRIGGER } from '../domain/entities/user-subscription.entity';
+export type { SavedItemList } from '../domain/entities';
+export { SAVED_ITEM_LIST } from '../domain/entities';
 
 // Module
 export { UserActionsModule } from '../user-actions.module';

--- a/apps/api/src/modules/user-media/application/me-lists.service.spec.ts
+++ b/apps/api/src/modules/user-media/application/me-lists.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { SavedItemsService, SAVED_ITEM_LIST } from '../../user-actions/public';
 import { MeListsService } from './me-lists.service';
 import { UserMediaService } from './user-media.service';
 import {
@@ -28,6 +29,7 @@ const mockCard: CardMeta = {
 describe('MeListsService', () => {
   let service: MeListsService;
   let userMediaService: jest.Mocked<UserMediaService>;
+  let savedItemsService: jest.Mocked<SavedItemsService>;
   let mockRepo: { listFavoriteUpdates: jest.Mock };
 
   beforeEach(async () => {
@@ -36,6 +38,10 @@ describe('MeListsService', () => {
       listWithMedia: jest.fn(),
       countActivityWithMedia: jest.fn(),
       listActivityWithMedia: jest.fn(),
+    };
+
+    const mockSavedItemsService = {
+      countByList: jest.fn(),
     };
 
     mockRepo = {
@@ -53,11 +59,16 @@ describe('MeListsService', () => {
           provide: USER_MEDIA_STATE_REPOSITORY,
           useValue: mockRepo,
         },
+        {
+          provide: SavedItemsService,
+          useValue: mockSavedItemsService,
+        },
       ],
     }).compile();
 
     service = module.get<MeListsService>(MeListsService);
     userMediaService = module.get(UserMediaService);
+    savedItemsService = module.get(SavedItemsService);
   });
 
   describe('getRatings', () => {
@@ -389,6 +400,28 @@ describe('MeListsService', () => {
         expect.objectContaining({
           states: expect.arrayContaining([USER_MEDIA_STATE.PAUSED]),
         }),
+      );
+    });
+
+    it('should narrow states to [completed] when state=completed is provided', async () => {
+      const userId = 'user-1';
+      const limit = 10;
+      const offset = 0;
+
+      userMediaService.countWithMedia.mockResolvedValue(0);
+      userMediaService.listWithMedia.mockResolvedValue([]);
+
+      await service.getHistory(userId, limit, offset, undefined, undefined, USER_MEDIA_STATE.COMPLETED);
+
+      expect(userMediaService.countWithMedia).toHaveBeenCalledWith(userId, {
+        states: [USER_MEDIA_STATE.COMPLETED],
+        type: undefined,
+      });
+      expect(userMediaService.listWithMedia).toHaveBeenCalledWith(
+        userId,
+        limit,
+        offset,
+        expect.objectContaining({ states: [USER_MEDIA_STATE.COMPLETED] }),
       );
     });
   });
@@ -726,6 +759,85 @@ describe('MeListsService', () => {
       const result = await service.getFavoriteUpdates(userId);
 
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('getListCounts', () => {
+    it('aggregates strict state counts from user-media and saved-items services', async () => {
+      const userId = 'user-1';
+      userMediaService.countWithMedia.mockImplementation(async (_userId, options) => {
+        if (options?.states?.includes(USER_MEDIA_STATE.WATCHING)) return 3;
+        if (options?.states?.includes(USER_MEDIA_STATE.PAUSED)) return 2;
+        if (options?.states?.includes(USER_MEDIA_STATE.DROPPED)) return 5;
+        if (options?.states?.includes(USER_MEDIA_STATE.COMPLETED)) return 42;
+        if (options?.states?.includes(USER_MEDIA_STATE.CAUGHT_UP)) return 7;
+        return 0;
+      });
+      savedItemsService.countByList.mockImplementation(async (_userId, list) => {
+        if (list === SAVED_ITEM_LIST.FOR_LATER) return 10;
+        if (list === SAVED_ITEM_LIST.CONSIDERING) return 4;
+        return 0;
+      });
+
+      const result = await service.getListCounts(userId);
+
+      expect(result).toEqual({
+        watching: 3,
+        paused: 2,
+        dropped: 5,
+        completed: 42,
+        caughtUp: 7,
+        forLater: 10,
+        considering: 4,
+      });
+
+      expect(userMediaService.countWithMedia).toHaveBeenCalledTimes(5);
+      expect(savedItemsService.countByList).toHaveBeenCalledWith(userId, SAVED_ITEM_LIST.FOR_LATER);
+      expect(savedItemsService.countByList).toHaveBeenCalledWith(
+        userId,
+        SAVED_ITEM_LIST.CONSIDERING,
+      );
+    });
+
+    it('does NOT use the activity OR-progress semantics (would double-count paused-with-progress)', async () => {
+      userMediaService.countWithMedia.mockResolvedValue(0);
+      savedItemsService.countByList.mockResolvedValue(0);
+
+      await service.getListCounts('user-1');
+
+      // Service must use strict `state=watching`, not the activity OR-semantics.
+      expect(userMediaService.countActivityWithMedia).not.toHaveBeenCalled();
+      expect(userMediaService.countWithMedia).toHaveBeenCalledWith('user-1', {
+        states: [USER_MEDIA_STATE.WATCHING],
+      });
+    });
+
+    it('returns zeros when user has no items anywhere', async () => {
+      userMediaService.countWithMedia.mockResolvedValue(0);
+      savedItemsService.countByList.mockResolvedValue(0);
+
+      const result = await service.getListCounts('user-empty');
+
+      expect(result).toEqual({
+        watching: 0,
+        paused: 0,
+        dropped: 0,
+        completed: 0,
+        caughtUp: 0,
+        forLater: 0,
+        considering: 0,
+      });
+    });
+
+    it('dispatches all queries concurrently via Promise.all', async () => {
+      userMediaService.countWithMedia.mockResolvedValue(0);
+      savedItemsService.countByList.mockResolvedValue(0);
+
+      await service.getListCounts('user-1');
+
+      // 5 state counts (watching/paused/dropped/completed/caught_up) + 2 saved-items counts.
+      expect(userMediaService.countWithMedia).toHaveBeenCalledTimes(5);
+      expect(savedItemsService.countByList).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/apps/api/src/modules/user-media/application/me-lists.service.ts
+++ b/apps/api/src/modules/user-media/application/me-lists.service.ts
@@ -1,16 +1,19 @@
 import { Inject, Injectable } from '@nestjs/common';
 
 import { type MediaType } from '../../../common/enums/media-type.enum';
+import { SAVED_ITEM_LIST, SavedItemsService } from '../../user-actions/public';
 import {
   FAVORITE_UPDATES_DAYS_AHEAD,
   FAVORITE_UPDATES_DAYS_BACK,
   FAVORITE_UPDATES_LIMIT,
   FAVORITE_UPDATES_RATING_THRESHOLD,
 } from '../domain/constants/favorite-updates.constants';
+import { type UserListCounts } from '../domain/entities/user-list-counts.entity';
 import {
   USER_MEDIA_HISTORY_STATES,
   USER_MEDIA_STATE,
   USER_MEDIA_WATCHLIST_STATES,
+  type UserMediaHistoryState,
 } from '../domain/entities/user-media-state.entity';
 import {
   type FavoriteUpdateItem,
@@ -31,6 +34,7 @@ export class MeListsService {
     private readonly userMediaService: UserMediaService,
     @Inject(USER_MEDIA_STATE_REPOSITORY)
     private readonly repo: IUserMediaStateRepository,
+    private readonly savedItemsService: SavedItemsService,
   ) {}
 
   /**
@@ -96,6 +100,9 @@ export class MeListsService {
    * @param {number} limit - Page size
    * @param {number} offset - Offset
    * @param {UserMediaListSort} sort - Sort order
+   * @param {UserMediaHistoryState} state - Narrow history to a single state
+   *   (watching, completed, or paused). DTO validation guarantees the value
+   *   belongs to HISTORY_STATES before it reaches this service.
    * @returns {Promise<{ total: number; data: any }>} Total count and page items
    */
   async getHistory(
@@ -104,12 +111,14 @@ export class MeListsService {
     offset: number,
     sort?: UserMediaListSort,
     type?: MediaType,
+    state?: UserMediaHistoryState,
   ) {
     const effectiveSort = sort ?? USER_MEDIA_LIST_SORT.RECENT;
-    const options = { states: USER_MEDIA_HISTORY_STATES, sort: effectiveSort, type };
+    const states = state ? [state] : USER_MEDIA_HISTORY_STATES;
+    const options = { states, sort: effectiveSort, type };
 
     const [total, data] = await Promise.all([
-      this.userMediaService.countWithMedia(userId, { states: USER_MEDIA_HISTORY_STATES, type }),
+      this.userMediaService.countWithMedia(userId, { states, type }),
       this.userMediaService.listWithMedia(userId, limit, offset, options),
     ]);
 
@@ -225,5 +234,32 @@ export class MeListsService {
       daysAhead: FAVORITE_UPDATES_DAYS_AHEAD,
       limit: FAVORITE_UPDATES_LIMIT,
     });
+  }
+
+  /**
+   * Gets aggregated counts for all user lists in parallel.
+   * Used to render tab badges cheaply, without fetching full list payloads.
+   *
+   * Uses strict state matching (not the "activity" OR-progress semantics),
+   * so buckets are mutually exclusive: a paused-with-progress item is counted
+   * ONLY in `paused`, never in `watching`. This keeps badge arithmetic
+   * intuitive and prevents overlap with the Paused/Dropped tabs.
+   *
+   * @param {string} userId - User identifier
+   * @returns {Promise<UserListCounts>} Counts for each list
+   */
+  async getListCounts(userId: string): Promise<UserListCounts> {
+    const [watching, paused, dropped, completed, caughtUp, forLater, considering] =
+      await Promise.all([
+        this.userMediaService.countWithMedia(userId, { states: [USER_MEDIA_STATE.WATCHING] }),
+        this.userMediaService.countWithMedia(userId, { states: [USER_MEDIA_STATE.PAUSED] }),
+        this.userMediaService.countWithMedia(userId, { states: [USER_MEDIA_STATE.DROPPED] }),
+        this.userMediaService.countWithMedia(userId, { states: [USER_MEDIA_STATE.COMPLETED] }),
+        this.userMediaService.countWithMedia(userId, { states: [USER_MEDIA_STATE.CAUGHT_UP] }),
+        this.savedItemsService.countByList(userId, SAVED_ITEM_LIST.FOR_LATER),
+        this.savedItemsService.countByList(userId, SAVED_ITEM_LIST.CONSIDERING),
+      ]);
+
+    return { watching, paused, dropped, completed, caughtUp, forLater, considering };
   }
 }

--- a/apps/api/src/modules/user-media/domain/entities/user-list-counts.entity.ts
+++ b/apps/api/src/modules/user-media/domain/entities/user-list-counts.entity.ts
@@ -1,0 +1,16 @@
+/**
+ * Aggregated counts of a user's lists that feed tab badges on the client.
+ *
+ * Buckets are mutually exclusive: a paused-with-progress item is counted
+ * only in `paused`, never in `watching`. This keeps badge arithmetic
+ * intuitive and avoids overlap with the Paused/Dropped tabs.
+ */
+export interface UserListCounts {
+  watching: number;
+  paused: number;
+  dropped: number;
+  completed: number;
+  caughtUp: number;
+  forLater: number;
+  considering: number;
+}

--- a/apps/api/src/modules/user-media/domain/entities/user-media-state.entity.ts
+++ b/apps/api/src/modules/user-media/domain/entities/user-media-state.entity.ts
@@ -38,9 +38,14 @@ export const USER_MEDIA_STATE_VALUES: UserMediaState['state'][] = Object.values(
 export const USER_MEDIA_WATCHLIST_STATES: UserMediaState['state'][] = [USER_MEDIA_STATE.PLANNED];
 
 /**
+ * Subset of user media states that are part of watch history.
+ */
+export type UserMediaHistoryState = 'watching' | 'completed' | 'paused' | 'caught_up';
+
+/**
  * Defines states that belong to watch history.
  */
-export const USER_MEDIA_HISTORY_STATES: UserMediaState['state'][] = [
+export const USER_MEDIA_HISTORY_STATES: UserMediaHistoryState[] = [
   USER_MEDIA_STATE.WATCHING,
   USER_MEDIA_STATE.COMPLETED,
   USER_MEDIA_STATE.PAUSED,

--- a/apps/api/src/modules/user-media/presentation/controllers/me-lists.controller.spec.ts
+++ b/apps/api/src/modules/user-media/presentation/controllers/me-lists.controller.spec.ts
@@ -245,6 +245,7 @@ describe('MeListsController', () => {
         10,
         USER_MEDIA_LIST_SORT.RATING,
         undefined,
+        undefined,
       );
     });
 
@@ -256,7 +257,14 @@ describe('MeListsController', () => {
 
       await controller.history(mockUser, query);
 
-      expect(meListsService.getHistory).toHaveBeenCalledWith('user-1', 20, 0, undefined, undefined);
+      expect(meListsService.getHistory).toHaveBeenCalledWith(
+        'user-1',
+        20,
+        0,
+        undefined,
+        undefined,
+        undefined,
+      );
     });
 
     it('should handle large history dataset', async () => {

--- a/apps/api/src/modules/user-media/presentation/controllers/me-lists.controller.ts
+++ b/apps/api/src/modules/user-media/presentation/controllers/me-lists.controller.ts
@@ -17,6 +17,8 @@ import { MeListsService } from '../../application/me-lists.service';
 import { type UserMediaState } from '../../domain/entities/user-media-state.entity';
 import { FavoriteUpdatesResponseDto } from '../dto/favorite-updates.dto';
 import {
+  MeHistoryListQueryDto,
+  MeListCountsResponseDto,
   MeUserMediaListQueryDto,
   type MeUserMediaListItemDto,
   PaginatedMeUserMediaResponseDto,
@@ -154,7 +156,7 @@ export class MeListsController {
   @ApiOkResponse({ type: PaginatedMeUserMediaResponseDto })
   async history(
     @CurrentUser() user: { id: string },
-    @Query() query: MeUserMediaListQueryDto,
+    @Query() query: MeHistoryListQueryDto,
   ): Promise<PaginatedMeUserMediaResponseDto> {
     const limit = query.limit ?? DEFAULT_PAGE_SIZE;
     const offset = query.offset ?? 0;
@@ -164,6 +166,7 @@ export class MeListsController {
       offset,
       query.sort,
       query.type,
+      query.state,
     );
 
     const items = (data as UserMediaWithSummary[]).map((i) => this.mapItem(i));
@@ -325,6 +328,22 @@ export class MeListsController {
         hasMore: offset + items.length < total,
       },
     };
+  }
+
+  /**
+   * Gets aggregated counts for all user lists (activity + saved).
+   *
+   * Single lightweight endpoint that replaces 6 full list-with-join fetches
+   * previously used just to render tab-count badges on /saved and /activity.
+   *
+   * @param {{ id: string }} user - Current user context
+   * @returns {Promise<MeListCountsResponseDto>} Counts for each list
+   */
+  @Get('lists/counts')
+  @ApiOperation({ summary: 'Counts of my lists (auth: Bearer)' })
+  @ApiOkResponse({ type: MeListCountsResponseDto })
+  async listCounts(@CurrentUser() user: { id: string }): Promise<MeListCountsResponseDto> {
+    return this.meListsService.getListCounts(user.id);
   }
 
   /**

--- a/apps/api/src/modules/user-media/presentation/dto/me-lists.dto.ts
+++ b/apps/api/src/modules/user-media/presentation/dto/me-lists.dto.ts
@@ -6,6 +6,11 @@ import { OffsetPaginationMetaDto, OffsetPaginationQueryDto } from '../../../../c
 import { type ImageDto } from '../../../../common/dtos/image.dto';
 import { MediaType } from '../../../../common/enums/media-type.enum';
 import { CardMetaDto } from '../../../shared/cards/presentation/dtos/card-meta.dto';
+import { type UserListCounts } from '../../domain/entities/user-list-counts.entity';
+import {
+  USER_MEDIA_HISTORY_STATES,
+  type UserMediaHistoryState,
+} from '../../domain/entities/user-media-state.entity';
 import {
   USER_MEDIA_LIST_SORT,
   type UserMediaListSort,
@@ -67,6 +72,21 @@ export class MeUserMediaListQueryDto extends OffsetPaginationQueryDto {
 }
 
 /**
+ * Query DTO for the history endpoint. Allows narrowing the result to a
+ * single state within the history set (watching / completed / paused).
+ */
+export class MeHistoryListQueryDto extends MeUserMediaListQueryDto {
+  @ApiPropertyOptional({
+    required: false,
+    enum: USER_MEDIA_HISTORY_STATES,
+    description: 'Narrow history to a single state (must be one of HISTORY_STATES).',
+  })
+  @IsOptional()
+  @IsIn(USER_MEDIA_HISTORY_STATES)
+  state?: UserMediaHistoryState;
+}
+
+/**
  * Represents media summary in owner-only lists.
  */
 export class MeUserMediaSummaryDto {
@@ -123,4 +143,39 @@ export class PaginatedMeUserMediaResponseDto {
 
   @ApiProperty({ type: OffsetPaginationMetaDto })
   meta!: OffsetPaginationMetaDto;
+}
+
+/**
+ * Aggregated counts for user's lists (activity + saved).
+ * Used to render tab badges without fetching full list payloads.
+ *
+ * Shape mirrors {@link UserListCounts} from the domain layer — the class
+ * implements that interface so any shape drift between the domain model and
+ * its HTTP contract surfaces as a TypeScript error.
+ */
+export class MeListCountsResponseDto implements UserListCounts {
+  @ApiProperty({
+    description: 'Items with state=watching (strict, no overlap with paused/dropped)',
+  })
+  watching!: number;
+
+  @ApiProperty({ description: 'Items paused by the user' })
+  paused!: number;
+
+  @ApiProperty({ description: 'Items dropped by the user' })
+  dropped!: number;
+
+  @ApiProperty({ description: 'Items the user completed watching' })
+  completed!: number;
+
+  @ApiProperty({
+    description: 'Items caught up on (ongoing shows with all aired episodes watched)',
+  })
+  caughtUp!: number;
+
+  @ApiProperty({ description: 'Saved items in the "for later" list' })
+  forLater!: number;
+
+  @ApiProperty({ description: 'Saved items in the "considering" list' })
+  considering!: number;
 }

--- a/apps/api/src/modules/user-media/presentation/dto/me-lists.dto.ts
+++ b/apps/api/src/modules/user-media/presentation/dto/me-lists.dto.ts
@@ -155,27 +155,39 @@ export class PaginatedMeUserMediaResponseDto {
  */
 export class MeListCountsResponseDto implements UserListCounts {
   @ApiProperty({
+    type: 'integer',
+    minimum: 0,
     description: 'Items with state=watching (strict, no overlap with paused/dropped)',
   })
   watching!: number;
 
-  @ApiProperty({ description: 'Items paused by the user' })
+  @ApiProperty({ type: 'integer', minimum: 0, description: 'Items paused by the user' })
   paused!: number;
 
-  @ApiProperty({ description: 'Items dropped by the user' })
+  @ApiProperty({ type: 'integer', minimum: 0, description: 'Items dropped by the user' })
   dropped!: number;
 
-  @ApiProperty({ description: 'Items the user completed watching' })
+  @ApiProperty({ type: 'integer', minimum: 0, description: 'Items the user completed watching' })
   completed!: number;
 
   @ApiProperty({
+    type: 'integer',
+    minimum: 0,
     description: 'Items caught up on (ongoing shows with all aired episodes watched)',
   })
   caughtUp!: number;
 
-  @ApiProperty({ description: 'Saved items in the "for later" list' })
+  @ApiProperty({
+    type: 'integer',
+    minimum: 0,
+    description: 'Saved items in the "for later" list',
+  })
   forLater!: number;
 
-  @ApiProperty({ description: 'Saved items in the "considering" list' })
+  @ApiProperty({
+    type: 'integer',
+    minimum: 0,
+    description: 'Saved items in the "considering" list',
+  })
   considering!: number;
 }

--- a/apps/web-client/src/app/(main)/activity/page.tsx
+++ b/apps/web-client/src/app/(main)/activity/page.tsx
@@ -10,8 +10,16 @@ import { Suspense, useCallback, type MouseEvent } from 'react';
 import { Tabs, TabsList, TabsTrigger, TabsContent, Badge } from '@/shared/ui';
 import { useTranslation } from '@/shared/i18n';
 import { useAuth } from '@/core/auth';
-import { Watchlist, HistoryList, PausedList, CaughtUpList, DroppedList, FavoriteUpdates, ActivityEpisodeSheet } from '@/modules/saved';
-import { useListCounts } from '@/modules/saved/hooks/use-me-lists';
+import {
+  Watchlist,
+  HistoryList,
+  PausedList,
+  CaughtUpList,
+  DroppedList,
+  FavoriteUpdates,
+  ActivityEpisodeSheet,
+  useListCounts,
+} from '@/modules/saved';
 import { USER_MEDIA_STATE } from '@/core/api';
 
 /**

--- a/apps/web-client/src/app/(main)/activity/page.tsx
+++ b/apps/web-client/src/app/(main)/activity/page.tsx
@@ -1,22 +1,21 @@
 /**
  * Activity page - user's watching progress.
- * Contains tabs: Watching, Paused, Completed (history).
+ * Contains tabs: Watching, Caught Up, Paused, Dropped, History.
  */
 
 'use client';
 
 import { useSearchParams } from 'next/navigation';
 import { Suspense, useCallback, type MouseEvent } from 'react';
-import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/shared/ui';
+import { Tabs, TabsList, TabsTrigger, TabsContent, Badge } from '@/shared/ui';
 import { useTranslation } from '@/shared/i18n';
 import { useAuth } from '@/core/auth';
 import { Watchlist, HistoryList, PausedList, CaughtUpList, DroppedList, FavoriteUpdates, ActivityEpisodeSheet } from '@/modules/saved';
+import { useListCounts } from '@/modules/saved/hooks/use-me-lists';
 import { USER_MEDIA_STATE } from '@/core/api';
 
 /**
  * Tab identifiers for URL params and Radix UI.
- * WATCHING and PAUSED use USER_MEDIA_STATE for consistency.
- * HISTORY is a UI concept (shows completed items).
  */
 const TAB_VALUES = {
   WATCHING: USER_MEDIA_STATE.WATCHING,
@@ -52,6 +51,21 @@ function ActivityPageContent() {
     }
   }, []);
 
+  const countsQuery = useListCounts(isAuthenticated);
+  const {
+    watching: watchingTotal = 0,
+    caughtUp: caughtUpTotal = 0,
+    paused: pausedTotal = 0,
+    dropped: droppedTotal = 0,
+    completed: historyTotal = 0,
+  } = (countsQuery.data as {
+    watching?: number;
+    caughtUp?: number;
+    paused?: number;
+    dropped?: number;
+    completed?: number;
+  }) ?? {};
+
   if (isLoading) {
     return (
       <div className="min-h-screen pt-24 pb-12">
@@ -84,20 +98,25 @@ function ActivityPageContent() {
         <Tabs defaultValue={defaultTab} className="w-full">
           <div className="overflow-x-auto scrollbar-none mb-6" onClick={handleTabClick}>
             <TabsList className="bg-cinema-card border border-cinema-borderSoft h-auto gap-0.5 md:gap-1 p-1 md:w-auto w-max">
-              <TabsTrigger value={TAB_VALUES.WATCHING} className="px-2.5 md:px-3 text-[13px] md:text-sm whitespace-nowrap data-[state=active]:bg-cinema-elevated data-[state=inactive]:hover:bg-cinema-elevated/50">
+              <TabsTrigger value={TAB_VALUES.WATCHING} className="px-2.5 md:px-3 text-[13px] md:text-sm whitespace-nowrap gap-1.5 data-[state=active]:bg-cinema-elevated data-[state=inactive]:hover:bg-cinema-elevated/50">
                 {dict.activity.tabs.watching}
+                {watchingTotal > 0 && <Badge as="span" variant="count">{watchingTotal}</Badge>}
               </TabsTrigger>
-              <TabsTrigger value={TAB_VALUES.CAUGHT_UP} className="px-2.5 md:px-3 text-[13px] md:text-sm whitespace-nowrap data-[state=active]:bg-cinema-elevated data-[state=inactive]:hover:bg-cinema-elevated/50">
+              <TabsTrigger value={TAB_VALUES.CAUGHT_UP} className="px-2.5 md:px-3 text-[13px] md:text-sm whitespace-nowrap gap-1.5 data-[state=active]:bg-cinema-elevated data-[state=inactive]:hover:bg-cinema-elevated/50">
                 {dict.activity.tabs.caughtUp}
+                {caughtUpTotal > 0 && <Badge as="span" variant="count">{caughtUpTotal}</Badge>}
               </TabsTrigger>
-              <TabsTrigger value={TAB_VALUES.PAUSED} className="px-2.5 md:px-3 text-[13px] md:text-sm whitespace-nowrap data-[state=active]:bg-cinema-elevated data-[state=inactive]:hover:bg-cinema-elevated/50">
+              <TabsTrigger value={TAB_VALUES.PAUSED} className="px-2.5 md:px-3 text-[13px] md:text-sm whitespace-nowrap gap-1.5 data-[state=active]:bg-cinema-elevated data-[state=inactive]:hover:bg-cinema-elevated/50">
                 {dict.activity.tabs.paused}
+                {pausedTotal > 0 && <Badge as="span" variant="count">{pausedTotal}</Badge>}
               </TabsTrigger>
-              <TabsTrigger value={TAB_VALUES.DROPPED} className="px-2.5 md:px-3 text-[13px] md:text-sm whitespace-nowrap data-[state=active]:bg-cinema-elevated data-[state=inactive]:hover:bg-cinema-elevated/50">
+              <TabsTrigger value={TAB_VALUES.DROPPED} className="px-2.5 md:px-3 text-[13px] md:text-sm whitespace-nowrap gap-1.5 data-[state=active]:bg-cinema-elevated data-[state=inactive]:hover:bg-cinema-elevated/50">
                 {dict.activity.tabs.dropped}
+                {droppedTotal > 0 && <Badge as="span" variant="count">{droppedTotal}</Badge>}
               </TabsTrigger>
-              <TabsTrigger value={TAB_VALUES.HISTORY} className="px-2.5 md:px-3 text-[13px] md:text-sm whitespace-nowrap data-[state=active]:bg-cinema-elevated data-[state=inactive]:hover:bg-cinema-elevated/50">
+              <TabsTrigger value={TAB_VALUES.HISTORY} className="px-2.5 md:px-3 text-[13px] md:text-sm whitespace-nowrap gap-1.5 data-[state=active]:bg-cinema-elevated data-[state=inactive]:hover:bg-cinema-elevated/50">
                 {dict.activity.tabs.history}
+                {historyTotal > 0 && <Badge as="span" variant="count">{historyTotal}</Badge>}
               </TabsTrigger>
             </TabsList>
           </div>

--- a/apps/web-client/src/app/(main)/saved/page.tsx
+++ b/apps/web-client/src/app/(main)/saved/page.tsx
@@ -7,10 +7,11 @@
 
 import { useSearchParams } from 'next/navigation';
 import { Suspense } from 'react';
-import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/shared/ui';
+import { Tabs, TabsList, TabsTrigger, TabsContent, Badge } from '@/shared/ui';
 import { useTranslation } from '@/shared/i18n';
 import { useAuth } from '@/core/auth';
 import { SavedList } from '@/modules/saved';
+import { useListCounts } from '@/modules/saved/hooks/use-me-lists';
 
 const TAB_VALUES = {
   FOR_LATER: 'for-later',
@@ -32,6 +33,10 @@ function SavedPageContent() {
   const searchParams = useSearchParams();
 
   const defaultTab = getTabFromParam(searchParams.get('tab'));
+
+  const countsQuery = useListCounts(isAuthenticated);
+  const { forLater: forLaterTotal = 0, considering: consideringTotal = 0 } =
+    countsQuery.data ?? {};
 
   if (isLoading) {
     return (
@@ -64,11 +69,13 @@ function SavedPageContent() {
 
         <Tabs defaultValue={defaultTab} className="w-full">
           <TabsList className="bg-cinema-card border border-cinema-borderSoft mb-6 h-auto gap-0.5 md:gap-1 p-1 md:w-auto w-full">
-            <TabsTrigger value={TAB_VALUES.FOR_LATER} className="flex-1 md:flex-none min-w-0 px-2 md:px-3 text-[13px] md:text-sm data-[state=active]:bg-cinema-elevated data-[state=inactive]:hover:bg-cinema-elevated/50">
+            <TabsTrigger value={TAB_VALUES.FOR_LATER} className="flex-1 md:flex-none min-w-0 px-2 md:px-3 text-[13px] md:text-sm gap-1.5 data-[state=active]:bg-cinema-elevated data-[state=inactive]:hover:bg-cinema-elevated/50">
               {dict.saved.tabs.forLater}
+              {forLaterTotal > 0 && <Badge as="span" variant="count">{forLaterTotal}</Badge>}
             </TabsTrigger>
-            <TabsTrigger value={TAB_VALUES.CONSIDERING} className="flex-1 md:flex-none min-w-0 px-2 md:px-3 text-[13px] md:text-sm data-[state=active]:bg-cinema-elevated data-[state=inactive]:hover:bg-cinema-elevated/50">
+            <TabsTrigger value={TAB_VALUES.CONSIDERING} className="flex-1 md:flex-none min-w-0 px-2 md:px-3 text-[13px] md:text-sm gap-1.5 data-[state=active]:bg-cinema-elevated data-[state=inactive]:hover:bg-cinema-elevated/50">
               {dict.saved.tabs.considering}
+              {consideringTotal > 0 && <Badge as="span" variant="count">{consideringTotal}</Badge>}
             </TabsTrigger>
           </TabsList>
 

--- a/apps/web-client/src/app/(main)/saved/page.tsx
+++ b/apps/web-client/src/app/(main)/saved/page.tsx
@@ -10,8 +10,7 @@ import { Suspense } from 'react';
 import { Tabs, TabsList, TabsTrigger, TabsContent, Badge } from '@/shared/ui';
 import { useTranslation } from '@/shared/i18n';
 import { useAuth } from '@/core/auth';
-import { SavedList } from '@/modules/saved';
-import { useListCounts } from '@/modules/saved/hooks/use-me-lists';
+import { SavedList, useListCounts } from '@/modules/saved';
 
 const TAB_VALUES = {
   FOR_LATER: 'for-later',

--- a/apps/web-client/src/core/api/me-lists.client.ts
+++ b/apps/web-client/src/core/api/me-lists.client.ts
@@ -15,6 +15,7 @@ import { apiGet, apiPatch, apiPost } from './client';
 
 export type MeUserMediaListItemDto = components['schemas']['MeUserMediaListItemDto'];
 export type PaginatedMeUserMediaResponseDto = components['schemas']['PaginatedMeUserMediaResponseDto'];
+export type MeListCountsDto = components['schemas']['MeListCountsResponseDto'];
 type SetUserMediaStateDto = components['schemas']['SetUserMediaStateDto'];
 
 export type UserMediaState = MeUserMediaListItemDto['state'];
@@ -64,12 +65,15 @@ export const meListsApi = {
   },
 
   /**
-   * Get user's watch history (watching/completed items).
+   * Get user's watch history (watching/completed/paused items by default).
    *
-   * @param params - Pagination and sorting parameters
+   * @param params - Pagination and sorting parameters; `state` narrows the
+   *   result to a single history state (watching | completed | paused).
    * @returns Paginated history items
    */
-  async getHistory(params?: MeListsParams): Promise<PaginatedMeUserMediaResponseDto> {
+  async getHistory(
+    params?: MeListsParams & { state?: 'watching' | 'completed' | 'paused' },
+  ): Promise<PaginatedMeUserMediaResponseDto> {
     return apiGet<PaginatedMeUserMediaResponseDto>('me/history', {
       searchParams: params as Record<string, string | number>,
     });
@@ -136,6 +140,16 @@ export const meListsApi = {
     return apiGet<PaginatedMeUserMediaResponseDto>('me/dropped', {
       searchParams: params as Record<string, string | number>,
     });
+  },
+
+  /**
+   * Get aggregated counts for all user lists (activity + saved).
+   * Single lightweight request used to render tab-count badges.
+   *
+   * @returns Counts for each list
+   */
+  async getListCounts(): Promise<MeListCountsDto> {
+    return apiGet<MeListCountsDto>('me/lists/counts');
   },
 
   /**

--- a/apps/web-client/src/core/query/keys.ts
+++ b/apps/web-client/src/core/query/keys.ts
@@ -108,12 +108,16 @@ export const queryKeys = {
   /** Me lists queries (activity, history, paused). */
   meLists: {
     all: ['me-lists'] as const,
-    /** Prefix key that matches all activity queries regardless of limit. */
+    /** Aggregated counts for all user lists (used for tab badges). */
+    counts: ['me-lists', 'counts'] as const,
+    /** Prefix key that matches all activity queries regardless of filter/limit. */
     activityAll: ['me-lists', 'activity'] as const,
-    activity: (type?: string, limit?: number) => ['me-lists', 'activity', type ?? null, limit ?? null] as const,
+    activity: (type?: string, limit?: number) =>
+      ['me-lists', 'activity', type ?? null, limit ?? null] as const,
     favoriteUpdates: ['me-lists', 'favorite-updates'] as const,
     historyAll: ['me-lists', 'history'] as const,
-    history: (sort?: string, type?: string, limit?: number) => ['me-lists', 'history', sort ?? null, type ?? null, limit ?? null] as const,
+    history: (sort?: string, type?: string, limit?: number) =>
+      ['me-lists', 'history', sort ?? null, type ?? null, limit ?? null] as const,
     ratingsAll: ['me-lists', 'ratings'] as const,
     ratings: (sort?: string, type?: string, limit?: number) => ['me-lists', 'ratings', sort ?? null, type ?? null, limit ?? null] as const,
     watchlistAll: ['me-lists', 'watchlist'] as const,

--- a/apps/web-client/src/modules/details/components/episodes-section.tsx
+++ b/apps/web-client/src/modules/details/components/episodes-section.tsx
@@ -5,13 +5,11 @@
  * Displays season selector with episode list and thumbnails.
  */
 
-import { useState, useMemo, useRef, useEffect, useCallback } from 'react';
+import { useState, useMemo, useRef, useEffect } from 'react';
 import { Clock } from 'lucide-react';
-import { toast } from 'sonner';
 import type { components } from '@ratingo/api-contract';
 import type { getDictionary } from '@/shared/i18n';
 import { formatDate } from '@/shared/utils/format';
-import { cn } from '@/shared/utils';
 import {
   AlertDialog,
   AlertDialogContent,
@@ -23,15 +21,10 @@ import {
   AlertDialogCancel,
 } from '@/shared/ui';
 import { useAuth } from '@/core/auth';
-import {
-  useShowProgress,
-  useToggleEpisodeWatched,
-  useMarkMultipleWatched,
-  useMarkAllEpisodesWatched,
-  useUnmarkEpisodes,
-  useResetSeason,
-} from '@/core/query';
 import { useUserMediaState } from '@/modules/saved/hooks/use-me-lists';
+import { useEpisodeProgress } from '../hooks/use-episode-progress';
+import { useCatchUp } from '../hooks/use-catch-up';
+import { useEpisodeToggle } from '../hooks/use-episode-toggle';
 import { CatchUpDialog } from './catch-up-dialog';
 import { EpisodeCard } from './episode-card';
 import { SeasonHeader } from './season-header';
@@ -42,9 +35,7 @@ export interface EpisodesSectionProps {
   seasons: SeasonDto[];
   nextEpisodeDate?: string | null;
   dict: ReturnType<typeof getDictionary>;
-  /** Show ID (from shows table) for progress tracking */
   showId?: string;
-  /** Media item ID for fetching user state (continuePoint) */
   mediaItemId?: string;
 }
 
@@ -60,13 +51,11 @@ export function EpisodesSection({
   const { data: userMediaState } = useUserMediaState(mediaItemId ?? '', isAuthenticated && !!mediaItemId);
   const continueSeasonNumber = userMediaState?.continuePoint?.season;
 
-  // Filter out seasons with no episodes and season 0 (specials)
   const validSeasons = useMemo(
     () => seasons.filter((s) => s.number > 0 && (s.episodes?.length || 0) > 0),
     [seasons],
   );
 
-  // Default to last season, will be updated when continuePoint loads
   const [selectedSeason, setSelectedSeason] = useState<SeasonDto | null>(() => {
     if (validSeasons.length === 0) return null;
     return validSeasons[validSeasons.length - 1];
@@ -86,7 +75,6 @@ export function EpisodesSection({
     }
   }, [continueSeasonNumber, hasAppliedContinue, validSeasons]);
 
-  // Ref for scrollable container
   const listRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -108,370 +96,48 @@ export function EpisodesSection({
     return () => window.removeEventListener('expandEpisodes', handleExpandEpisodes);
   }, [validSeasons]);
 
-  // Episode progress tracking
-  const { data: progressData } = useShowProgress(showId, {
-    enabled: isAuthenticated && !!showId,
-  });
-  const toggleWatched = useToggleEpisodeWatched(showId || '');
-  const markMultipleWatched = useMarkMultipleWatched(showId || '');
-  const markAllWatched = useMarkAllEpisodesWatched(showId || '');
-  const unmarkEpisodes = useUnmarkEpisodes(showId || '');
-  const resetSeason = useResetSeason(showId || '');
-
-  // Confirmation dialog state
-  const [showConfirmDialog, setShowConfirmDialog] = useState(false);
-  const [showResetConfirmDialog, setShowResetConfirmDialog] = useState(false);
-
-  // Get watched episode IDs for current season
-  // Simple .find() doesn't need useMemo per rerender-simple-expression-in-memo rule
-  const currentSeasonProgress = progressData?.seasons.find(
-    (s) => s.seasonNumber === selectedSeason?.number
-  ) ?? null;
-
-  const watchedEpisodeIds = useMemo(
-    () => new Set(currentSeasonProgress?.watchedEpisodeIds || []),
-    [currentSeasonProgress?.watchedEpisodeIds],
-  );
-
-  // Calculate total progress across all seasons
-  const totalProgress = useMemo(() => {
-    if (!progressData) return { watched: 0, total: 0 };
-    return progressData.seasons.reduce(
-      (acc, s) => ({
-        watched: acc.watched + s.watchedCount,
-        total: acc.total + s.totalCount,
-      }),
-      { watched: 0, total: 0 },
-    );
-  }, [progressData]);
-
-  // Episodes list from selected season
-  // Simple property access doesn't need useMemo per rerender-simple-expression-in-memo rule
   const episodes = selectedSeason?.episodes || [];
 
-  // Collect all aired episode IDs grouped by season number, count totals, and track last aired episode
-  // Combined iteration per js-combine-iterations rule
-  const { allEpisodesBySeasonNumber, totalEpisodesCount, totalAllEpisodes, lastAiredEpisodeInfo } = useMemo(() => {
-    const now = Date.now();
-    const map = new Map<number, string[]>();
-    let airedCount = 0;
-    let allCount = 0;
-    let lastSeason = 0;
-    let lastEpisode = 0;
-
-    for (const season of validSeasons) {
-      const episodes = season.episodes || [];
-      const ids: string[] = [];
-      allCount += episodes.length;
-
-      for (const ep of episodes) {
-        // Skip episodes with future air dates
-        // Cache property access per js-cache-property-access rule
-        const airDate = ep.airDate;
-        if (airDate && new Date(airDate).getTime() > now) continue;
-        airedCount++;
-        if (ep.id) ids.push(ep.id);
-        // Track last aired episode for success message
-        lastSeason = season.number;
-        lastEpisode = ep.number;
-      }
-
-      if (ids.length > 0) {
-        map.set(season.number, ids);
-      }
-    }
-
-    return {
-      allEpisodesBySeasonNumber: map,
-      totalEpisodesCount: airedCount,
-      totalAllEpisodes: allCount,
-      lastAiredEpisodeInfo: { season: lastSeason, episode: lastEpisode },
-    };
-  }, [validSeasons]);
-
-  // Store previous watched IDs and selected episodes for undo
-  const previousWatchedIdsRef = useRef<Map<number, string[]> | null>(null);
-  const selectedEpisodesRef = useRef<Map<number, string[]> | null>(null);
-  const catchUpToastIdRef = useRef<string | number | null>(null);
-
-  const handleUndo = useCallback(() => {
-    const previousWatched = previousWatchedIdsRef.current;
-    const selectedEpisodes = selectedEpisodesRef.current;
-    if (!previousWatched || !selectedEpisodes) return;
-
-    // Compute episode IDs from selected seasons only
-    const selectedEpisodeIds: string[] = [];
-    selectedEpisodes.forEach((ids) => {
-      selectedEpisodeIds.push(...ids);
-    });
-
-    // Get previously watched IDs as a set
-    const previouslyWatchedIds = new Set<string>();
-    previousWatched.forEach((ids) => {
-      ids.forEach((id) => previouslyWatchedIds.add(id));
-    });
-
-    // Episodes to unmark = selected episodes that weren't watched before
-    const episodesToUnmark = selectedEpisodeIds.filter((id) => !previouslyWatchedIds.has(id));
-    if (episodesToUnmark.length === 0) return;
-
-    unmarkEpisodes.mutate(episodesToUnmark, {
-      onSuccess: () => {
-        toast.success(dict.details.showStatus.undone);
-        previousWatchedIdsRef.current = null;
-        selectedEpisodesRef.current = null;
-      },
-      onError: () => {
-        toast.error(dict.common?.error || 'Щось пішло не так');
-      },
-    });
-  }, [unmarkEpisodes, dict]);
-
-  const handleCatchUpConfirm = useCallback(async (
-    toMark: Map<number, string[]>,
-    toUnmark: Map<number, string[]>,
-  ) => {
-    setShowConfirmDialog(false);
-
-    if (progressData) {
-      const prevMap = new Map<number, string[]>();
-      progressData.seasons.forEach((s) => {
-        prevMap.set(s.seasonNumber, [...s.watchedEpisodeIds]);
-      });
-      previousWatchedIdsRef.current = prevMap;
-    }
-    selectedEpisodesRef.current = toMark;
-
-    try {
-      // Mark first (additive), then unmark (destructive).
-      // If unmark fails after mark succeeds, user keeps extra progress
-      // rather than losing it — a safer partial-failure outcome.
-      if (toMark.size > 0) {
-        let selectedLastSeason = 0;
-        let selectedLastEpisode = 0;
-        const now = Date.now();
-        for (const season of validSeasons) {
-          if (!toMark.has(season.number)) continue;
-          for (const ep of season.episodes || []) {
-            if (ep.airDate && new Date(ep.airDate).getTime() > now) continue;
-            selectedLastSeason = season.number;
-            selectedLastEpisode = ep.number;
-          }
-        }
-
-        const selectedTotal = Array.from(toMark.values()).reduce((sum, ids) => sum + ids.length, 0);
-        const isFullCatchUp = selectedTotal === totalEpisodesCount && totalEpisodesCount === totalAllEpisodes;
-
-        await markAllWatched.mutateAsync({ episodesBySeasonNumber: toMark });
-
-        const message = isFullCatchUp
-          ? dict.details.showStatus.caughtUpAll
-          : dict.details.showStatus.caughtUp
-              .replace('{season}', String(selectedLastSeason))
-              .replace('{episode}', String(selectedLastEpisode));
-
-        if (toUnmark.size === 0) {
-          catchUpToastIdRef.current = toast.success(message, {
-            action: {
-              label: dict.details.showStatus.undo,
-              onClick: handleUndo,
-            },
-            duration: 8000,
-          });
-        } else {
-          toast.success(message);
-        }
-      }
-
-      if (toUnmark.size > 0) {
-        const idsToUnmark: string[] = [];
-        toUnmark.forEach((ids) => {
-          idsToUnmark.push(...ids);
-        });
-        if (idsToUnmark.length > 0) {
-          await unmarkEpisodes.mutateAsync(idsToUnmark);
-        }
-
-        if (toMark.size === 0) {
-          toast.success(dict.details.showStatus.seasonReset);
-        }
-
-        previousWatchedIdsRef.current = null;
-        selectedEpisodesRef.current = null;
-      }
-    } catch {
-      toast.error(dict.common?.error || 'Щось пішло не так');
-    }
-  }, [progressData, validSeasons, markAllWatched, unmarkEpisodes, dict, handleUndo, totalEpisodesCount, totalAllEpisodes]);
-
-  const handleMarkAllClick = useCallback(() => {
-    if (validSeasons.length <= 1) {
-      handleCatchUpConfirm(allEpisodesBySeasonNumber, new Map());
-    } else {
-      setShowConfirmDialog(true);
-    }
-  }, [validSeasons.length, handleCatchUpConfirm, allEpisodesBySeasonNumber]);
-
-  // Snapshot episode IDs and season number at dialog-open time
-  const resetEpisodeIdsRef = useRef<string[] | null>(null);
-  const resetSeasonNumberRef = useRef<number | null>(null);
-
-  const handleResetSeasonClick = useCallback(() => {
-    resetEpisodeIdsRef.current = currentSeasonProgress?.watchedEpisodeIds?.slice() ?? null;
-    resetSeasonNumberRef.current = selectedSeason?.number ?? null;
-    setShowResetConfirmDialog(true);
-  }, [currentSeasonProgress?.watchedEpisodeIds, selectedSeason?.number]);
-
-  const handleConfirmResetSeason = useCallback(() => {
-    setShowResetConfirmDialog(false);
-    if (catchUpToastIdRef.current !== null) {
-      toast.dismiss(catchUpToastIdRef.current);
-      catchUpToastIdRef.current = null;
-    }
-    const ids = resetEpisodeIdsRef.current;
-    const seasonNumber = resetSeasonNumberRef.current;
-    resetEpisodeIdsRef.current = null;
-    resetSeasonNumberRef.current = null;
-    if (!ids || ids.length === 0 || seasonNumber === null) return;
-
-    resetSeason.mutate(
-      { episodeIds: ids, seasonNumber },
-      {
-        onSuccess: () => {
-          toast.success(dict.details.showStatus.seasonReset);
-        },
-        onError: () => {
-          toast.error(dict.common?.error || 'Щось пішло не так');
-        },
-      },
-    );
-  }, [resetSeason, dict]);
-
-  // Track which episode is being toggled
-  const [togglingEpisodeId, setTogglingEpisodeId] = useState<string | null>(null);
-
-  // Track which episodes should animate (for bulk marking)
-  const [animatingIds, setAnimatingIds] = useState<Set<string>>(new Set());
-
-  const handleToggleWatched = useCallback(
-    (episodeId: string, seasonNumber: number) => {
-      if (!isAuthenticated || toggleWatched.isPending || markMultipleWatched.isPending) return;
-
-      const isCurrentlyWatched = watchedEpisodeIds.has(episodeId);
-      const wasCompleted = totalProgress.watched === totalProgress.total && totalProgress.total > 0;
-      const prevWatched = totalProgress.watched;
-
-      setTogglingEpisodeId(episodeId);
-
-      // Trigger animation for marking as watched
-      if (!isCurrentlyWatched) {
-        setAnimatingIds(new Set([episodeId]));
-      }
-
-      toggleWatched.mutate(
-        {
-          episodeId,
-          seasonNumber,
-          watched: !isCurrentlyWatched,
-        },
-        {
-          onSuccess: () => {
-            const newWatched = isCurrentlyWatched ? prevWatched - 1 : prevWatched + 1;
-            const prevTotal = totalProgress.total;
-            const isNowCompleted = newWatched === prevTotal && prevTotal > 0;
-
-            // Show toast based on state transition
-            if (!isCurrentlyWatched && isNowCompleted) {
-              toast.success(dict.activity.toast.completed);
-            } else if (!isCurrentlyWatched && prevWatched === 0) {
-              toast.success(dict.activity.toast.addedToWatching);
-            } else if (isCurrentlyWatched && wasCompleted) {
-              toast.info(dict.activity.toast.backToWatching);
-            } else if (isCurrentlyWatched && newWatched === 0) {
-              toast.info(dict.activity.toast.removedFromActivity);
-            }
-          },
-          onSettled: () => {
-            setTogglingEpisodeId(null);
-            // Clear animation after it completes
-            setTimeout(() => setAnimatingIds(new Set()), 350);
-          },
-        },
-      );
-    },
-    [isAuthenticated, toggleWatched, markMultipleWatched.isPending, watchedEpisodeIds, totalProgress, dict],
+  const progress = useEpisodeProgress(
+    showId,
+    isAuthenticated && !!showId,
+    validSeasons,
+    selectedSeason?.number,
   );
 
-  /**
-   * Marks this episode + all unwatched previous episodes as watched.
-   */
-  const handleMarkWithPrevious = useCallback(
-    (episodeIndex: number, seasonNumber: number) => {
-      if (!isAuthenticated || markMultipleWatched.isPending || toggleWatched.isPending) return;
+  const {
+    currentSeasonProgress,
+    watchedEpisodeIds,
+    totalProgress,
+    progressData,
+    allEpisodesBySeasonNumber,
+    totalEpisodesCount,
+  } = progress;
 
-      // Get all unwatched episodes from start up to and including this one
-      const episodesToMark: string[] = [];
-      for (let i = 0; i <= episodeIndex; i++) {
-        const ep = episodes[i];
-        if (ep.id && !watchedEpisodeIds.has(ep.id)) {
-          episodesToMark.push(ep.id);
-        }
-      }
+  const catchUp = useCatchUp({
+    showId: showId || '',
+    dict,
+    validSeasons,
+    progress,
+    selectedSeason,
+  });
 
-      if (episodesToMark.length === 0) return;
-
-      const prevWatched = totalProgress.watched;
-      setTogglingEpisodeId(episodesToMark[episodesToMark.length - 1]);
-
-      // Trigger animation for all episodes being marked
-      setAnimatingIds(new Set(episodesToMark));
-
-      markMultipleWatched.mutate(
-        {
-          episodeIds: episodesToMark,
-          seasonNumber,
-        },
-        {
-          onSuccess: () => {
-            const newWatched = prevWatched + episodesToMark.length;
-            const isNowCompleted = newWatched === totalProgress.total && totalProgress.total > 0;
-
-            if (isNowCompleted) {
-              toast.success(dict.activity.toast.completed);
-            } else if (prevWatched === 0) {
-              toast.success(dict.activity.toast.addedToWatching);
-            }
-          },
-          onSettled: () => {
-            setTogglingEpisodeId(null);
-            // Clear animation after it completes
-            setTimeout(() => setAnimatingIds(new Set()), 350);
-          },
-        },
-      );
-    },
-    [isAuthenticated, markMultipleWatched, toggleWatched.isPending, episodes, watchedEpisodeIds, totalProgress, dict],
-  );
-
-  /**
-   * Counts unwatched episodes before the given index.
-   */
-  const getUnwatchedPreviousCount = useCallback(
-    (episodeIndex: number): number => {
-      let count = 0;
-      for (let i = 0; i < episodeIndex; i++) {
-        const ep = episodes[i];
-        if (ep.id && !watchedEpisodeIds.has(ep.id)) {
-          count++;
-        }
-      }
-      return count;
-    },
-    [episodes, watchedEpisodeIds],
-  );
+  const {
+    togglingEpisodeId,
+    animatingIds,
+    handleToggleWatched,
+    handleMarkWithPrevious,
+    getUnwatchedPreviousCount,
+  } = useEpisodeToggle({
+    showId: showId || '',
+    isAuthenticated,
+    dict,
+    episodes,
+    watchedEpisodeIds,
+    totalProgress,
+  });
 
   // Find last aired episode index (only if there are upcoming episodes)
-  // Moved above early return to comply with Rules of Hooks
   const lastAiredIndex = useMemo(() => {
     if (episodes.length === 0) return -1;
 
@@ -491,34 +157,27 @@ export function EpisodesSection({
       }
     }
 
-    // Only return index if there are upcoming episodes (not all aired)
     return hasUpcoming ? lastIndex : -1;
   }, [episodes]);
 
-  // Episode card height for scroll calculations (64px card + 12px gap)
   const EPISODE_CARD_HEIGHT = 76;
 
-  // Scroll to last aired episode when expanded
   useEffect(() => {
     if (isExpanded && lastAiredIndex > 0 && listRef.current) {
-      // Wait for animation to complete
       const timer = setTimeout(() => {
         const container = listRef.current;
         if (!container) return;
 
-        const scrollPosition = lastAiredIndex * EPISODE_CARD_HEIGHT;
-
         container.scrollTo({
-          top: scrollPosition,
+          top: lastAiredIndex * EPISODE_CARD_HEIGHT,
           behavior: 'smooth',
         });
-      }, 350); // Slightly longer than animation duration
+      }, 350);
 
       return () => clearTimeout(timer);
     }
   }, [isExpanded, lastAiredIndex, selectedSeason]);
 
-  // Don't render if no valid seasons
   if (!selectedSeason || validSeasons.length === 0) {
     return null;
   }
@@ -530,7 +189,6 @@ export function EpisodesSection({
       </h2>
 
       <div className="bg-cinema-card/30 rounded-2xl p-5 border border-cinema-borderSoft/50">
-        {/* Next episode hint at top if available */}
         {nextEpisodeDate && (
           <div className="flex items-center gap-2.5 mb-4 pb-4 border-b border-cinema-borderSoft/30">
             <Clock className="w-4 h-4 text-blue-400 flex-shrink-0" />
@@ -543,7 +201,6 @@ export function EpisodesSection({
           </div>
         )}
 
-        {/* Season header with expand toggle */}
         <SeasonHeader
           seasons={validSeasons}
           selectedSeason={selectedSeason}
@@ -556,13 +213,12 @@ export function EpisodesSection({
           showProgress={isAuthenticated && !!showId}
           totalWatched={totalProgress.watched}
           totalEpisodes={totalEpisodesCount}
-          onMarkAllWatched={handleMarkAllClick}
-          isMarkingAll={markAllWatched.isPending}
-          onResetSeason={isAuthenticated && showId ? handleResetSeasonClick : undefined}
-          isResettingSeason={resetSeason.isPending}
+          onMarkAllWatched={catchUp.handleMarkAllClick}
+          isMarkingAll={catchUp.isMarkingAll}
+          onResetSeason={isAuthenticated && showId ? catchUp.handleResetSeasonClick : undefined}
+          isResettingSeason={catchUp.isResettingSeason}
         />
 
-        {/* Episodes list with smooth expand/collapse animation */}
         <div
           className="grid transition-[grid-template-rows,opacity] duration-300 ease-out"
           style={{
@@ -602,20 +258,18 @@ export function EpisodesSection({
         </div>
       </div>
 
-      {/* Season selector dialog for catch-up */}
       <CatchUpDialog
-        open={showConfirmDialog}
-        onOpenChange={setShowConfirmDialog}
+        open={catchUp.showConfirmDialog}
+        onOpenChange={catchUp.setShowConfirmDialog}
         validSeasons={validSeasons}
         allEpisodesBySeasonNumber={allEpisodesBySeasonNumber}
         progressData={progressData}
         dict={dict}
-        onConfirm={handleCatchUpConfirm}
-        isPending={markAllWatched.isPending || unmarkEpisodes.isPending}
+        onConfirm={catchUp.handleCatchUpConfirm}
+        isPending={catchUp.isMarkingAll || catchUp.isUnmarking}
       />
 
-      {/* Confirmation dialog for season reset */}
-      <AlertDialog open={showResetConfirmDialog} onOpenChange={setShowResetConfirmDialog}>
+      <AlertDialog open={catchUp.showResetConfirmDialog} onOpenChange={catchUp.setShowResetConfirmDialog}>
         <AlertDialogContent className="bg-cinema-card border-cinema-borderSoft">
           <AlertDialogHeader>
             <AlertDialogTitle className="text-cinema-text-primary">
@@ -633,7 +287,7 @@ export function EpisodesSection({
               {dict.common?.cancel || 'Скасувати'}
             </AlertDialogCancel>
             <AlertDialogAction
-              onClick={handleConfirmResetSeason}
+              onClick={catchUp.handleConfirmResetSeason}
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >
               {dict.details.showStatus.resetSeason}

--- a/apps/web-client/src/modules/details/hooks/__tests__/use-catch-up.spec.ts
+++ b/apps/web-client/src/modules/details/hooks/__tests__/use-catch-up.spec.ts
@@ -334,20 +334,5 @@ describe('useCatchUp', () => {
 
       expect(toast.error).toHaveBeenCalledWith('Помилка');
     });
-
-    it('dismisses catch-up toast before resetting', () => {
-      const params = defaultParams();
-      params.progress = makeProgress([
-        { seasonNumber: 1, watchedEpisodeIds: ['e1-1'], totalCount: 3 },
-      ]);
-
-      const { result } = renderHook(() => useCatchUp(params));
-
-      act(() => { result.current.handleResetSeasonClick(); });
-      act(() => { result.current.handleConfirmResetSeason(); });
-
-      // toast.dismiss should not throw even without a prior toast
-      expect(result.current.showResetConfirmDialog).toBe(false);
-    });
   });
 });

--- a/apps/web-client/src/modules/details/hooks/__tests__/use-catch-up.spec.ts
+++ b/apps/web-client/src/modules/details/hooks/__tests__/use-catch-up.spec.ts
@@ -1,0 +1,353 @@
+import { renderHook, act } from '@testing-library/react';
+import { useCatchUp } from '../use-catch-up';
+import type { EpisodeProgressData } from '../use-episode-progress';
+
+jest.mock('sonner', () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+    dismiss: jest.fn(),
+  },
+}));
+
+import { toast } from 'sonner';
+
+const mockMarkAllMutateAsync = jest.fn();
+const mockUnmarkMutate = jest.fn();
+const mockUnmarkMutateAsync = jest.fn();
+const mockResetMutate = jest.fn();
+
+jest.mock('@/core/query', () => ({
+  useMarkAllEpisodesWatched: () => ({
+    mutateAsync: mockMarkAllMutateAsync,
+    isPending: false,
+  }),
+  useUnmarkEpisodes: () => ({
+    mutate: mockUnmarkMutate,
+    mutateAsync: mockUnmarkMutateAsync,
+    isPending: false,
+  }),
+  useResetSeason: () => ({
+    mutate: mockResetMutate,
+    isPending: false,
+  }),
+}));
+
+const mockDict = {
+  details: {
+    showStatus: {
+      caughtUpAll: 'Все переглянуто!',
+      caughtUp: 'Наздогнав до S{season}E{episode}',
+      undo: 'Скасувати',
+      undone: 'Скасовано',
+      seasonReset: 'Сезон скинуто',
+      resetSeason: 'Скинути сезон',
+      resetSeasonConfirm: 'Скинути {season}?',
+      season: 'Сезон',
+    },
+  },
+  common: { error: 'Помилка' },
+} as ReturnType<typeof import('@/shared/i18n').getDictionary>;
+
+const makeSeason = (number: number, episodeIds: string[]) => ({
+  number,
+  name: null,
+  episodeCount: episodeIds.length,
+  posterPath: null,
+  airDate: null,
+  episodes: episodeIds.map((id, i) => ({
+    id,
+    number: i + 1,
+    title: null,
+    airDate: '2024-01-01',
+    runtime: null,
+    stillPath: null,
+  })),
+});
+
+const makeProgress = (
+  seasons: { seasonNumber: number; watchedEpisodeIds: string[]; totalCount: number }[],
+): EpisodeProgressData => ({
+  progressData: {
+    showId: 'show-1',
+    seasons: seasons.map((s) => ({
+      ...s,
+      watchedCount: s.watchedEpisodeIds.length,
+    })),
+  },
+  currentSeasonProgress: seasons[0]
+    ? {
+        seasonNumber: seasons[0].seasonNumber,
+        watchedEpisodeIds: seasons[0].watchedEpisodeIds,
+        watchedCount: seasons[0].watchedEpisodeIds.length,
+        totalCount: seasons[0].totalCount,
+      }
+    : null,
+  watchedEpisodeIds: new Set(seasons.flatMap((s) => s.watchedEpisodeIds)),
+  totalProgress: seasons.reduce(
+    (acc, s) => ({
+      watched: acc.watched + s.watchedEpisodeIds.length,
+      total: acc.total + s.totalCount,
+    }),
+    { watched: 0, total: 0 },
+  ),
+  allEpisodesBySeasonNumber: new Map(
+    seasons.map((s) => {
+      const ids = Array.from({ length: s.totalCount }, (_, i) => `e${s.seasonNumber}-${i + 1}`);
+      return [s.seasonNumber, ids];
+    }),
+  ),
+  totalEpisodesCount: seasons.reduce((sum, s) => sum + s.totalCount, 0),
+  totalAllEpisodes: seasons.reduce((sum, s) => sum + s.totalCount, 0),
+  lastAiredEpisodeInfo: { season: 1, episode: 1 },
+});
+
+const defaultParams = () => ({
+  showId: 'show-1',
+  dict: mockDict,
+  validSeasons: [makeSeason(1, ['e1-1', 'e1-2', 'e1-3'])],
+  progress: makeProgress([
+    { seasonNumber: 1, watchedEpisodeIds: [], totalCount: 3 },
+  ]),
+  selectedSeason: makeSeason(1, ['e1-1', 'e1-2', 'e1-3']),
+});
+
+describe('useCatchUp', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockMarkAllMutateAsync.mockResolvedValue(undefined);
+    mockUnmarkMutateAsync.mockResolvedValue(undefined);
+  });
+
+  describe('handleMarkAllClick', () => {
+    it('directly confirms catch-up for single-season shows', () => {
+      const { result } = renderHook(() => useCatchUp(defaultParams()));
+
+      act(() => {
+        result.current.handleMarkAllClick();
+      });
+
+      // Should call mutateAsync directly (no dialog)
+      expect(result.current.showConfirmDialog).toBe(false);
+      expect(mockMarkAllMutateAsync).toHaveBeenCalled();
+    });
+
+    it('opens confirm dialog for multi-season shows', () => {
+      const params = defaultParams();
+      params.validSeasons = [
+        makeSeason(1, ['e1-1']),
+        makeSeason(2, ['e2-1']),
+      ];
+
+      const { result } = renderHook(() => useCatchUp(params));
+
+      act(() => {
+        result.current.handleMarkAllClick();
+      });
+
+      expect(result.current.showConfirmDialog).toBe(true);
+      expect(mockMarkAllMutateAsync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleCatchUpConfirm', () => {
+    it('calls markAllWatched.mutateAsync with episodes to mark', async () => {
+      const { result } = renderHook(() => useCatchUp(defaultParams()));
+
+      const toMark = new Map([[1, ['e1-1', 'e1-2', 'e1-3']]]);
+
+      await act(async () => {
+        await result.current.handleCatchUpConfirm(toMark, new Map());
+      });
+
+      expect(mockMarkAllMutateAsync).toHaveBeenCalledWith({
+        episodesBySeasonNumber: toMark,
+      });
+    });
+
+    it('shows full catch-up toast when all episodes are marked', async () => {
+      const { result } = renderHook(() => useCatchUp(defaultParams()));
+
+      const toMark = new Map([[1, ['e1-1', 'e1-2', 'e1-3']]]);
+
+      await act(async () => {
+        await result.current.handleCatchUpConfirm(toMark, new Map());
+      });
+
+      expect(toast.success).toHaveBeenCalledWith(
+        'Все переглянуто!',
+        expect.objectContaining({ action: expect.any(Object), duration: 8000 }),
+      );
+    });
+
+    it('calls unmarkEpisodes.mutateAsync when toUnmark is provided', async () => {
+      const { result } = renderHook(() => useCatchUp(defaultParams()));
+
+      const toUnmark = new Map([[1, ['e1-3']]]);
+
+      await act(async () => {
+        await result.current.handleCatchUpConfirm(new Map(), toUnmark);
+      });
+
+      expect(mockUnmarkMutateAsync).toHaveBeenCalledWith(['e1-3']);
+    });
+
+    it('shows seasonReset toast when only unmarking', async () => {
+      const { result } = renderHook(() => useCatchUp(defaultParams()));
+
+      await act(async () => {
+        await result.current.handleCatchUpConfirm(new Map(), new Map([[1, ['e1-3']]]));
+      });
+
+      expect(toast.success).toHaveBeenCalledWith('Сезон скинуто');
+    });
+
+    it('shows error toast when mutation fails', async () => {
+      mockMarkAllMutateAsync.mockRejectedValue(new Error('fail'));
+
+      const { result } = renderHook(() => useCatchUp(defaultParams()));
+
+      await act(async () => {
+        await result.current.handleCatchUpConfirm(
+          new Map([[1, ['e1-1']]]),
+          new Map(),
+        );
+      });
+
+      expect(toast.error).toHaveBeenCalledWith('Помилка');
+    });
+
+    it('closes confirm dialog', async () => {
+      const { result } = renderHook(() => useCatchUp(defaultParams()));
+
+      act(() => {
+        result.current.setShowConfirmDialog(true);
+      });
+      expect(result.current.showConfirmDialog).toBe(true);
+
+      await act(async () => {
+        await result.current.handleCatchUpConfirm(new Map(), new Map());
+      });
+
+      expect(result.current.showConfirmDialog).toBe(false);
+    });
+  });
+
+  describe('handleResetSeasonClick', () => {
+    it('opens reset confirm dialog', () => {
+      const params = defaultParams();
+      params.progress = makeProgress([
+        { seasonNumber: 1, watchedEpisodeIds: ['e1-1', 'e1-2'], totalCount: 3 },
+      ]);
+
+      const { result } = renderHook(() => useCatchUp(params));
+
+      act(() => {
+        result.current.handleResetSeasonClick();
+      });
+
+      expect(result.current.showResetConfirmDialog).toBe(true);
+    });
+  });
+
+  describe('handleConfirmResetSeason', () => {
+    it('calls resetSeason.mutate with snapshotted episode IDs and season number', () => {
+      const params = defaultParams();
+      params.progress = makeProgress([
+        { seasonNumber: 1, watchedEpisodeIds: ['e1-1', 'e1-2'], totalCount: 3 },
+      ]);
+
+      const { result } = renderHook(() => useCatchUp(params));
+
+      // First open the dialog to snapshot state
+      act(() => {
+        result.current.handleResetSeasonClick();
+      });
+
+      // Then confirm
+      act(() => {
+        result.current.handleConfirmResetSeason();
+      });
+
+      expect(mockResetMutate).toHaveBeenCalledWith(
+        { episodeIds: ['e1-1', 'e1-2'], seasonNumber: 1 },
+        expect.any(Object),
+      );
+    });
+
+    it('closes reset confirm dialog', () => {
+      const params = defaultParams();
+      params.progress = makeProgress([
+        { seasonNumber: 1, watchedEpisodeIds: ['e1-1'], totalCount: 3 },
+      ]);
+
+      const { result } = renderHook(() => useCatchUp(params));
+
+      act(() => { result.current.handleResetSeasonClick(); });
+      expect(result.current.showResetConfirmDialog).toBe(true);
+
+      act(() => { result.current.handleConfirmResetSeason(); });
+      expect(result.current.showResetConfirmDialog).toBe(false);
+    });
+
+    it('does nothing when no episode IDs were snapshotted', () => {
+      const { result } = renderHook(() => useCatchUp(defaultParams()));
+
+      // Confirm without opening the dialog first (no snapshot)
+      act(() => {
+        result.current.handleConfirmResetSeason();
+      });
+
+      expect(mockResetMutate).not.toHaveBeenCalled();
+    });
+
+    it('shows success toast on reset', () => {
+      const params = defaultParams();
+      params.progress = makeProgress([
+        { seasonNumber: 1, watchedEpisodeIds: ['e1-1'], totalCount: 3 },
+      ]);
+
+      const { result } = renderHook(() => useCatchUp(params));
+
+      act(() => { result.current.handleResetSeasonClick(); });
+      act(() => { result.current.handleConfirmResetSeason(); });
+
+      const onSuccess = mockResetMutate.mock.calls[0][1].onSuccess;
+      act(() => { onSuccess(); });
+
+      expect(toast.success).toHaveBeenCalledWith('Сезон скинуто');
+    });
+
+    it('shows error toast on reset failure', () => {
+      const params = defaultParams();
+      params.progress = makeProgress([
+        { seasonNumber: 1, watchedEpisodeIds: ['e1-1'], totalCount: 3 },
+      ]);
+
+      const { result } = renderHook(() => useCatchUp(params));
+
+      act(() => { result.current.handleResetSeasonClick(); });
+      act(() => { result.current.handleConfirmResetSeason(); });
+
+      const onError = mockResetMutate.mock.calls[0][1].onError;
+      act(() => { onError(); });
+
+      expect(toast.error).toHaveBeenCalledWith('Помилка');
+    });
+
+    it('dismisses catch-up toast before resetting', () => {
+      const params = defaultParams();
+      params.progress = makeProgress([
+        { seasonNumber: 1, watchedEpisodeIds: ['e1-1'], totalCount: 3 },
+      ]);
+
+      const { result } = renderHook(() => useCatchUp(params));
+
+      act(() => { result.current.handleResetSeasonClick(); });
+      act(() => { result.current.handleConfirmResetSeason(); });
+
+      // toast.dismiss should not throw even without a prior toast
+      expect(result.current.showResetConfirmDialog).toBe(false);
+    });
+  });
+});

--- a/apps/web-client/src/modules/details/hooks/__tests__/use-episode-progress.spec.ts
+++ b/apps/web-client/src/modules/details/hooks/__tests__/use-episode-progress.spec.ts
@@ -1,0 +1,206 @@
+import { renderHook } from '@testing-library/react';
+import { useEpisodeProgress } from '../use-episode-progress';
+
+const mockUseShowProgress = jest.fn();
+jest.mock('@/core/query', () => ({
+  useShowProgress: (...args: unknown[]) => mockUseShowProgress(...args),
+}));
+
+const makeSeason = (
+  number: number,
+  episodes: { id?: string; number: number; airDate: string | null }[],
+) => ({
+  number,
+  name: null,
+  episodeCount: episodes.length,
+  posterPath: null,
+  airDate: null,
+  episodes: episodes.map((e) => ({
+    ...e,
+    title: null,
+    runtime: null,
+    stillPath: null,
+  })),
+});
+
+const makeProgressSeason = (
+  seasonNumber: number,
+  watchedEpisodeIds: string[],
+  totalCount: number,
+) => ({
+  seasonNumber,
+  watchedEpisodeIds,
+  watchedCount: watchedEpisodeIds.length,
+  totalCount,
+});
+
+describe('useEpisodeProgress', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseShowProgress.mockReturnValue({ data: null });
+  });
+
+  it('returns empty defaults when no progress data', () => {
+    const seasons = [makeSeason(1, [{ id: 'e1', number: 1, airDate: '2024-01-01' }])];
+
+    const { result } = renderHook(() =>
+      useEpisodeProgress('show-1', true, seasons, 1),
+    );
+
+    expect(result.current.progressData).toBeNull();
+    expect(result.current.currentSeasonProgress).toBeNull();
+    expect(result.current.watchedEpisodeIds.size).toBe(0);
+    expect(result.current.totalProgress).toEqual({ watched: 0, total: 0 });
+  });
+
+  it('finds currentSeasonProgress for the selected season', () => {
+    mockUseShowProgress.mockReturnValue({
+      data: {
+        seasons: [
+          makeProgressSeason(1, ['e1', 'e2'], 5),
+          makeProgressSeason(2, ['e10'], 8),
+        ],
+      },
+    });
+
+    const seasons = [
+      makeSeason(1, [{ id: 'e1', number: 1, airDate: '2024-01-01' }]),
+      makeSeason(2, [{ id: 'e10', number: 1, airDate: '2024-06-01' }]),
+    ];
+
+    const { result } = renderHook(() =>
+      useEpisodeProgress('show-1', true, seasons, 2),
+    );
+
+    expect(result.current.currentSeasonProgress?.seasonNumber).toBe(2);
+    expect(result.current.currentSeasonProgress?.watchedCount).toBe(1);
+  });
+
+  it('returns null currentSeasonProgress when selected season has no progress', () => {
+    mockUseShowProgress.mockReturnValue({
+      data: { seasons: [makeProgressSeason(1, ['e1'], 5)] },
+    });
+
+    const seasons = [
+      makeSeason(1, [{ id: 'e1', number: 1, airDate: '2024-01-01' }]),
+      makeSeason(2, [{ id: 'e10', number: 1, airDate: '2024-06-01' }]),
+    ];
+
+    const { result } = renderHook(() =>
+      useEpisodeProgress('show-1', true, seasons, 2),
+    );
+
+    expect(result.current.currentSeasonProgress).toBeNull();
+  });
+
+  it('builds watchedEpisodeIds Set from current season progress', () => {
+    mockUseShowProgress.mockReturnValue({
+      data: { seasons: [makeProgressSeason(1, ['e1', 'e3'], 5)] },
+    });
+
+    const seasons = [makeSeason(1, [
+      { id: 'e1', number: 1, airDate: '2024-01-01' },
+      { id: 'e2', number: 2, airDate: '2024-01-08' },
+      { id: 'e3', number: 3, airDate: '2024-01-15' },
+    ])];
+
+    const { result } = renderHook(() =>
+      useEpisodeProgress('show-1', true, seasons, 1),
+    );
+
+    expect(result.current.watchedEpisodeIds.has('e1')).toBe(true);
+    expect(result.current.watchedEpisodeIds.has('e2')).toBe(false);
+    expect(result.current.watchedEpisodeIds.has('e3')).toBe(true);
+  });
+
+  it('calculates totalProgress across all seasons', () => {
+    mockUseShowProgress.mockReturnValue({
+      data: {
+        seasons: [
+          makeProgressSeason(1, ['e1', 'e2'], 5),
+          makeProgressSeason(2, ['e10'], 8),
+        ],
+      },
+    });
+
+    const seasons = [
+      makeSeason(1, [{ id: 'e1', number: 1, airDate: '2024-01-01' }]),
+      makeSeason(2, [{ id: 'e10', number: 1, airDate: '2024-06-01' }]),
+    ];
+
+    const { result } = renderHook(() =>
+      useEpisodeProgress('show-1', true, seasons, 1),
+    );
+
+    expect(result.current.totalProgress).toEqual({ watched: 3, total: 13 });
+  });
+
+  it('groups aired episode IDs by season number, excluding future episodes', () => {
+    const futureDate = new Date();
+    futureDate.setFullYear(futureDate.getFullYear() + 1);
+
+    const seasons = [
+      makeSeason(1, [
+        { id: 'e1', number: 1, airDate: '2024-01-01' },
+        { id: 'e2', number: 2, airDate: '2024-01-08' },
+      ]),
+      makeSeason(2, [
+        { id: 'e10', number: 1, airDate: '2024-06-01' },
+        { id: 'e11', number: 2, airDate: futureDate.toISOString() },
+      ]),
+    ];
+
+    const { result } = renderHook(() =>
+      useEpisodeProgress('show-1', true, seasons, 1),
+    );
+
+    expect(result.current.allEpisodesBySeasonNumber.get(1)).toEqual(['e1', 'e2']);
+    expect(result.current.allEpisodesBySeasonNumber.get(2)).toEqual(['e10']);
+    expect(result.current.totalEpisodesCount).toBe(3);
+    expect(result.current.totalAllEpisodes).toBe(4);
+  });
+
+  it('tracks lastAiredEpisodeInfo across all seasons', () => {
+    const seasons = [
+      makeSeason(1, [
+        { id: 'e1', number: 1, airDate: '2024-01-01' },
+        { id: 'e2', number: 2, airDate: '2024-01-08' },
+      ]),
+      makeSeason(2, [
+        { id: 'e10', number: 1, airDate: '2024-06-01' },
+        { id: 'e11', number: 2, airDate: '2024-06-08' },
+      ]),
+    ];
+
+    const { result } = renderHook(() =>
+      useEpisodeProgress('show-1', true, seasons, 1),
+    );
+
+    expect(result.current.lastAiredEpisodeInfo).toEqual({ season: 2, episode: 2 });
+  });
+
+  it('skips seasons with no aired episodes in allEpisodesBySeasonNumber', () => {
+    const futureDate = new Date();
+    futureDate.setFullYear(futureDate.getFullYear() + 1);
+
+    const seasons = [
+      makeSeason(1, [{ id: 'e1', number: 1, airDate: '2024-01-01' }]),
+      makeSeason(2, [{ id: 'e10', number: 1, airDate: futureDate.toISOString() }]),
+    ];
+
+    const { result } = renderHook(() =>
+      useEpisodeProgress('show-1', true, seasons, 1),
+    );
+
+    expect(result.current.allEpisodesBySeasonNumber.has(1)).toBe(true);
+    expect(result.current.allEpisodesBySeasonNumber.has(2)).toBe(false);
+  });
+
+  it('passes showId and enabled to useShowProgress', () => {
+    const seasons = [makeSeason(1, [{ id: 'e1', number: 1, airDate: '2024-01-01' }])];
+
+    renderHook(() => useEpisodeProgress('show-42', false, seasons, 1));
+
+    expect(mockUseShowProgress).toHaveBeenCalledWith('show-42', { enabled: false });
+  });
+});

--- a/apps/web-client/src/modules/details/hooks/__tests__/use-episode-toggle.spec.ts
+++ b/apps/web-client/src/modules/details/hooks/__tests__/use-episode-toggle.spec.ts
@@ -1,0 +1,328 @@
+import { renderHook, act } from '@testing-library/react';
+import { useEpisodeToggle } from '../use-episode-toggle';
+
+jest.mock('sonner', () => ({
+  toast: { success: jest.fn(), info: jest.fn(), error: jest.fn() },
+}));
+
+import { toast } from 'sonner';
+
+const mockMutate = jest.fn();
+const mockMultipleMutate = jest.fn();
+
+jest.mock('@/core/query', () => ({
+  useToggleEpisodeWatched: () => ({
+    mutate: mockMutate,
+    isPending: false,
+  }),
+  useMarkMultipleWatched: () => ({
+    mutate: mockMultipleMutate,
+    isPending: false,
+  }),
+}));
+
+const mockDict = {
+  activity: {
+    toast: {
+      completed: 'Завершено',
+      addedToWatching: 'Додано до перегляду',
+      backToWatching: 'Повернено до перегляду',
+      removedFromActivity: 'Видалено з активності',
+    },
+  },
+} as ReturnType<typeof import('@/shared/i18n').getDictionary>;
+
+const makeEpisode = (id: string, number: number) => ({
+  id,
+  number,
+  title: null,
+  airDate: null,
+  runtime: null,
+  stillPath: null,
+});
+
+const defaultParams = () => ({
+  showId: 'show-1',
+  isAuthenticated: true,
+  dict: mockDict,
+  episodes: [makeEpisode('e1', 1), makeEpisode('e2', 2), makeEpisode('e3', 3)],
+  watchedEpisodeIds: new Set<string>(),
+  totalProgress: { watched: 0, total: 3 },
+});
+
+describe('useEpisodeToggle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('handleToggleWatched', () => {
+    it('calls mutate with correct params for unwatched episode', () => {
+      const { result } = renderHook(() => useEpisodeToggle(defaultParams()));
+
+      act(() => {
+        result.current.handleToggleWatched('e1', 1);
+      });
+
+      expect(mockMutate).toHaveBeenCalledWith(
+        { episodeId: 'e1', seasonNumber: 1, watched: true },
+        expect.any(Object),
+      );
+    });
+
+    it('calls mutate with watched=false for already watched episode', () => {
+      const params = defaultParams();
+      params.watchedEpisodeIds = new Set(['e1']);
+      params.totalProgress = { watched: 1, total: 3 };
+
+      const { result } = renderHook(() => useEpisodeToggle(params));
+
+      act(() => {
+        result.current.handleToggleWatched('e1', 1);
+      });
+
+      expect(mockMutate).toHaveBeenCalledWith(
+        { episodeId: 'e1', seasonNumber: 1, watched: false },
+        expect.any(Object),
+      );
+    });
+
+    it('sets togglingEpisodeId during mutation', () => {
+      const { result } = renderHook(() => useEpisodeToggle(defaultParams()));
+
+      act(() => {
+        result.current.handleToggleWatched('e2', 1);
+      });
+
+      expect(result.current.togglingEpisodeId).toBe('e2');
+    });
+
+    it('sets animatingIds when marking as watched', () => {
+      const { result } = renderHook(() => useEpisodeToggle(defaultParams()));
+
+      act(() => {
+        result.current.handleToggleWatched('e1', 1);
+      });
+
+      expect(result.current.animatingIds.has('e1')).toBe(true);
+    });
+
+    it('does not set animatingIds when unmarking', () => {
+      const params = defaultParams();
+      params.watchedEpisodeIds = new Set(['e1']);
+      params.totalProgress = { watched: 1, total: 3 };
+
+      const { result } = renderHook(() => useEpisodeToggle(params));
+
+      act(() => {
+        result.current.handleToggleWatched('e1', 1);
+      });
+
+      expect(result.current.animatingIds.size).toBe(0);
+    });
+
+    it('does not call mutate when not authenticated', () => {
+      const params = defaultParams();
+      params.isAuthenticated = false;
+
+      const { result } = renderHook(() => useEpisodeToggle(params));
+
+      act(() => {
+        result.current.handleToggleWatched('e1', 1);
+      });
+
+      expect(mockMutate).not.toHaveBeenCalled();
+    });
+
+    it('shows "completed" toast when last episode is marked', () => {
+      const params = defaultParams();
+      params.watchedEpisodeIds = new Set(['e1', 'e2']);
+      params.totalProgress = { watched: 2, total: 3 };
+
+      const { result } = renderHook(() => useEpisodeToggle(params));
+
+      act(() => {
+        result.current.handleToggleWatched('e3', 1);
+      });
+
+      // Trigger onSuccess
+      const onSuccess = mockMutate.mock.calls[0][1].onSuccess;
+      act(() => { onSuccess(); });
+
+      expect(toast.success).toHaveBeenCalledWith('Завершено');
+    });
+
+    it('shows "addedToWatching" toast when first episode is marked', () => {
+      const { result } = renderHook(() => useEpisodeToggle(defaultParams()));
+
+      act(() => {
+        result.current.handleToggleWatched('e1', 1);
+      });
+
+      const onSuccess = mockMutate.mock.calls[0][1].onSuccess;
+      act(() => { onSuccess(); });
+
+      expect(toast.success).toHaveBeenCalledWith('Додано до перегляду');
+    });
+
+    it('shows "backToWatching" toast when unmarking from completed state', () => {
+      const params = defaultParams();
+      params.watchedEpisodeIds = new Set(['e1', 'e2', 'e3']);
+      params.totalProgress = { watched: 3, total: 3 };
+
+      const { result } = renderHook(() => useEpisodeToggle(params));
+
+      act(() => {
+        result.current.handleToggleWatched('e3', 1);
+      });
+
+      const onSuccess = mockMutate.mock.calls[0][1].onSuccess;
+      act(() => { onSuccess(); });
+
+      expect(toast.info).toHaveBeenCalledWith('Повернено до перегляду');
+    });
+
+    it('shows "removedFromActivity" toast when last watched episode is unmarked', () => {
+      const params = defaultParams();
+      params.watchedEpisodeIds = new Set(['e1']);
+      params.totalProgress = { watched: 1, total: 3 };
+
+      const { result } = renderHook(() => useEpisodeToggle(params));
+
+      act(() => {
+        result.current.handleToggleWatched('e1', 1);
+      });
+
+      const onSuccess = mockMutate.mock.calls[0][1].onSuccess;
+      act(() => { onSuccess(); });
+
+      expect(toast.info).toHaveBeenCalledWith('Видалено з активності');
+    });
+
+    it('clears togglingEpisodeId and animatingIds on settled', () => {
+      const { result } = renderHook(() => useEpisodeToggle(defaultParams()));
+
+      act(() => {
+        result.current.handleToggleWatched('e1', 1);
+      });
+
+      expect(result.current.togglingEpisodeId).toBe('e1');
+
+      const onSettled = mockMutate.mock.calls[0][1].onSettled;
+      act(() => { onSettled(); });
+
+      expect(result.current.togglingEpisodeId).toBeNull();
+
+      act(() => { jest.advanceTimersByTime(350); });
+
+      expect(result.current.animatingIds.size).toBe(0);
+    });
+  });
+
+  describe('handleMarkWithPrevious', () => {
+    it('marks all unwatched episodes up to and including the given index', () => {
+      const { result } = renderHook(() => useEpisodeToggle(defaultParams()));
+
+      act(() => {
+        result.current.handleMarkWithPrevious(2, 1);
+      });
+
+      expect(mockMultipleMutate).toHaveBeenCalledWith(
+        { episodeIds: ['e1', 'e2', 'e3'], seasonNumber: 1 },
+        expect.any(Object),
+      );
+    });
+
+    it('skips already watched episodes', () => {
+      const params = defaultParams();
+      params.watchedEpisodeIds = new Set(['e1']);
+      params.totalProgress = { watched: 1, total: 3 };
+
+      const { result } = renderHook(() => useEpisodeToggle(params));
+
+      act(() => {
+        result.current.handleMarkWithPrevious(2, 1);
+      });
+
+      expect(mockMultipleMutate).toHaveBeenCalledWith(
+        { episodeIds: ['e2', 'e3'], seasonNumber: 1 },
+        expect.any(Object),
+      );
+    });
+
+    it('does nothing when all episodes up to index are already watched', () => {
+      const params = defaultParams();
+      params.watchedEpisodeIds = new Set(['e1', 'e2']);
+      params.totalProgress = { watched: 2, total: 3 };
+
+      const { result } = renderHook(() => useEpisodeToggle(params));
+
+      act(() => {
+        result.current.handleMarkWithPrevious(1, 1);
+      });
+
+      expect(mockMultipleMutate).not.toHaveBeenCalled();
+    });
+
+    it('sets animatingIds for all episodes being marked', () => {
+      const { result } = renderHook(() => useEpisodeToggle(defaultParams()));
+
+      act(() => {
+        result.current.handleMarkWithPrevious(1, 1);
+      });
+
+      expect(result.current.animatingIds.has('e1')).toBe(true);
+      expect(result.current.animatingIds.has('e2')).toBe(true);
+    });
+
+    it('does not call mutate when not authenticated', () => {
+      const params = defaultParams();
+      params.isAuthenticated = false;
+
+      const { result } = renderHook(() => useEpisodeToggle(params));
+
+      act(() => {
+        result.current.handleMarkWithPrevious(2, 1);
+      });
+
+      expect(mockMultipleMutate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getUnwatchedPreviousCount', () => {
+    it('returns count of unwatched episodes before given index', () => {
+      const params = defaultParams();
+      params.watchedEpisodeIds = new Set(['e2']);
+
+      const { result } = renderHook(() => useEpisodeToggle(params));
+
+      // Before index 2: e1 (unwatched), e2 (watched) → 1 unwatched
+      expect(result.current.getUnwatchedPreviousCount(2)).toBe(1);
+    });
+
+    it('returns 0 for index 0', () => {
+      const { result } = renderHook(() => useEpisodeToggle(defaultParams()));
+
+      expect(result.current.getUnwatchedPreviousCount(0)).toBe(0);
+    });
+
+    it('returns 0 when all previous episodes are watched', () => {
+      const params = defaultParams();
+      params.watchedEpisodeIds = new Set(['e1', 'e2']);
+
+      const { result } = renderHook(() => useEpisodeToggle(params));
+
+      expect(result.current.getUnwatchedPreviousCount(2)).toBe(0);
+    });
+
+    it('counts all unwatched when none are watched', () => {
+      const { result } = renderHook(() => useEpisodeToggle(defaultParams()));
+
+      expect(result.current.getUnwatchedPreviousCount(3)).toBe(3);
+    });
+  });
+});

--- a/apps/web-client/src/modules/details/hooks/use-catch-up.ts
+++ b/apps/web-client/src/modules/details/hooks/use-catch-up.ts
@@ -1,0 +1,200 @@
+import { useState, useRef, useCallback } from 'react';
+import { toast } from 'sonner';
+import type { components } from '@ratingo/api-contract';
+import type { getDictionary } from '@/shared/i18n';
+import {
+  useMarkAllEpisodesWatched,
+  useUnmarkEpisodes,
+  useResetSeason,
+} from '@/core/query';
+import type { EpisodeProgressData } from './use-episode-progress';
+
+type SeasonDto = components['schemas']['SeasonDto'];
+
+interface UseCatchUpParams {
+  showId: string;
+  dict: ReturnType<typeof getDictionary>;
+  validSeasons: SeasonDto[];
+  progress: EpisodeProgressData;
+  selectedSeason: SeasonDto | null;
+}
+
+export function useCatchUp({
+  showId,
+  dict,
+  validSeasons,
+  progress,
+  selectedSeason,
+}: UseCatchUpParams) {
+  const { progressData, currentSeasonProgress, allEpisodesBySeasonNumber, totalEpisodesCount, totalAllEpisodes } = progress;
+
+  const markAllWatched = useMarkAllEpisodesWatched(showId);
+  const unmarkEpisodes = useUnmarkEpisodes(showId);
+  const resetSeason = useResetSeason(showId);
+
+  const [showConfirmDialog, setShowConfirmDialog] = useState(false);
+  const [showResetConfirmDialog, setShowResetConfirmDialog] = useState(false);
+
+  const previousWatchedIdsRef = useRef<Map<number, string[]> | null>(null);
+  const selectedEpisodesRef = useRef<Map<number, string[]> | null>(null);
+  const catchUpToastIdRef = useRef<string | number | null>(null);
+  const resetEpisodeIdsRef = useRef<string[] | null>(null);
+  const resetSeasonNumberRef = useRef<number | null>(null);
+
+  const handleUndo = useCallback(() => {
+    const previousWatched = previousWatchedIdsRef.current;
+    const selectedEpisodes = selectedEpisodesRef.current;
+    if (!previousWatched || !selectedEpisodes) return;
+
+    const selectedEpisodeIds: string[] = [];
+    selectedEpisodes.forEach((ids) => {
+      selectedEpisodeIds.push(...ids);
+    });
+
+    const previouslyWatchedIds = new Set<string>();
+    previousWatched.forEach((ids) => {
+      ids.forEach((id) => previouslyWatchedIds.add(id));
+    });
+
+    const episodesToUnmark = selectedEpisodeIds.filter((id) => !previouslyWatchedIds.has(id));
+    if (episodesToUnmark.length === 0) return;
+
+    unmarkEpisodes.mutate(episodesToUnmark, {
+      onSuccess: () => {
+        toast.success(dict.details.showStatus.undone);
+        previousWatchedIdsRef.current = null;
+        selectedEpisodesRef.current = null;
+      },
+      onError: () => {
+        toast.error(dict.common?.error || 'Щось пішло не так');
+      },
+    });
+  }, [unmarkEpisodes, dict]);
+
+  const handleCatchUpConfirm = useCallback(async (
+    toMark: Map<number, string[]>,
+    toUnmark: Map<number, string[]>,
+  ) => {
+    setShowConfirmDialog(false);
+
+    if (progressData) {
+      const prevMap = new Map<number, string[]>();
+      progressData.seasons.forEach((s) => {
+        prevMap.set(s.seasonNumber, [...s.watchedEpisodeIds]);
+      });
+      previousWatchedIdsRef.current = prevMap;
+    }
+    selectedEpisodesRef.current = toMark;
+
+    try {
+      if (toMark.size > 0) {
+        let selectedLastSeason = 0;
+        let selectedLastEpisode = 0;
+        const now = Date.now();
+        for (const season of validSeasons) {
+          if (!toMark.has(season.number)) continue;
+          for (const ep of season.episodes || []) {
+            if (ep.airDate && new Date(ep.airDate).getTime() > now) continue;
+            selectedLastSeason = season.number;
+            selectedLastEpisode = ep.number;
+          }
+        }
+
+        const selectedTotal = Array.from(toMark.values()).reduce((sum, ids) => sum + ids.length, 0);
+        const isFullCatchUp = selectedTotal === totalEpisodesCount && totalEpisodesCount === totalAllEpisodes;
+
+        await markAllWatched.mutateAsync({ episodesBySeasonNumber: toMark });
+
+        const message = isFullCatchUp
+          ? dict.details.showStatus.caughtUpAll
+          : dict.details.showStatus.caughtUp
+              .replace('{season}', String(selectedLastSeason))
+              .replace('{episode}', String(selectedLastEpisode));
+
+        if (toUnmark.size === 0) {
+          catchUpToastIdRef.current = toast.success(message, {
+            action: {
+              label: dict.details.showStatus.undo,
+              onClick: handleUndo,
+            },
+            duration: 8000,
+          });
+        } else {
+          toast.success(message);
+        }
+      }
+
+      if (toUnmark.size > 0) {
+        const idsToUnmark: string[] = [];
+        toUnmark.forEach((ids) => {
+          idsToUnmark.push(...ids);
+        });
+        if (idsToUnmark.length > 0) {
+          await unmarkEpisodes.mutateAsync(idsToUnmark);
+        }
+
+        if (toMark.size === 0) {
+          toast.success(dict.details.showStatus.seasonReset);
+        }
+
+        previousWatchedIdsRef.current = null;
+        selectedEpisodesRef.current = null;
+      }
+    } catch {
+      toast.error(dict.common?.error || 'Щось пішло не так');
+    }
+  }, [progressData, validSeasons, markAllWatched, unmarkEpisodes, dict, handleUndo, totalEpisodesCount, totalAllEpisodes]);
+
+  const handleMarkAllClick = useCallback(() => {
+    if (validSeasons.length <= 1) {
+      handleCatchUpConfirm(allEpisodesBySeasonNumber, new Map());
+    } else {
+      setShowConfirmDialog(true);
+    }
+  }, [validSeasons.length, handleCatchUpConfirm, allEpisodesBySeasonNumber]);
+
+  const handleResetSeasonClick = useCallback(() => {
+    resetEpisodeIdsRef.current = currentSeasonProgress?.watchedEpisodeIds?.slice() ?? null;
+    resetSeasonNumberRef.current = selectedSeason?.number ?? null;
+    setShowResetConfirmDialog(true);
+  }, [currentSeasonProgress?.watchedEpisodeIds, selectedSeason?.number]);
+
+  const handleConfirmResetSeason = useCallback(() => {
+    setShowResetConfirmDialog(false);
+    if (catchUpToastIdRef.current !== null) {
+      toast.dismiss(catchUpToastIdRef.current);
+      catchUpToastIdRef.current = null;
+    }
+    const ids = resetEpisodeIdsRef.current;
+    const seasonNumber = resetSeasonNumberRef.current;
+    resetEpisodeIdsRef.current = null;
+    resetSeasonNumberRef.current = null;
+    if (!ids || ids.length === 0 || seasonNumber === null) return;
+
+    resetSeason.mutate(
+      { episodeIds: ids, seasonNumber },
+      {
+        onSuccess: () => {
+          toast.success(dict.details.showStatus.seasonReset);
+        },
+        onError: () => {
+          toast.error(dict.common?.error || 'Щось пішло не так');
+        },
+      },
+    );
+  }, [resetSeason, dict]);
+
+  return {
+    showConfirmDialog,
+    setShowConfirmDialog,
+    showResetConfirmDialog,
+    setShowResetConfirmDialog,
+    handleCatchUpConfirm,
+    handleMarkAllClick,
+    handleResetSeasonClick,
+    handleConfirmResetSeason,
+    isMarkingAll: markAllWatched.isPending,
+    isUnmarking: unmarkEpisodes.isPending,
+    isResettingSeason: resetSeason.isPending,
+  };
+}

--- a/apps/web-client/src/modules/details/hooks/use-episode-progress.ts
+++ b/apps/web-client/src/modules/details/hooks/use-episode-progress.ts
@@ -1,0 +1,96 @@
+import { useMemo } from 'react';
+import type { components } from '@ratingo/api-contract';
+import { useShowProgress } from '@/core/query';
+
+type SeasonDto = components['schemas']['SeasonDto'];
+
+export interface EpisodeProgressData {
+  progressData: ReturnType<typeof useShowProgress>['data'];
+  currentSeasonProgress: {
+    watchedCount: number;
+    totalCount: number;
+    watchedEpisodeIds: string[];
+    seasonNumber: number;
+  } | null;
+  watchedEpisodeIds: Set<string>;
+  totalProgress: { watched: number; total: number };
+  allEpisodesBySeasonNumber: Map<number, string[]>;
+  totalEpisodesCount: number;
+  totalAllEpisodes: number;
+  lastAiredEpisodeInfo: { season: number; episode: number };
+}
+
+export function useEpisodeProgress(
+  showId: string | undefined,
+  enabled: boolean,
+  validSeasons: SeasonDto[],
+  selectedSeasonNumber: number | undefined,
+): EpisodeProgressData {
+  const { data: progressData } = useShowProgress(showId, { enabled });
+
+  const currentSeasonProgress = progressData?.seasons.find(
+    (s) => s.seasonNumber === selectedSeasonNumber
+  ) ?? null;
+
+  const watchedEpisodeIds = useMemo(
+    () => new Set(currentSeasonProgress?.watchedEpisodeIds || []),
+    [currentSeasonProgress?.watchedEpisodeIds],
+  );
+
+  const totalProgress = useMemo(() => {
+    if (!progressData) return { watched: 0, total: 0 };
+    return progressData.seasons.reduce(
+      (acc, s) => ({
+        watched: acc.watched + s.watchedCount,
+        total: acc.total + s.totalCount,
+      }),
+      { watched: 0, total: 0 },
+    );
+  }, [progressData]);
+
+  const { allEpisodesBySeasonNumber, totalEpisodesCount, totalAllEpisodes, lastAiredEpisodeInfo } = useMemo(() => {
+    const now = Date.now();
+    const map = new Map<number, string[]>();
+    let airedCount = 0;
+    let allCount = 0;
+    let lastSeason = 0;
+    let lastEpisode = 0;
+
+    for (const season of validSeasons) {
+      const episodes = season.episodes || [];
+      const ids: string[] = [];
+      allCount += episodes.length;
+
+      for (const ep of episodes) {
+        const airDate = ep.airDate;
+        if (airDate && new Date(airDate).getTime() > now) continue;
+        airedCount++;
+        if (ep.id) ids.push(ep.id);
+        lastSeason = season.number;
+        lastEpisode = ep.number;
+      }
+
+      if (ids.length > 0) {
+        map.set(season.number, ids);
+      }
+    }
+
+    return {
+      allEpisodesBySeasonNumber: map,
+      totalEpisodesCount: airedCount,
+      totalAllEpisodes: allCount,
+      lastAiredEpisodeInfo: { season: lastSeason, episode: lastEpisode },
+    };
+  }, [validSeasons]);
+
+  return {
+    progressData,
+    currentSeasonProgress,
+    watchedEpisodeIds,
+    totalProgress,
+    allEpisodesBySeasonNumber,
+    totalEpisodesCount,
+    totalAllEpisodes,
+    lastAiredEpisodeInfo,
+  };
+}

--- a/apps/web-client/src/modules/details/hooks/use-episode-toggle.ts
+++ b/apps/web-client/src/modules/details/hooks/use-episode-toggle.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { toast } from 'sonner';
 import type { components } from '@ratingo/api-contract';
 import type { getDictionary } from '@/shared/i18n';
@@ -31,8 +31,31 @@ export function useEpisodeToggle({
 
   const [togglingEpisodeId, setTogglingEpisodeId] = useState<string | null>(null);
   const [animatingIds, setAnimatingIds] = useState<Set<string>>(new Set());
+  const clearAnimatingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   const clearAnimating = useCallback(
     () => setAnimatingIds((prev) => (prev.size > 0 ? new Set() : prev)),
+    [],
+  );
+
+  const scheduleClearAnimating = useCallback(() => {
+    if (clearAnimatingTimeoutRef.current !== null) {
+      clearTimeout(clearAnimatingTimeoutRef.current);
+    }
+    clearAnimatingTimeoutRef.current = setTimeout(() => {
+      clearAnimatingTimeoutRef.current = null;
+      clearAnimating();
+    }, 350);
+  }, [clearAnimating]);
+
+  // Cancel any pending clear-animating timer when the hook unmounts so we
+  // never call setState on an unmounted component.
+  useEffect(
+    () => () => {
+      if (clearAnimatingTimeoutRef.current !== null) {
+        clearTimeout(clearAnimatingTimeoutRef.current);
+      }
+    },
     [],
   );
 
@@ -74,12 +97,20 @@ export function useEpisodeToggle({
           },
           onSettled: () => {
             setTogglingEpisodeId(null);
-            setTimeout(clearAnimating, 350);
+            scheduleClearAnimating();
           },
         },
       );
     },
-    [isAuthenticated, toggleWatched, markMultipleWatched.isPending, watchedEpisodeIds, totalProgress, dict],
+    [
+      isAuthenticated,
+      toggleWatched,
+      markMultipleWatched.isPending,
+      watchedEpisodeIds,
+      totalProgress,
+      dict,
+      scheduleClearAnimating,
+    ],
   );
 
   const handleMarkWithPrevious = useCallback(
@@ -118,12 +149,21 @@ export function useEpisodeToggle({
           },
           onSettled: () => {
             setTogglingEpisodeId(null);
-            setTimeout(clearAnimating, 350);
+            scheduleClearAnimating();
           },
         },
       );
     },
-    [isAuthenticated, markMultipleWatched, toggleWatched.isPending, episodes, watchedEpisodeIds, totalProgress, dict],
+    [
+      isAuthenticated,
+      markMultipleWatched,
+      toggleWatched.isPending,
+      episodes,
+      watchedEpisodeIds,
+      totalProgress,
+      dict,
+      scheduleClearAnimating,
+    ],
   );
 
   const getUnwatchedPreviousCount = useCallback(

--- a/apps/web-client/src/modules/details/hooks/use-episode-toggle.ts
+++ b/apps/web-client/src/modules/details/hooks/use-episode-toggle.ts
@@ -1,0 +1,150 @@
+import { useState, useCallback } from 'react';
+import { toast } from 'sonner';
+import type { components } from '@ratingo/api-contract';
+import type { getDictionary } from '@/shared/i18n';
+import {
+  useToggleEpisodeWatched,
+  useMarkMultipleWatched,
+} from '@/core/query';
+
+type EpisodeDto = components['schemas']['EpisodeDto'];
+
+interface UseEpisodeToggleParams {
+  showId: string;
+  isAuthenticated: boolean;
+  dict: ReturnType<typeof getDictionary>;
+  episodes: EpisodeDto[];
+  watchedEpisodeIds: Set<string>;
+  totalProgress: { watched: number; total: number };
+}
+
+export function useEpisodeToggle({
+  showId,
+  isAuthenticated,
+  dict,
+  episodes,
+  watchedEpisodeIds,
+  totalProgress,
+}: UseEpisodeToggleParams) {
+  const toggleWatched = useToggleEpisodeWatched(showId);
+  const markMultipleWatched = useMarkMultipleWatched(showId);
+
+  const [togglingEpisodeId, setTogglingEpisodeId] = useState<string | null>(null);
+  const [animatingIds, setAnimatingIds] = useState<Set<string>>(new Set());
+  const clearAnimating = useCallback(
+    () => setAnimatingIds((prev) => (prev.size > 0 ? new Set() : prev)),
+    [],
+  );
+
+  const handleToggleWatched = useCallback(
+    (episodeId: string, seasonNumber: number) => {
+      if (!isAuthenticated || toggleWatched.isPending || markMultipleWatched.isPending) return;
+
+      const isCurrentlyWatched = watchedEpisodeIds.has(episodeId);
+      const wasCompleted = totalProgress.watched === totalProgress.total && totalProgress.total > 0;
+      const prevWatched = totalProgress.watched;
+
+      setTogglingEpisodeId(episodeId);
+
+      if (!isCurrentlyWatched) {
+        setAnimatingIds(new Set([episodeId]));
+      }
+
+      toggleWatched.mutate(
+        {
+          episodeId,
+          seasonNumber,
+          watched: !isCurrentlyWatched,
+        },
+        {
+          onSuccess: () => {
+            const newWatched = isCurrentlyWatched ? prevWatched - 1 : prevWatched + 1;
+            const prevTotal = totalProgress.total;
+            const isNowCompleted = newWatched === prevTotal && prevTotal > 0;
+
+            if (!isCurrentlyWatched && isNowCompleted) {
+              toast.success(dict.activity.toast.completed);
+            } else if (!isCurrentlyWatched && prevWatched === 0) {
+              toast.success(dict.activity.toast.addedToWatching);
+            } else if (isCurrentlyWatched && wasCompleted) {
+              toast.info(dict.activity.toast.backToWatching);
+            } else if (isCurrentlyWatched && newWatched === 0) {
+              toast.info(dict.activity.toast.removedFromActivity);
+            }
+          },
+          onSettled: () => {
+            setTogglingEpisodeId(null);
+            setTimeout(clearAnimating, 350);
+          },
+        },
+      );
+    },
+    [isAuthenticated, toggleWatched, markMultipleWatched.isPending, watchedEpisodeIds, totalProgress, dict],
+  );
+
+  const handleMarkWithPrevious = useCallback(
+    (episodeIndex: number, seasonNumber: number) => {
+      if (!isAuthenticated || markMultipleWatched.isPending || toggleWatched.isPending) return;
+
+      const episodesToMark: string[] = [];
+      for (let i = 0; i <= episodeIndex; i++) {
+        const ep = episodes[i];
+        if (ep.id && !watchedEpisodeIds.has(ep.id)) {
+          episodesToMark.push(ep.id);
+        }
+      }
+
+      if (episodesToMark.length === 0) return;
+
+      const prevWatched = totalProgress.watched;
+      setTogglingEpisodeId(episodesToMark[episodesToMark.length - 1]);
+      setAnimatingIds(new Set(episodesToMark));
+
+      markMultipleWatched.mutate(
+        {
+          episodeIds: episodesToMark,
+          seasonNumber,
+        },
+        {
+          onSuccess: () => {
+            const newWatched = prevWatched + episodesToMark.length;
+            const isNowCompleted = newWatched === totalProgress.total && totalProgress.total > 0;
+
+            if (isNowCompleted) {
+              toast.success(dict.activity.toast.completed);
+            } else if (prevWatched === 0) {
+              toast.success(dict.activity.toast.addedToWatching);
+            }
+          },
+          onSettled: () => {
+            setTogglingEpisodeId(null);
+            setTimeout(clearAnimating, 350);
+          },
+        },
+      );
+    },
+    [isAuthenticated, markMultipleWatched, toggleWatched.isPending, episodes, watchedEpisodeIds, totalProgress, dict],
+  );
+
+  const getUnwatchedPreviousCount = useCallback(
+    (episodeIndex: number): number => {
+      let count = 0;
+      for (let i = 0; i < episodeIndex; i++) {
+        const ep = episodes[i];
+        if (ep.id && !watchedEpisodeIds.has(ep.id)) {
+          count++;
+        }
+      }
+      return count;
+    },
+    [episodes, watchedEpisodeIds],
+  );
+
+  return {
+    togglingEpisodeId,
+    animatingIds,
+    handleToggleWatched,
+    handleMarkWithPrevious,
+    getUnwatchedPreviousCount,
+  };
+}

--- a/apps/web-client/src/modules/saved/hooks/__tests__/use-me-lists.test.tsx
+++ b/apps/web-client/src/modules/saved/hooks/__tests__/use-me-lists.test.tsx
@@ -9,6 +9,7 @@ import {
   useCompleted,
   usePaused,
   useDropped,
+  useListCounts,
   usePauseMedia,
   useResumeMedia,
   useDropMedia,
@@ -26,6 +27,7 @@ jest.mock('@/core/api/me-lists.client', () => ({
     getHistory: jest.fn(),
     getPaused: jest.fn(),
     getDropped: jest.fn(),
+    getListCounts: jest.fn(),
     pauseMedia: jest.fn(),
     resumeMedia: jest.fn(),
     dropMedia: jest.fn(),
@@ -49,6 +51,7 @@ const mockGetActivity = meListsApi.getActivity as jest.Mock;
 const mockGetHistory = meListsApi.getHistory as jest.Mock;
 const mockGetPaused = meListsApi.getPaused as jest.Mock;
 const mockGetDropped = meListsApi.getDropped as jest.Mock;
+const mockGetListCounts = meListsApi.getListCounts as jest.Mock;
 const mockPauseMedia = meListsApi.pauseMedia as jest.Mock;
 const mockResumeMedia = meListsApi.resumeMedia as jest.Mock;
 const mockDropMedia = meListsApi.dropMedia as jest.Mock;
@@ -258,7 +261,7 @@ describe('useWatching', () => {
     queryClient.clear();
   });
 
-  it('returns watching items from getActivity', async () => {
+  it('requests watching items from /me/activity', async () => {
     const items = [
       makeHistoryItem({ mediaItemId: 'w1', state: 'watching' }),
       makeHistoryItem({ mediaItemId: 'w2', state: 'watching' }),
@@ -278,7 +281,7 @@ describe('useWatching', () => {
     expect(data.data.every((item: { state: string }) => item.state === 'watching')).toBe(true);
   });
 
-  it('returns empty array when no watching items exist', async () => {
+  it('returns empty array when server returns no watching items', async () => {
     mockGetActivity.mockResolvedValue(makeHistoryResponse([]));
 
     renderWithClient(<WatchingConsumer />, queryClient);
@@ -523,6 +526,119 @@ describe('useDropped', () => {
 
     expect(mockGetDropped).not.toHaveBeenCalled();
     expect(screen.getByTestId('status').textContent).toBe('pending');
+  });
+});
+
+describe('useListCounts', () => {
+  let queryClient: QueryClient;
+
+  function ListCountsConsumer({ enabled = true }: { enabled?: boolean }) {
+    const query = useListCounts(enabled);
+    return (
+      <div>
+        <div data-testid="status">{query.status}</div>
+        <div data-testid="data">{JSON.stringify(query.data ?? null)}</div>
+      </div>
+    );
+  }
+
+  beforeEach(() => {
+    queryClient = createQueryClient();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  it('fetches aggregated counts for all lists in a single request', async () => {
+    mockGetListCounts.mockResolvedValue({
+      watching: 3,
+      paused: 1,
+      dropped: 0,
+      completed: 42,
+      forLater: 10,
+      considering: 4,
+    });
+
+    renderWithClient(<ListCountsConsumer />, queryClient);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('status').textContent).toBe('success');
+    });
+
+    expect(mockGetListCounts).toHaveBeenCalledTimes(1);
+    const data = JSON.parse(screen.getByTestId('data').textContent!);
+    expect(data).toEqual({
+      watching: 3,
+      paused: 1,
+      dropped: 0,
+      completed: 42,
+      forLater: 10,
+      considering: 4,
+    });
+  });
+
+  it('does not fetch when enabled is false', async () => {
+    renderWithClient(<ListCountsConsumer enabled={false} />, queryClient);
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    expect(mockGetListCounts).not.toHaveBeenCalled();
+    expect(screen.getByTestId('status').textContent).toBe('pending');
+  });
+
+  it('deduplicates requests when multiple consumers mount at once', async () => {
+    mockGetListCounts.mockResolvedValue({
+      watching: 0,
+      paused: 0,
+      dropped: 0,
+      completed: 0,
+      forLater: 0,
+      considering: 0,
+    });
+
+    renderWithClient(
+      <>
+        <ListCountsConsumer />
+        <ListCountsConsumer />
+        <ListCountsConsumer />
+      </>,
+      queryClient,
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('status')[0].textContent).toBe('success');
+    });
+
+    // TanStack Query dedupes by queryKey → single network call
+    expect(mockGetListCounts).toHaveBeenCalledTimes(1);
+  });
+
+  it('is invalidated when pause/resume/drop/restore mutations invalidate meLists.counts', async () => {
+    // Seed cache
+    mockGetListCounts.mockResolvedValue({
+      watching: 0,
+      paused: 0,
+      dropped: 0,
+      completed: 0,
+      forLater: 0,
+      considering: 0,
+    });
+    renderWithClient(<ListCountsConsumer />, queryClient);
+    await waitFor(() => {
+      expect(screen.getByTestId('status').textContent).toBe('success');
+    });
+
+    const stateBefore = queryClient.getQueryState(queryKeys.meLists.counts);
+    expect(stateBefore?.isInvalidated).toBe(false);
+
+    queryClient.invalidateQueries({ queryKey: queryKeys.meLists.counts });
+
+    const stateAfter = queryClient.getQueryState(queryKeys.meLists.counts);
+    expect(stateAfter?.isInvalidated).toBe(true);
   });
 });
 
@@ -917,6 +1033,11 @@ describe('usePauseMedia', () => {
     expect(invalidateSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         queryKey: queryKeys.meLists.pausedAll,
+      }),
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: queryKeys.meLists.counts,
       }),
     );
 

--- a/apps/web-client/src/modules/saved/hooks/__tests__/use-me-lists.test.tsx
+++ b/apps/web-client/src/modules/saved/hooks/__tests__/use-me-lists.test.tsx
@@ -616,30 +616,6 @@ describe('useListCounts', () => {
     // TanStack Query dedupes by queryKey → single network call
     expect(mockGetListCounts).toHaveBeenCalledTimes(1);
   });
-
-  it('is invalidated when pause/resume/drop/restore mutations invalidate meLists.counts', async () => {
-    // Seed cache
-    mockGetListCounts.mockResolvedValue({
-      watching: 0,
-      paused: 0,
-      dropped: 0,
-      completed: 0,
-      forLater: 0,
-      considering: 0,
-    });
-    renderWithClient(<ListCountsConsumer />, queryClient);
-    await waitFor(() => {
-      expect(screen.getByTestId('status').textContent).toBe('success');
-    });
-
-    const stateBefore = queryClient.getQueryState(queryKeys.meLists.counts);
-    expect(stateBefore?.isInvalidated).toBe(false);
-
-    queryClient.invalidateQueries({ queryKey: queryKeys.meLists.counts });
-
-    const stateAfter = queryClient.getQueryState(queryKeys.meLists.counts);
-    expect(stateAfter?.isInvalidated).toBe(true);
-  });
 });
 
 describe('useFavoriteUpdates', () => {

--- a/apps/web-client/src/modules/saved/hooks/index.ts
+++ b/apps/web-client/src/modules/saved/hooks/index.ts
@@ -5,5 +5,5 @@ export {
   useUnsaveItem,
 } from './use-saved-items';
 export { useSubscriptions, useSubscribe, useUnsubscribe } from './use-subscriptions';
-export { useWatching, useCompleted, useSetRating, useUserMediaState } from './use-me-lists';
+export { useWatching, useCompleted, useSetRating, useUserMediaState, useListCounts } from './use-me-lists';
 export { useMeListState } from './use-me-list-state';

--- a/apps/web-client/src/modules/saved/hooks/use-me-lists.ts
+++ b/apps/web-client/src/modules/saved/hooks/use-me-lists.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo } from 'react';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { meListsApi, USER_MEDIA_STATE, type MeListSort, type MeUserMediaListItemDto } from '@/core/api/me-lists.client';
 import type { MediaType } from '@/shared/types';
 import { queryKeys } from '@/core/query/keys';
@@ -99,6 +99,28 @@ export function useDropped({ sort, type = 'all', limit = PAGE_SIZE, enabled = tr
   });
 }
 
+/**
+ * Fetches aggregated counts for all user lists in a single request.
+ * Used to render tab-count badges without pulling full list payloads.
+ *
+ * `keepPreviousData` avoids badge flicker (briefly showing 0) during
+ * background refetches triggered by invalidations.
+ *
+ * Note: `watching` count uses strict `state=watching` matching while the
+ * Watchlist tab list uses `/me/activity` (state OR progress), so badge
+ * and list totals may differ for shows with progress in paused/dropped
+ * state. Aligning this is a follow-up.
+ */
+export function useListCounts(enabled = true) {
+  return useQuery({
+    queryKey: queryKeys.meLists.counts,
+    queryFn: () => meListsApi.getListCounts(),
+    enabled,
+    staleTime: STALE_5_MIN,
+    placeholderData: keepPreviousData,
+  });
+}
+
 export function usePauseMedia() {
   const queryClient = useQueryClient();
 
@@ -110,6 +132,7 @@ export function usePauseMedia() {
       queryClient.invalidateQueries({ queryKey: queryKeys.meLists.ratingsAll });
       queryClient.invalidateQueries({ queryKey: queryKeys.meLists.pausedAll });
       queryClient.invalidateQueries({ queryKey: queryKeys.meLists.caughtUpAll });
+      queryClient.invalidateQueries({ queryKey: queryKeys.meLists.counts });
       queryClient.invalidateQueries({ queryKey: queryKeys.userMedia.state(mediaItemId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.shows.personalizedCalendarAll });
     },
@@ -127,6 +150,7 @@ export function useResumeMedia() {
       queryClient.invalidateQueries({ queryKey: queryKeys.meLists.ratingsAll });
       queryClient.invalidateQueries({ queryKey: queryKeys.meLists.pausedAll });
       queryClient.invalidateQueries({ queryKey: queryKeys.meLists.caughtUpAll });
+      queryClient.invalidateQueries({ queryKey: queryKeys.meLists.counts });
       queryClient.invalidateQueries({ queryKey: queryKeys.userMedia.state(mediaItemId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.shows.personalizedCalendarAll });
     },
@@ -139,13 +163,13 @@ export function useDropMedia() {
   return useMutation({
     mutationFn: (mediaItemId: string) => meListsApi.dropMedia(mediaItemId),
     onSuccess: (_data, mediaItemId) => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.meLists.activityAll });
       queryClient.invalidateQueries({ queryKey: queryKeys.meLists.historyAll });
       queryClient.invalidateQueries({ queryKey: queryKeys.meLists.ratingsAll });
       queryClient.invalidateQueries({ queryKey: queryKeys.meLists.pausedAll });
       queryClient.invalidateQueries({ queryKey: queryKeys.meLists.caughtUpAll });
       queryClient.invalidateQueries({ queryKey: queryKeys.meLists.watchlistAll });
       queryClient.invalidateQueries({ queryKey: queryKeys.meLists.droppedAll });
+      queryClient.invalidateQueries({ queryKey: queryKeys.meLists.counts });
       queryClient.invalidateQueries({ queryKey: queryKeys.userMedia.state(mediaItemId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.shows.personalizedCalendarAll });
     },
@@ -158,12 +182,12 @@ export function useRestoreMedia() {
   return useMutation({
     mutationFn: (mediaItemId: string) => meListsApi.restoreMedia(mediaItemId),
     onSuccess: (_data, mediaItemId) => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.meLists.activityAll });
       queryClient.invalidateQueries({ queryKey: queryKeys.meLists.historyAll });
       queryClient.invalidateQueries({ queryKey: queryKeys.meLists.ratingsAll });
       queryClient.invalidateQueries({ queryKey: queryKeys.meLists.caughtUpAll });
       queryClient.invalidateQueries({ queryKey: queryKeys.meLists.watchlistAll });
       queryClient.invalidateQueries({ queryKey: queryKeys.meLists.droppedAll });
+      queryClient.invalidateQueries({ queryKey: queryKeys.meLists.counts });
       queryClient.invalidateQueries({ queryKey: queryKeys.userMedia.state(mediaItemId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.shows.personalizedCalendarAll });
     },
@@ -188,6 +212,10 @@ export function useUserMediaState(mediaItemId: string, enabled = true) {
   });
 }
 
+// Rating does not move items between list buckets (watching/paused/dropped/
+// completed/forLater/considering), so `meLists.counts` is not invalidated.
+// Revisit if the backend ever auto-transitions state on rating (e.g. sets
+// state=completed when user rates an unrated movie).
 export function useSetRating(mediaItemId: string) {
   const queryClient = useQueryClient();
 

--- a/apps/web-client/src/modules/saved/hooks/use-saved-items.ts
+++ b/apps/web-client/src/modules/saved/hooks/use-saved-items.ts
@@ -7,6 +7,7 @@
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { userActionsApi, type SavedItemList } from '@/core/api/user-actions.client';
+import { queryKeys } from '@/core/query/keys';
 import type { MediaTypeFilter } from './use-me-lists';
 import { useFilterAwarePlaceholder } from './use-filter-aware-placeholder';
 
@@ -53,6 +54,7 @@ export function useSaveItem() {
     }) => userActionsApi.saveItem(params),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['saved-items'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.meLists.counts });
     },
   });
 }
@@ -65,6 +67,7 @@ export function useUnsaveItem() {
       userActionsApi.unsaveItem(params),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['saved-items'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.meLists.counts });
     },
   });
 }

--- a/apps/web-client/src/shared/ui/badge.tsx
+++ b/apps/web-client/src/shared/ui/badge.tsx
@@ -15,6 +15,8 @@ const badgeVariants = cva(
         destructive:
           "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80",
         outline: "text-foreground",
+        count:
+          "border-transparent bg-cinema-elevated/60 text-cinema-text-muted font-medium tabular-nums px-1.5 py-0 rounded text-[11px] leading-4",
       },
     },
     defaultVariants: {
@@ -24,12 +26,18 @@ const badgeVariants = cva(
 )
 
 export interface BadgeProps
-  extends React.HTMLAttributes<HTMLDivElement>,
-    VariantProps<typeof badgeVariants> {}
+  extends React.HTMLAttributes<HTMLElement>,
+    VariantProps<typeof badgeVariants> {
+  /**
+   * Element to render. Use `"span"` when nesting inside interactive content
+   * (e.g. `<button>`, Radix `TabsTrigger`) to keep the DOM HTML5-valid.
+   */
+  as?: "div" | "span"
+}
 
-function Badge({ className, variant, ...props }: BadgeProps) {
+function Badge({ className, variant, as: Comp = "div", ...props }: BadgeProps) {
   return (
-    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+    <Comp className={cn(badgeVariants({ variant }), className)} {...props} />
   )
 }
 

--- a/packages/api-contract/openapi.json
+++ b/packages/api-contract/openapi.json
@@ -11120,31 +11120,38 @@
         "type": "object",
         "properties": {
           "watching": {
-            "type": "number",
+            "type": "integer",
+            "minimum": 0,
             "description": "Items with state=watching (strict, no overlap with paused/dropped)"
           },
           "paused": {
-            "type": "number",
+            "type": "integer",
+            "minimum": 0,
             "description": "Items paused by the user"
           },
           "dropped": {
-            "type": "number",
+            "type": "integer",
+            "minimum": 0,
             "description": "Items dropped by the user"
           },
           "completed": {
-            "type": "number",
+            "type": "integer",
+            "minimum": 0,
             "description": "Items the user completed watching"
           },
           "caughtUp": {
-            "type": "number",
+            "type": "integer",
+            "minimum": 0,
             "description": "Items caught up on (ongoing shows with all aired episodes watched)"
           },
           "forLater": {
-            "type": "number",
+            "type": "integer",
+            "minimum": 0,
             "description": "Saved items in the \"for later\" list"
           },
           "considering": {
-            "type": "number",
+            "type": "integer",
+            "minimum": 0,
             "description": "Saved items in the \"considering\" list"
           }
         },

--- a/packages/api-contract/openapi.json
+++ b/packages/api-contract/openapi.json
@@ -2599,6 +2599,21 @@
               ],
               "type": "string"
             }
+          },
+          {
+            "name": "state",
+            "required": false,
+            "in": "query",
+            "description": "Narrow history to a single state (must be one of HISTORY_STATES).",
+            "schema": {
+              "enum": [
+                "watching",
+                "completed",
+                "paused",
+                "caught_up"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -2973,6 +2988,48 @@
                     },
                     "data": {
                       "$ref": "#/components/schemas/PaginatedMeUserMediaResponseDto"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Me"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/me/lists/counts": {
+      "get": {
+        "operationId": "MeListsController_listCounts",
+        "summary": "Counts of my lists (auth: Bearer)",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/MeListCountsResponseDto"
                     }
                   }
                 }
@@ -11057,6 +11114,48 @@
         "required": [
           "data",
           "meta"
+        ]
+      },
+      "MeListCountsResponseDto": {
+        "type": "object",
+        "properties": {
+          "watching": {
+            "type": "number",
+            "description": "Items with state=watching (strict, no overlap with paused/dropped)"
+          },
+          "paused": {
+            "type": "number",
+            "description": "Items paused by the user"
+          },
+          "dropped": {
+            "type": "number",
+            "description": "Items dropped by the user"
+          },
+          "completed": {
+            "type": "number",
+            "description": "Items the user completed watching"
+          },
+          "caughtUp": {
+            "type": "number",
+            "description": "Items caught up on (ongoing shows with all aired episodes watched)"
+          },
+          "forLater": {
+            "type": "number",
+            "description": "Saved items in the \"for later\" list"
+          },
+          "considering": {
+            "type": "number",
+            "description": "Saved items in the \"considering\" list"
+          }
+        },
+        "required": [
+          "watching",
+          "paused",
+          "dropped",
+          "completed",
+          "caughtUp",
+          "forLater",
+          "considering"
         ]
       },
       "EpisodeInfoDto": {

--- a/packages/api-contract/src/api-types.ts
+++ b/packages/api-contract/src/api-types.ts
@@ -625,6 +625,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/me/lists/counts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Counts of my lists (auth: Bearer) */
+        get: operations["MeListsController_listCounts"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/me/favorites/updates": {
         parameters: {
             query?: never;
@@ -3481,6 +3498,22 @@ export interface components {
         PaginatedMeUserMediaResponseDto: {
             data: components["schemas"]["MeUserMediaListItemDto"][];
             meta: components["schemas"]["OffsetPaginationMetaDto"];
+        };
+        MeListCountsResponseDto: {
+            /** @description Items with state=watching (strict, no overlap with paused/dropped) */
+            watching: number;
+            /** @description Items paused by the user */
+            paused: number;
+            /** @description Items dropped by the user */
+            dropped: number;
+            /** @description Items the user completed watching */
+            completed: number;
+            /** @description Items caught up on (ongoing shows with all aired episodes watched) */
+            caughtUp: number;
+            /** @description Saved items in the "for later" list */
+            forLater: number;
+            /** @description Saved items in the "considering" list */
+            considering: number;
         };
         EpisodeInfoDto: {
             /**
@@ -7137,6 +7170,8 @@ export interface operations {
                 sort?: "recent" | "rating" | "releaseDate";
                 /** @description Filter by media type */
                 type?: "movie" | "show";
+                /** @description Narrow history to a single state (must be one of HISTORY_STATES). */
+                state?: "watching" | "completed" | "paused" | "caught_up";
             };
             header?: never;
             path?: never;
@@ -7269,6 +7304,29 @@ export interface operations {
                         /** @enum {boolean} */
                         success: true;
                         data: components["schemas"]["PaginatedMeUserMediaResponseDto"];
+                    };
+                };
+            };
+        };
+    };
+    MeListsController_listCounts: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {boolean} */
+                        success: true;
+                        data: components["schemas"]["MeListCountsResponseDto"];
                     };
                 };
             };


### PR DESCRIPTION
## Summary

- Closes #80. Adds a small count badge next to every tab on `/saved` and `/activity` so users see list sizes at a glance.
- New `GET /me/lists/counts` endpoint returns seven integer counts (watching, paused, dropped, completed, caughtUp, forLater, considering) in one response via parallel `COUNT(*)` queries, replacing the previous waterfall of six full list-with-JOIN fetches.
- Bonus commit: `episodes-section.tsx` decomposed into three focused custom hooks (`useCatchUp`, `useEpisodeProgress`, `useEpisodeToggle`) with their own tests.

## Key details

- **Strict state matching** on `watching/paused/dropped/completed/caughtUp` buckets — a paused-with-progress item is counted only in `paused`, never in `watching`. Badge buckets are mutually exclusive.
- `UserListCounts` lives in the domain layer; `MeListCountsResponseDto implements UserListCounts` catches shape drift at compile time.
- `SavedItemsService.countByList` exposed through `user-actions/public` for cross-module use; no new repository created.
- History endpoint extended with optional `?state=` filter (DTO-validated to the HISTORY_STATES subset). Backend-only addition; kept for future use.
- `Badge` made polymorphic (`as="span"`) so it renders valid DOM inside Radix `TabsTrigger`.
- Mutations that move items between buckets (pause/resume/drop/restore/save/unsave) invalidate `queryKeys.meLists.counts`. Episode-progress mutations invalidate the broader `meLists.all` prefix (already covers counts).

## Performance

| | Before | After |
|---|---|---|
| HTTP on `/activity` mount | 4 list+JOIN | 1 counts + 1 active tab |
| HTTP on `/saved` mount | 2 list+JOIN | 1 counts + 1 active tab |
| Backend SQL | 6× list-with-JOIN + count | 7× `COUNT(*)` |

## Known trade-offs (intentional, flagged for reviewers)

1. **`counts.watching` is strict, Watchlist tab uses OR-progress.** `/me/activity` (used by `useWatching` for list rendering) returns items where `state='watching' OR progress IS NOT NULL`; the counts endpoint uses strict `state='watching'`. A paused-with-progress item therefore appears in the Watchlist list but not the Watching badge count. Aligning the two requires a product decision on what "Watching" means for items with progress but non-active state — tracked as follow-up.

2. **Counts are global, not filtered by media-type.** Each list tab has its own local `type=movie|show` filter (via `useMeListState`); the filter is not lifted to page level. Badges show total bucket counts; list view respects the active filter. Matches the "badge = total, view = filtered" pattern used by Gmail, Linear, Notion.

3. **Backend `/me/history?state=` accepted but unused by client.** `useCompleted` still filters client-side via `useMemo` (matches mono's pattern with `useFilterAwarePlaceholder`). The server-side filter is a no-op for now; cleanup is a marginal ~20-line refactor, not blocking.

## Follow-ups (not in this PR)

- Compound `(user_id, state)` index on `user_media_state` for efficient strict-state counts on power users.
- Remove dead `/me/activity` endpoint chain if strict Watching semantics are chosen.
- HTTP `Cache-Control: private, max-age=30` on `/me/lists/counts` if profiling shows it helps.
- Use server-side `state=completed` in `useCompleted` to drop the client-side filter noise.

## Test plan

- [x] Backend: `npm run test:api` — 3841/3841 passed (including me-lists suite).
- [x] Frontend: `npm run test:client` — 887/887 passed.
- [x] `npm run contracts:update` produces consistent `MeListCountsResponseDto`.
- [ ] Manual: open `/activity` on a logged-in user — Network shows 2 requests, badges reflect real counts, pause/drop mutations update badges live.
- [ ] Manual: open `/saved` — 2 requests, `for-later` / `considering` counts correct.
- [ ] Manual: mobile viewport (375px) — badges don't break tab layout.
- [ ] Manual: anonymous visit to both pages — no `/me/lists/counts` request fired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)