### PR TITLE
fix(details): render metacritic + rotten tomatoes badges on media pages

### DIFF
--- a/apps/web-client/src/modules/details/components/rating-badge.tsx
+++ b/apps/web-client/src/modules/details/components/rating-badge.tsx
@@ -4,7 +4,7 @@
  */
 
 interface RatingBadgeProps {
-  source: 'IMDb' | 'TMDB' | 'Trakt' | 'RT' | 'RT Audience';
+  source: 'IMDb' | 'TMDB' | 'Trakt' | 'RT' | 'RT Audience' | 'Metacritic';
   rating: number;
   isPercentage?: boolean;
 }
@@ -16,12 +16,14 @@ interface RatingBadgeProps {
 // RT (Tomatometer) stays green — matches Ratingo's existing critics-centric display.
 // RT Audience (Popcornmeter) gets orange — visually distinct and aligned with the
 // popcorn colour used on rottentomatoes.com for audience scores.
+// Metacritic gets purple — matches metacritic.com's brand colour.
 const SOURCE_CONFIG = {
   IMDb: { text: 'text-yellow-400', bg: 'bg-yellow-400/20' },
   TMDB: { text: 'text-blue-400', bg: 'bg-blue-400/20' },
   Trakt: { text: 'text-red-400', bg: 'bg-red-400/20' },
   RT: { text: 'text-green-400', bg: 'bg-green-400/20' },
   'RT Audience': { text: 'text-orange-400', bg: 'bg-orange-400/20' },
+  Metacritic: { text: 'text-purple-400', bg: 'bg-purple-400/20' },
 } as const;
 
 export function RatingBadge({ source, rating, isPercentage = false }: RatingBadgeProps) {

--- a/apps/web-client/src/modules/details/components/signals-section.tsx
+++ b/apps/web-client/src/modules/details/components/signals-section.tsx
@@ -86,7 +86,10 @@ export function SignalsSection({
   const hasExternalRatings =
     externalRatings?.imdb?.rating ||
     externalRatings?.tmdb?.rating ||
-    externalRatings?.trakt?.rating;
+    externalRatings?.trakt?.rating ||
+    externalRatings?.metacritic?.rating != null ||
+    externalRatings?.rottenTomatoes?.rating != null ||
+    externalRatings?.rottenTomatoesAudience?.rating != null;
 
   if (!hasBadges && !hasActivity && !hasGenres && !hasExternalRatings) {
     return null;
@@ -172,6 +175,27 @@ export function SignalsSection({
             )}
             {externalRatings?.trakt?.rating != null && externalRatings.trakt.rating > 0 && (
               <RatingBadge source="Trakt" rating={externalRatings.trakt.rating} />
+            )}
+            {externalRatings?.metacritic?.rating != null && (
+              <RatingBadge
+                source="Metacritic"
+                rating={externalRatings.metacritic.rating}
+                isPercentage
+              />
+            )}
+            {externalRatings?.rottenTomatoes?.rating != null && (
+              <RatingBadge
+                source="RT"
+                rating={externalRatings.rottenTomatoes.rating}
+                isPercentage
+              />
+            )}
+            {externalRatings?.rottenTomatoesAudience?.rating != null && (
+              <RatingBadge
+                source="RT Audience"
+                rating={externalRatings.rottenTomatoesAudience.rating}
+                isPercentage
+              />
             )}
           </div>
         </div>


### PR DESCRIPTION
Follow-up to PR #91. Data for `metacritic`, `rottenTomatoes`, and `rottenTomatoesAudience` is already in production (OMDb + MDBList backfill), and the API correctly returns it — but the **signals-section** component on movie/show detail pages rendered only IMDb / TMDB / Trakt.

## Problem

`SignalsSection` is the consumer of `RatingBadge` on detail pages. The sibling `ExternalRatingsRow` component (which PR #91 updated to include RT audience) is not actually used anywhere — it's dead code. So my PR #91 frontend edits had zero visible effect.

Verified against live production data (Spider-Man 2, `tmdbId=558`):

```json
{
  \"externalRatings\": {
    \"metacritic\": { \"rating\": 83 },
    \"rottenTomatoes\": { \"rating\": 93 },
    \"rottenTomatoesAudience\": { \"rating\": 82 }
  }
}
```

None of these three values rendered on the page.

## Fix

- `signals-section.tsx` now renders Metacritic, RT critics, RT audience badges in addition to IMDb/TMDB/Trakt.
- `hasExternalRatings` guard widened so the section appears when only Metacritic/RT values are present.
- `rating-badge.tsx` gets a new \`Metacritic\` source (purple — matches metacritic.com brand colour). Tailwind JIT confirmed — \`text-purple-400\` and \`bg-purple-400\` already in use elsewhere, so classes compile.

## Test plan

- [ ] Open https://ratingo.top/movies/lyudyna-pavuk-2 after deploy — expect 5 badges in external ratings section: IMDb 7.5, TMDB 7.3, Trakt 7.5, Metacritic 83%, RT 93%, RT Audience 82%
- [ ] Spot-check a title with no RT data (majority of catalog) — only IMDb/TMDB/Trakt/Metacritic render
- [ ] Title with neither RT nor Metacritic — section still shows IMDb/TMDB/Trakt
- [ ] Check colours: RT green, RT Audience orange, Metacritic purple