### PR TITLE
feat(ingestion): schedule mdblist ratings backfill daily at 02:00 UTC

### DIFF
--- a/apps/api/src/config/scheduler.config.ts
+++ b/apps/api/src/config/scheduler.config.ts
@@ -84,6 +84,16 @@ const DEFAULT_JOBS: Omit<ScheduledJobConfig, 'enabled'>[] = [
     jobId: 'scheduled-new-releases',
     data: { region: 'UA', daysBack: 30 },
   },
+  {
+    name: 'mdblistRatings',
+    jobType: 'backfill-mdblist-ratings-dispatcher',
+    // 02:00 UTC daily — safely after MDBList's 00:00 UTC quota reset.
+    // Dispatcher caps at 900 items per run; worker drains them at 40/hour
+    // (~23h), leaving headroom before next fire.
+    pattern: '0 2 * * *',
+    jobId: 'scheduled-mdblist-ratings',
+    data: {},
+  },
 ];
 
 /**


### PR DESCRIPTION
Follow-up to PR #91 / #92. Replaces the admin-only manual trigger with a daily BullMQ Job Scheduler entry.

## Change

Single new entry in [scheduler.config.ts](apps/api/src/config/scheduler.config.ts) \`DEFAULT_JOBS\`:

\`\`\`ts
{
  name: 'mdblistRatings',
  jobType: 'backfill-mdblist-ratings-dispatcher',
  pattern: '0 2 * * *',           // 02:00 UTC daily
  jobId: 'scheduled-mdblist-ratings',
  data: {},
}
\`\`\`

\`IngestionSchedulerService\` is already idempotent and reconciles desired vs existing schedulers in Redis on every boot — adding this entry triggers exactly one \`upsertJobScheduler\` call for the new key \`{env}:scheduled-mdblist-ratings\`.

## Why 02:00 UTC

- MDBList quota resets at 00:00 UTC — 02:00 leaves margin against timing races.
- Dispatcher caps at 900 items/run; worker drains at 40/hour (BullMQ limiter) → full drain in ~23h, fits inside the 24h cron window.
- Off-peak for UA (~04:00-05:00 Kyiv).

## Env overrides

- \`SCHEDULER_INGESTION_MDBLIST_RATINGS_ENABLED=false\` → disable without redeploy.
- \`SCHEDULER_INGESTION_MDBLIST_RATINGS_PATTERN=...\` → custom cron.
- \`SCHEDULER_ENABLED=false\` → master kill-switch (existing).

## Coexistence with manual trigger

\`POST /ingestion/backfill/mdblist-ratings\` is kept. Both the manual endpoint and the cron dispatcher deduplicate by UTC day (\`backfill_mdblist_ratings_YYYY-MM-DD\` jobId), so firing both on the same day is a no-op on the second call. Manual \`?force=true\` still bypasses the dedup for same-day re-run.

## Test plan

- [ ] Deploy, check logs on boot: \`[mdblistRatings] Added: 0 2 * * * UTC\`
- [ ] Next 02:00 UTC, verify dispatcher log: \`Starting MDBList ratings backfill dispatcher...\` and job count matches \`MDBLIST_DAILY_BUDGET=900\` or queue exhaustion.
- [ ] Daily check for a week: \`rt_fetched_at\` coverage grows by ~960/day until the candidate pool shrinks.
- [ ] Temporarily set \`SCHEDULER_INGESTION_MDBLIST_RATINGS_ENABLED=false\` → restart → scheduler entry removed from Redis (visible via \`ingestionQueue.getJobSchedulers()\`).