### PR TITLE
fix(api): infrastructure & DB layer hardening

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,10 @@ module/
 ### BullMQ
 Design all jobs as idempotent. Define job types in `*.constants.ts`.
 
+### Database Migrations
+- Use `CREATE INDEX CONCURRENTLY` for new indexes on existing tables (avoids table locks)
+- Follow expand/contract pattern for breaking schema changes: add nullable column first, backfill, then add constraint
+
 ## Frontend Architecture
 
 - **Types**: Use `import type { components } from '@ratingo/api-contract'` for all API types

--- a/apps/api/src/common/utils/db-error.utils.ts
+++ b/apps/api/src/common/utils/db-error.utils.ts
@@ -1,5 +1,6 @@
 import { Logger } from '@nestjs/common';
 
+import { AppException } from '../exceptions/app.exception';
 import { DatabaseException } from '../exceptions/database.exception';
 
 /**
@@ -66,6 +67,9 @@ export async function withDbError<T>(
   try {
     return await fn();
   } catch (error) {
+    // Re-throw application exceptions (NotFoundException, ForbiddenException, etc.) as-is
+    if (error instanceof AppException) throw error;
+
     const msg = error instanceof Error ? error.message : String(error);
     const pgDetails = extractPgErrorDetails(error);
     const stack = error instanceof Error ? error.stack : undefined;

--- a/apps/api/src/modules/auth/infrastructure/repositories/drizzle-refresh-tokens.repository.ts
+++ b/apps/api/src/modules/auth/infrastructure/repositories/drizzle-refresh-tokens.repository.ts
@@ -3,7 +3,7 @@ import { Inject, Injectable, Logger } from '@nestjs/common';
 import { and, eq, gte, isNull } from 'drizzle-orm';
 import { type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 
-import { DatabaseException } from '../../../../common/exceptions/database.exception';
+import { withDbError } from '../../../../common/utils/db-error.utils';
 import { DATABASE_CONNECTION } from '../../../../database/database.module';
 import * as schema from '../../../../database/schema';
 import { type RefreshToken } from '../../domain/entities/refresh-token.entity';
@@ -28,24 +28,26 @@ export class DrizzleRefreshTokensRepository implements IRefreshTokensRepository 
    * @returns {Promise<RefreshToken>} Persisted token
    */
   async issue(token: Omit<RefreshToken, 'createdAt'>): Promise<RefreshToken> {
-    try {
-      const [row] = await this.db
-        .insert(schema.refreshTokens)
-        .values({
-          id: token.id,
-          userId: token.userId,
-          tokenHash: token.tokenHash,
-          userAgent: token.userAgent ?? null,
-          ip: token.ip ?? null,
-          expiresAt: token.expiresAt,
-          revokedAt: token.revokedAt ?? null,
-        })
-        .returning();
-      return this.mapRow(row);
-    } catch (error) {
-      this.logger.error(`issue failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to issue refresh token', { userId: token.userId });
-    }
+    return withDbError(
+      'issue refresh token',
+      this.logger,
+      async () => {
+        const [row] = await this.db
+          .insert(schema.refreshTokens)
+          .values({
+            id: token.id,
+            userId: token.userId,
+            tokenHash: token.tokenHash,
+            userAgent: token.userAgent ?? null,
+            ip: token.ip ?? null,
+            expiresAt: token.expiresAt,
+            revokedAt: token.revokedAt ?? null,
+          })
+          .returning();
+        return this.mapRow(row);
+      },
+      { userId: token.userId },
+    );
   }
 
   /**
@@ -55,16 +57,18 @@ export class DrizzleRefreshTokensRepository implements IRefreshTokensRepository 
    * @returns {Promise<RefreshToken | null>} Token or null
    */
   async findById(id: string): Promise<RefreshToken | null> {
-    try {
-      const [row] = await this.db
-        .select()
-        .from(schema.refreshTokens)
-        .where(eq(schema.refreshTokens.id, id));
-      return row ? this.mapRow(row) : null;
-    } catch (error) {
-      this.logger.error(`findById failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to fetch refresh token', { id });
-    }
+    return withDbError(
+      'fetch refresh token',
+      this.logger,
+      async () => {
+        const [row] = await this.db
+          .select()
+          .from(schema.refreshTokens)
+          .where(eq(schema.refreshTokens.id, id));
+        return row ? this.mapRow(row) : null;
+      },
+      { id },
+    );
   }
 
   /**
@@ -74,23 +78,25 @@ export class DrizzleRefreshTokensRepository implements IRefreshTokensRepository 
    * @returns {Promise<RefreshToken[]>} Active tokens
    */
   async findValidByUser(userId: string): Promise<RefreshToken[]> {
-    try {
-      const now = new Date();
-      const rows = await this.db
-        .select()
-        .from(schema.refreshTokens)
-        .where(
-          and(
-            eq(schema.refreshTokens.userId, userId),
-            isNull(schema.refreshTokens.revokedAt),
-            gte(schema.refreshTokens.expiresAt, now),
-          ),
-        );
-      return rows.map((r) => this.mapRow(r));
-    } catch (error) {
-      this.logger.error(`findValidByUser failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to list refresh tokens', { userId });
-    }
+    return withDbError(
+      'list refresh tokens',
+      this.logger,
+      async () => {
+        const now = new Date();
+        const rows = await this.db
+          .select()
+          .from(schema.refreshTokens)
+          .where(
+            and(
+              eq(schema.refreshTokens.userId, userId),
+              isNull(schema.refreshTokens.revokedAt),
+              gte(schema.refreshTokens.expiresAt, now),
+            ),
+          );
+        return rows.map((r) => this.mapRow(r));
+      },
+      { userId },
+    );
   }
 
   /**
@@ -100,15 +106,17 @@ export class DrizzleRefreshTokensRepository implements IRefreshTokensRepository 
    * @returns {Promise<void>} Nothing
    */
   async revoke(id: string): Promise<void> {
-    try {
-      await this.db
-        .update(schema.refreshTokens)
-        .set({ revokedAt: new Date() })
-        .where(eq(schema.refreshTokens.id, id));
-    } catch (error) {
-      this.logger.error(`revoke failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to revoke refresh token', { id });
-    }
+    return withDbError(
+      'revoke refresh token',
+      this.logger,
+      () =>
+        this.db
+          .update(schema.refreshTokens)
+          .set({ revokedAt: new Date() })
+          .where(eq(schema.refreshTokens.id, id))
+          .then(() => undefined),
+      { id },
+    );
   }
 
   /**
@@ -118,15 +126,17 @@ export class DrizzleRefreshTokensRepository implements IRefreshTokensRepository 
    * @returns {Promise<void>} Nothing
    */
   async revokeAllForUser(userId: string): Promise<void> {
-    try {
-      await this.db
-        .update(schema.refreshTokens)
-        .set({ revokedAt: new Date() })
-        .where(eq(schema.refreshTokens.userId, userId));
-    } catch (error) {
-      this.logger.error(`revokeAllForUser failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to revoke user refresh tokens', { userId });
-    }
+    return withDbError(
+      'revoke user refresh tokens',
+      this.logger,
+      () =>
+        this.db
+          .update(schema.refreshTokens)
+          .set({ revokedAt: new Date() })
+          .where(eq(schema.refreshTokens.userId, userId))
+          .then(() => undefined),
+      { userId },
+    );
   }
 
   private mapRow(row: typeof schema.refreshTokens.$inferSelect): RefreshToken {

--- a/apps/api/src/modules/catalog-policy/application/services/catalog-policy.service.spec.ts
+++ b/apps/api/src/modules/catalog-policy/application/services/catalog-policy.service.spec.ts
@@ -78,7 +78,7 @@ describe('CatalogPolicyService', () => {
 
       const result = await service.getActiveOrThrow();
 
-      expect(result).toBe(policy);
+      expect(result).toStrictEqual(policy);
       expect(mockPolicyRepository.findActive).toHaveBeenCalled();
     });
 
@@ -96,7 +96,7 @@ describe('CatalogPolicyService', () => {
 
       const result = await service.getActive();
 
-      expect(result).toBe(policy);
+      expect(result).toStrictEqual(policy);
     });
 
     it('should return null when no active policy', async () => {

--- a/apps/api/src/modules/catalog-policy/application/services/catalog-policy.service.ts
+++ b/apps/api/src/modules/catalog-policy/application/services/catalog-policy.service.ts
@@ -26,11 +26,12 @@ export class CatalogPolicyService {
     if (!policy) {
       throw new NotFoundException('No active policy found. Please seed the default policy first.');
     }
-    return policy;
+    return this.sortBreakoutRules(policy);
   }
 
   async getActive(): Promise<CatalogPolicy | null> {
-    return this.policyRepository.findActive();
+    const policy = await this.policyRepository.findActive();
+    return policy ? this.sortBreakoutRules(policy) : null;
   }
 
   async getById(id: string): Promise<CatalogPolicy | null> {
@@ -75,5 +76,15 @@ export class CatalogPolicyService {
 
   async listAll(): Promise<CatalogPolicy[]> {
     return this.policyRepository.findAll();
+  }
+
+  private sortBreakoutRules(policy: CatalogPolicy): CatalogPolicy {
+    return {
+      ...policy,
+      policy: {
+        ...policy.policy,
+        breakoutRules: [...policy.policy.breakoutRules].sort((a, b) => a.priority - b.priority),
+      },
+    };
   }
 }

--- a/apps/api/src/modules/catalog-policy/domain/evaluators/breakout-rule.evaluator.ts
+++ b/apps/api/src/modules/catalog-policy/domain/evaluators/breakout-rule.evaluator.ts
@@ -67,8 +67,9 @@ export function matchesBreakoutRule(input: PolicyEngineInput, rule: BreakoutRule
 }
 
 /**
- * Finds the first matching breakout rule by priority.
- * Rules are sorted by priority (lowest number = highest priority) before evaluation.
+ * Finds the first matching breakout rule by priority (lowest number = highest priority).
+ * CatalogPolicyService pre-sorts rules on load, so this sort is typically O(n) on
+ * an already-sorted array. Kept defensive for callers that bypass the service.
  *
  * @param input - Media item data and stats
  * @param policy - Policy configuration
@@ -78,10 +79,9 @@ export function findMatchingBreakoutRule(
   input: PolicyEngineInput,
   policy: PolicyConfig,
 ): BreakoutRule | null {
-  // Defensive sort: ensure priority order regardless of input array order
-  const sortedRules = [...policy.breakoutRules].sort((a, b) => a.priority - b.priority);
+  const rules = [...policy.breakoutRules].sort((a, b) => a.priority - b.priority);
 
-  for (const rule of sortedRules) {
+  for (const rule of rules) {
     if (matchesBreakoutRule(input, rule)) {
       return rule;
     }

--- a/apps/api/src/modules/catalog-policy/infrastructure/repositories/admin-catalog.repository.ts
+++ b/apps/api/src/modules/catalog-policy/infrastructure/repositories/admin-catalog.repository.ts
@@ -20,7 +20,10 @@ import { type MediaType } from '../../../../common/enums/media-type.enum';
 import { DatabaseException } from '../../../../common/exceptions';
 import { DATABASE_CONNECTION } from '../../../../database/database.module';
 import * as schema from '../../../../database/schema';
-import { type EligibilityStatusType } from '../../domain/constants/evaluation.constants';
+import {
+  DEFAULT_EVALUATION_CONTEXT,
+  type EligibilityStatusType,
+} from '../../domain/constants/evaluation.constants';
 
 export const ADMIN_CATALOG_REPOSITORY = 'ADMIN_CATALOG_REPOSITORY';
 
@@ -165,25 +168,29 @@ export class AdminCatalogRepository implements IAdminCatalogRepository {
         conditions.push(eq(schema.mediaItems.type, options.type));
       }
 
-      // Build query
+      if (options?.eligibilityStatus) {
+        conditions.push(eq(schema.mediaCatalogEvaluations.status, options.eligibilityStatus));
+      }
+
+      // Build query — restrict JOIN to active policy + catalog context to avoid duplicate rows
       let query = this.db
         .select(this.selectFields)
         .from(schema.mediaItems)
         .leftJoin(
           schema.mediaCatalogEvaluations,
-          eq(schema.mediaItems.id, schema.mediaCatalogEvaluations.mediaItemId),
+          and(
+            eq(schema.mediaItems.id, schema.mediaCatalogEvaluations.mediaItemId),
+            eq(
+              schema.mediaCatalogEvaluations.policyVersion,
+              sql`(SELECT version FROM catalog_policies WHERE is_active = true LIMIT 1)`,
+            ),
+            eq(schema.mediaCatalogEvaluations.context, DEFAULT_EVALUATION_CONTEXT),
+          ),
         );
 
       // Apply conditions
       if (conditions.length > 0) {
         query = query.where(and(...conditions)) as typeof query;
-      }
-
-      // Apply eligibility status filter (after join)
-      if (options?.eligibilityStatus) {
-        query = query.where(
-          eq(schema.mediaCatalogEvaluations.status, options.eligibilityStatus),
-        ) as typeof query;
       }
 
       // Apply sorting

--- a/apps/api/src/modules/catalog-policy/infrastructure/repositories/media-catalog-evaluation.repository.ts
+++ b/apps/api/src/modules/catalog-policy/infrastructure/repositories/media-catalog-evaluation.repository.ts
@@ -9,7 +9,7 @@
 
 import { Inject, Injectable, Logger } from '@nestjs/common';
 
-import { eq, and, sql, inArray } from 'drizzle-orm';
+import { eq, and, sql, inArray, desc } from 'drizzle-orm';
 import { type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 
 import { DatabaseException } from '../../../../common/exceptions';
@@ -141,6 +141,7 @@ export class MediaCatalogEvaluationRepository implements IMediaCatalogEvaluation
             eq(schema.mediaCatalogEvaluations.context, context),
           ),
         )
+        .orderBy(desc(schema.mediaCatalogEvaluations.policyVersion))
         .limit(1);
 
       if (result.length === 0) {
@@ -233,6 +234,10 @@ export class MediaCatalogEvaluationRepository implements IMediaCatalogEvaluation
             eq(schema.mediaCatalogEvaluations.policyVersion, policyVersion),
             eq(schema.mediaCatalogEvaluations.context, context),
           ),
+        )
+        .orderBy(
+          desc(schema.mediaCatalogEvaluations.evaluatedAt),
+          desc(schema.mediaCatalogEvaluations.mediaItemId),
         );
 
       if (options?.limit) {
@@ -264,6 +269,10 @@ export class MediaCatalogEvaluationRepository implements IMediaCatalogEvaluation
             eq(schema.mediaCatalogEvaluations.status, status),
             eq(schema.mediaCatalogEvaluations.context, context),
           ),
+        )
+        .orderBy(
+          desc(schema.mediaCatalogEvaluations.evaluatedAt),
+          desc(schema.mediaCatalogEvaluations.mediaItemId),
         );
 
       if (options?.limit) {

--- a/apps/api/src/modules/catalog-policy/infrastructure/repositories/public-catalog.repository.ts
+++ b/apps/api/src/modules/catalog-policy/infrastructure/repositories/public-catalog.repository.ts
@@ -196,7 +196,7 @@ export class PublicCatalogRepository implements IPublicCatalogRepository {
           COALESCE(popularity_score, 0) * 0.20 +
           (COALESCE(watchers_count, 0)::float / (COALESCE(watchers_count, 0) + 100)) * 100 * 0.25 +
           COALESCE(trending_score, 0) / 100.0 * 0.05
-        ) DESC NULLS LAST
+        ) DESC NULLS LAST, id DESC
         LIMIT ${limit} OFFSET ${offset}
       `;
 
@@ -230,7 +230,7 @@ export class PublicCatalogRepository implements IPublicCatalogRepository {
       }
 
       sqlQuery = sql`${sqlQuery}
-        ORDER BY rank DESC, trending_score DESC NULLS LAST
+        ORDER BY rank DESC, trending_score DESC NULLS LAST, id DESC
         LIMIT ${limit} OFFSET ${offset}
       `;
 

--- a/apps/api/src/modules/ingestion/infrastructure/repositories/snapshots.repository.ts
+++ b/apps/api/src/modules/ingestion/infrastructure/repositories/snapshots.repository.ts
@@ -1,8 +1,9 @@
-import { Injectable, Inject } from '@nestjs/common';
+import { Injectable, Inject, Logger } from '@nestjs/common';
 
 import { eq, sql } from 'drizzle-orm';
 import { type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 
+import { withDbError } from '../../../../common/utils/db-error.utils';
 import { DATABASE_CONNECTION } from '../../../../database/database.module';
 import * as schema from '../../../../database/schema';
 import {
@@ -16,6 +17,8 @@ import {
  */
 @Injectable()
 export class SnapshotsRepository implements ISnapshotsRepository {
+  private readonly logger = new Logger(SnapshotsRepository.name);
+
   constructor(
     @Inject(DATABASE_CONNECTION)
     private readonly db: PostgresJsDatabase<typeof schema>,
@@ -25,44 +28,54 @@ export class SnapshotsRepository implements ISnapshotsRepository {
    * @inheritdoc
    */
   async findMediaItemForSnapshot(mediaItemId: string): Promise<MediaItemForSnapshot | null> {
-    const items = await this.db
-      .select({
-        tmdbId: schema.mediaItems.tmdbId,
-        type: schema.mediaItems.type,
-      })
-      .from(schema.mediaItems)
-      .where(eq(schema.mediaItems.id, mediaItemId))
-      .limit(1);
+    return withDbError(
+      'find media item for snapshot',
+      this.logger,
+      async () => {
+        const items = await this.db
+          .select({
+            tmdbId: schema.mediaItems.tmdbId,
+            type: schema.mediaItems.type,
+          })
+          .from(schema.mediaItems)
+          .where(eq(schema.mediaItems.id, mediaItemId))
+          .limit(1);
 
-    if (!items.length) {
-      return null;
-    }
-
-    return items[0];
+        return items[0] ?? null;
+      },
+      { mediaItemId },
+    );
   }
 
   /**
    * @inheritdoc
    */
   async upsertSnapshot(data: SnapshotUpsertData): Promise<void> {
-    await this.db
-      .insert(schema.mediaWatchersSnapshots)
-      .values({
-        mediaItemId: data.mediaItemId,
-        snapshotDate: data.snapshotDate,
-        totalWatchers: data.totalWatchers,
-        region: data.region,
-      })
-      .onConflictDoUpdate({
-        target: [
-          schema.mediaWatchersSnapshots.mediaItemId,
-          schema.mediaWatchersSnapshots.snapshotDate,
-          schema.mediaWatchersSnapshots.region,
-        ],
-        set: {
-          totalWatchers: data.totalWatchers,
-        },
-      });
+    return withDbError(
+      'upsert snapshot',
+      this.logger,
+      () =>
+        this.db
+          .insert(schema.mediaWatchersSnapshots)
+          .values({
+            mediaItemId: data.mediaItemId,
+            snapshotDate: data.snapshotDate,
+            totalWatchers: data.totalWatchers,
+            region: data.region,
+          })
+          .onConflictDoUpdate({
+            target: [
+              schema.mediaWatchersSnapshots.mediaItemId,
+              schema.mediaWatchersSnapshots.snapshotDate,
+              schema.mediaWatchersSnapshots.region,
+            ],
+            set: {
+              totalWatchers: data.totalWatchers,
+            },
+          })
+          .then(() => undefined),
+      { mediaItemId: data.mediaItemId, snapshotDate: data.snapshotDate },
+    );
   }
 
   /**
@@ -70,26 +83,33 @@ export class SnapshotsRepository implements ISnapshotsRepository {
    */
   async bulkUpsertSnapshots(data: SnapshotUpsertData[]): Promise<void> {
     if (data.length === 0) return;
+    return withDbError(
+      'bulk upsert snapshots',
+      this.logger,
+      () => {
+        const values = data.map((d) => ({
+          mediaItemId: d.mediaItemId,
+          snapshotDate: d.snapshotDate,
+          totalWatchers: d.totalWatchers,
+          region: d.region,
+        }));
 
-    const values = data.map((d) => ({
-      mediaItemId: d.mediaItemId,
-      snapshotDate: d.snapshotDate,
-      totalWatchers: d.totalWatchers,
-      region: d.region,
-    }));
-
-    await this.db
-      .insert(schema.mediaWatchersSnapshots)
-      .values(values)
-      .onConflictDoUpdate({
-        target: [
-          schema.mediaWatchersSnapshots.mediaItemId,
-          schema.mediaWatchersSnapshots.snapshotDate,
-          schema.mediaWatchersSnapshots.region,
-        ],
-        set: {
-          totalWatchers: sql`excluded.total_watchers`,
-        },
-      });
+        return this.db
+          .insert(schema.mediaWatchersSnapshots)
+          .values(values)
+          .onConflictDoUpdate({
+            target: [
+              schema.mediaWatchersSnapshots.mediaItemId,
+              schema.mediaWatchersSnapshots.snapshotDate,
+              schema.mediaWatchersSnapshots.region,
+            ],
+            set: {
+              totalWatchers: sql`excluded.total_watchers`,
+            },
+          })
+          .then(() => undefined);
+      },
+      { count: data.length },
+    );
   }
 }

--- a/apps/api/src/modules/provider/infrastructure/repositories/media-watch-offers.repository.spec.ts
+++ b/apps/api/src/modules/provider/infrastructure/repositories/media-watch-offers.repository.spec.ts
@@ -152,8 +152,8 @@ describe('MediaWatchOffersRepository', () => {
       // Act
       await repository.upsertManyByRegions('media-123', offers);
 
-      // Assert - should have 2 transactions (one per region)
-      expect(mockDb.transaction).toHaveBeenCalledTimes(2);
+      // Assert - all regions in a single atomic transaction
+      expect(mockDb.transaction).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/apps/api/src/modules/provider/infrastructure/repositories/media-watch-offers.repository.spec.ts
+++ b/apps/api/src/modules/provider/infrastructure/repositories/media-watch-offers.repository.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { DatabaseException } from '../../../../common/exceptions/database.exception';
 import { DATABASE_CONNECTION } from '../../../../database/database.module';
 import {
   CreateWatchOfferInput,
@@ -119,7 +120,7 @@ describe('MediaWatchOffersRepository', () => {
 
       // Act & Assert
       await expect(repository.upsertMany('media-123', 'US', [createOfferInput()])).rejects.toThrow(
-        'DB Error',
+        DatabaseException,
       );
     });
   });
@@ -224,7 +225,7 @@ describe('MediaWatchOffersRepository', () => {
       mockDb.where.mockRejectedValue(new Error('DB Error'));
 
       // Act & Assert
-      await expect(repository.findByMediaItemId('media-123')).rejects.toThrow('DB Error');
+      await expect(repository.findByMediaItemId('media-123')).rejects.toThrow(DatabaseException);
     });
   });
 
@@ -261,7 +262,7 @@ describe('MediaWatchOffersRepository', () => {
       mockDb.where.mockRejectedValue(new Error('DB Error'));
 
       // Act & Assert
-      await expect(repository.findByTmdbProviderId(8)).rejects.toThrow('DB Error');
+      await expect(repository.findByTmdbProviderId(8)).rejects.toThrow(DatabaseException);
     });
   });
 
@@ -313,7 +314,7 @@ describe('MediaWatchOffersRepository', () => {
       mockDb.where.mockRejectedValue(new Error('DB Error'));
 
       // Act & Assert
-      await expect(repository.findByMediaItemIds(['media-1'])).rejects.toThrow('DB Error');
+      await expect(repository.findByMediaItemIds(['media-1'])).rejects.toThrow(DatabaseException);
     });
   });
 
@@ -335,7 +336,7 @@ describe('MediaWatchOffersRepository', () => {
       mockDb.where.mockRejectedValue(new Error('DB Error'));
 
       // Act & Assert
-      await expect(repository.deleteByMediaItemId('media-123')).rejects.toThrow('DB Error');
+      await expect(repository.deleteByMediaItemId('media-123')).rejects.toThrow(DatabaseException);
     });
   });
 
@@ -358,7 +359,7 @@ describe('MediaWatchOffersRepository', () => {
 
       // Act & Assert
       await expect(repository.deleteByMediaItemIdAndRegion('media-123', 'US')).rejects.toThrow(
-        'DB Error',
+        DatabaseException,
       );
     });
   });
@@ -497,7 +498,9 @@ describe('MediaWatchOffersRepository', () => {
       mockDb.where.mockRejectedValue(new Error('DB Error'));
 
       // Act & Assert
-      await expect(repository.getOffersForMediaBatch(['media-1'])).rejects.toThrow('DB Error');
+      await expect(repository.getOffersForMediaBatch(['media-1'])).rejects.toThrow(
+        DatabaseException,
+      );
     });
   });
 });

--- a/apps/api/src/modules/provider/infrastructure/repositories/media-watch-offers.repository.ts
+++ b/apps/api/src/modules/provider/infrastructure/repositories/media-watch-offers.repository.ts
@@ -86,9 +86,36 @@ export class MediaWatchOffersRepository implements IMediaWatchOffersRepository {
       offersByRegion.set(offer.region, regionOffers);
     }
 
-    // Upsert each region
-    for (const [region, regionOffers] of offersByRegion) {
-      await this.upsertMany(mediaItemId, region, regionOffers);
+    try {
+      // All regions in a single atomic transaction
+      await this.db.transaction(async (tx) => {
+        for (const [region, regionOffers] of offersByRegion) {
+          await tx
+            .delete(mediaWatchOffers)
+            .where(
+              and(
+                eq(mediaWatchOffers.mediaItemId, mediaItemId),
+                eq(mediaWatchOffers.region, region),
+              ),
+            );
+
+          await tx.insert(mediaWatchOffers).values(
+            regionOffers.map((offer) => ({
+              mediaItemId: offer.mediaItemId,
+              providerId: offer.providerId,
+              variantId: offer.variantId,
+              distributionChannel: offer.distributionChannel,
+              offerType: offer.offerType,
+              region: offer.region,
+              link: offer.link,
+              tmdbProviderId: offer.tmdbProviderId,
+            })),
+          );
+        }
+      });
+    } catch (error) {
+      this.logger.error(`Failed to upsert offers for media=${mediaItemId}`, error);
+      throw error;
     }
   }
 

--- a/apps/api/src/modules/provider/infrastructure/repositories/media-watch-offers.repository.ts
+++ b/apps/api/src/modules/provider/infrastructure/repositories/media-watch-offers.repository.ts
@@ -9,6 +9,7 @@ import { Inject, Injectable, Logger } from '@nestjs/common';
 import { and, eq, inArray } from 'drizzle-orm';
 import { type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 
+import { withDbError } from '../../../../common/utils/db-error.utils';
 import { DATABASE_CONNECTION } from '../../../../database/database.module';
 import * as schema from '../../../../database/schema';
 import { mediaWatchOffers, providerVariants } from '../../../../database/schema';
@@ -41,38 +42,40 @@ export class MediaWatchOffersRepository implements IMediaWatchOffersRepository {
   ): Promise<void> {
     if (offers.length === 0) return;
 
-    try {
-      // Replace-per-region strategy: DELETE existing, then INSERT
-      await this.db.transaction(async (tx) => {
-        // Delete existing offers for this media item + region
-        await tx
-          .delete(mediaWatchOffers)
-          .where(
-            and(eq(mediaWatchOffers.mediaItemId, mediaItemId), eq(mediaWatchOffers.region, region)),
+    await withDbError(
+      'upsertMany',
+      this.logger,
+      async () => {
+        await this.db.transaction(async (tx) => {
+          await tx
+            .delete(mediaWatchOffers)
+            .where(
+              and(
+                eq(mediaWatchOffers.mediaItemId, mediaItemId),
+                eq(mediaWatchOffers.region, region),
+              ),
+            );
+
+          await tx.insert(mediaWatchOffers).values(
+            offers.map((offer) => ({
+              mediaItemId: offer.mediaItemId,
+              providerId: offer.providerId,
+              variantId: offer.variantId,
+              distributionChannel: offer.distributionChannel,
+              offerType: offer.offerType,
+              region: offer.region,
+              link: offer.link,
+              tmdbProviderId: offer.tmdbProviderId,
+            })),
           );
+        });
 
-        // Insert new offers
-        await tx.insert(mediaWatchOffers).values(
-          offers.map((offer) => ({
-            mediaItemId: offer.mediaItemId,
-            providerId: offer.providerId,
-            variantId: offer.variantId,
-            distributionChannel: offer.distributionChannel,
-            offerType: offer.offerType,
-            region: offer.region,
-            link: offer.link,
-            tmdbProviderId: offer.tmdbProviderId,
-          })),
+        this.logger.debug(
+          `Upserted ${offers.length} offers for media=${mediaItemId} region=${region}`,
         );
-      });
-
-      this.logger.debug(
-        `Upserted ${offers.length} offers for media=${mediaItemId} region=${region}`,
-      );
-    } catch (error) {
-      this.logger.error(`Failed to upsert offers for media=${mediaItemId} region=${region}`, error);
-      throw error;
-    }
+      },
+      { mediaItemId, region },
+    );
   }
 
   async upsertManyByRegions(mediaItemId: string, offers: CreateWatchOfferInput[]): Promise<void> {
@@ -86,84 +89,89 @@ export class MediaWatchOffersRepository implements IMediaWatchOffersRepository {
       offersByRegion.set(offer.region, regionOffers);
     }
 
-    try {
-      // All regions in a single atomic transaction
-      await this.db.transaction(async (tx) => {
-        for (const [region, regionOffers] of offersByRegion) {
-          await tx
-            .delete(mediaWatchOffers)
-            .where(
-              and(
-                eq(mediaWatchOffers.mediaItemId, mediaItemId),
-                eq(mediaWatchOffers.region, region),
-              ),
-            );
+    await withDbError(
+      'upsertManyByRegions',
+      this.logger,
+      async () => {
+        await this.db.transaction(async (tx) => {
+          for (const [region, regionOffers] of offersByRegion) {
+            await tx
+              .delete(mediaWatchOffers)
+              .where(
+                and(
+                  eq(mediaWatchOffers.mediaItemId, mediaItemId),
+                  eq(mediaWatchOffers.region, region),
+                ),
+              );
 
-          await tx.insert(mediaWatchOffers).values(
-            regionOffers.map((offer) => ({
-              mediaItemId: offer.mediaItemId,
-              providerId: offer.providerId,
-              variantId: offer.variantId,
-              distributionChannel: offer.distributionChannel,
-              offerType: offer.offerType,
-              region: offer.region,
-              link: offer.link,
-              tmdbProviderId: offer.tmdbProviderId,
-            })),
-          );
-        }
-      });
-    } catch (error) {
-      this.logger.error(`Failed to upsert offers for media=${mediaItemId}`, error);
-      throw error;
-    }
+            await tx.insert(mediaWatchOffers).values(
+              regionOffers.map((offer) => ({
+                mediaItemId: offer.mediaItemId,
+                providerId: offer.providerId,
+                variantId: offer.variantId,
+                distributionChannel: offer.distributionChannel,
+                offerType: offer.offerType,
+                region: offer.region,
+                link: offer.link,
+                tmdbProviderId: offer.tmdbProviderId,
+              })),
+            );
+          }
+        });
+      },
+      { mediaItemId, regionCount: offersByRegion.size },
+    );
   }
 
   async findByMediaItemId(
     mediaItemId: string,
     options?: FindOffersOptions,
   ): Promise<MediaWatchOffer[]> {
-    try {
-      const conditions = [eq(mediaWatchOffers.mediaItemId, mediaItemId)];
+    return withDbError(
+      'findByMediaItemId',
+      this.logger,
+      async () => {
+        const conditions = [eq(mediaWatchOffers.mediaItemId, mediaItemId)];
 
-      if (options?.offerTypes?.length) {
-        conditions.push(inArray(mediaWatchOffers.offerType, options.offerTypes));
-      }
+        if (options?.offerTypes?.length) {
+          conditions.push(inArray(mediaWatchOffers.offerType, options.offerTypes));
+        }
 
-      if (options?.distributionChannels?.length) {
-        conditions.push(
-          inArray(mediaWatchOffers.distributionChannel, options.distributionChannels),
-        );
-      }
+        if (options?.distributionChannels?.length) {
+          conditions.push(
+            inArray(mediaWatchOffers.distributionChannel, options.distributionChannels),
+          );
+        }
 
-      if (options?.region) {
-        conditions.push(eq(mediaWatchOffers.region, options.region));
-      }
+        if (options?.region) {
+          conditions.push(eq(mediaWatchOffers.region, options.region));
+        }
 
-      const rows = await this.db
-        .select()
-        .from(mediaWatchOffers)
-        .where(and(...conditions));
+        const rows = await this.db
+          .select()
+          .from(mediaWatchOffers)
+          .where(and(...conditions));
 
-      return rows.map(this.toDomain);
-    } catch (error) {
-      this.logger.error(`Failed to find offers for media=${mediaItemId}`, error);
-      throw error;
-    }
+        return rows.map(this.toDomain);
+      },
+      { mediaItemId },
+    );
   }
 
   async findByTmdbProviderId(tmdbProviderId: number): Promise<MediaWatchOffer[]> {
-    try {
-      const rows = await this.db
-        .select()
-        .from(mediaWatchOffers)
-        .where(eq(mediaWatchOffers.tmdbProviderId, tmdbProviderId));
+    return withDbError(
+      'findByTmdbProviderId',
+      this.logger,
+      async () => {
+        const rows = await this.db
+          .select()
+          .from(mediaWatchOffers)
+          .where(eq(mediaWatchOffers.tmdbProviderId, tmdbProviderId));
 
-      return rows.map(this.toDomain);
-    } catch (error) {
-      this.logger.error(`Failed to find offers for tmdbProviderId=${tmdbProviderId}`, error);
-      throw error;
-    }
+        return rows.map(this.toDomain);
+      },
+      { tmdbProviderId },
+    );
   }
 
   async findByMediaItemIds(
@@ -174,67 +182,70 @@ export class MediaWatchOffersRepository implements IMediaWatchOffersRepository {
       return new Map();
     }
 
-    try {
-      const conditions = [inArray(mediaWatchOffers.mediaItemId, mediaItemIds)];
+    return withDbError(
+      'findByMediaItemIds',
+      this.logger,
+      async () => {
+        const conditions = [inArray(mediaWatchOffers.mediaItemId, mediaItemIds)];
 
-      if (options?.offerTypes?.length) {
-        conditions.push(inArray(mediaWatchOffers.offerType, options.offerTypes));
-      }
+        if (options?.offerTypes?.length) {
+          conditions.push(inArray(mediaWatchOffers.offerType, options.offerTypes));
+        }
 
-      if (options?.distributionChannels?.length) {
-        conditions.push(
-          inArray(mediaWatchOffers.distributionChannel, options.distributionChannels),
-        );
-      }
+        if (options?.distributionChannels?.length) {
+          conditions.push(
+            inArray(mediaWatchOffers.distributionChannel, options.distributionChannels),
+          );
+        }
 
-      if (options?.region) {
-        conditions.push(eq(mediaWatchOffers.region, options.region));
-      }
+        if (options?.region) {
+          conditions.push(eq(mediaWatchOffers.region, options.region));
+        }
 
-      const rows = await this.db
-        .select()
-        .from(mediaWatchOffers)
-        .where(and(...conditions));
+        const rows = await this.db
+          .select()
+          .from(mediaWatchOffers)
+          .where(and(...conditions));
 
-      // Group by media item
-      const grouped = new Map<string, MediaWatchOffer[]>();
-      for (const row of rows) {
-        const offers = grouped.get(row.mediaItemId) ?? [];
-        offers.push(this.toDomain(row));
-        grouped.set(row.mediaItemId, offers);
-      }
+        const grouped = new Map<string, MediaWatchOffer[]>();
+        for (const row of rows) {
+          const offers = grouped.get(row.mediaItemId) ?? [];
+          offers.push(this.toDomain(row));
+          grouped.set(row.mediaItemId, offers);
+        }
 
-      return grouped;
-    } catch (error) {
-      this.logger.error(`Failed to find offers for ${mediaItemIds.length} media items`, error);
-      throw error;
-    }
+        return grouped;
+      },
+      { count: mediaItemIds.length },
+    );
   }
 
   async deleteByMediaItemId(mediaItemId: string): Promise<void> {
-    try {
-      await this.db.delete(mediaWatchOffers).where(eq(mediaWatchOffers.mediaItemId, mediaItemId));
-
-      this.logger.debug(`Deleted all offers for media=${mediaItemId}`);
-    } catch (error) {
-      this.logger.error(`Failed to delete offers for media=${mediaItemId}`, error);
-      throw error;
-    }
+    await withDbError(
+      'deleteByMediaItemId',
+      this.logger,
+      async () => {
+        await this.db.delete(mediaWatchOffers).where(eq(mediaWatchOffers.mediaItemId, mediaItemId));
+        this.logger.debug(`Deleted all offers for media=${mediaItemId}`);
+      },
+      { mediaItemId },
+    );
   }
 
   async deleteByMediaItemIdAndRegion(mediaItemId: string, region: string): Promise<void> {
-    try {
-      await this.db
-        .delete(mediaWatchOffers)
-        .where(
-          and(eq(mediaWatchOffers.mediaItemId, mediaItemId), eq(mediaWatchOffers.region, region)),
-        );
-
-      this.logger.debug(`Deleted offers for media=${mediaItemId} region=${region}`);
-    } catch (error) {
-      this.logger.error(`Failed to delete offers for media=${mediaItemId} region=${region}`, error);
-      throw error;
-    }
+    await withDbError(
+      'deleteByMediaItemIdAndRegion',
+      this.logger,
+      async () => {
+        await this.db
+          .delete(mediaWatchOffers)
+          .where(
+            and(eq(mediaWatchOffers.mediaItemId, mediaItemId), eq(mediaWatchOffers.region, region)),
+          );
+        this.logger.debug(`Deleted offers for media=${mediaItemId} region=${region}`);
+      },
+      { mediaItemId, region },
+    );
   }
 
   async getOffersForMediaBatch(
@@ -245,53 +256,53 @@ export class MediaWatchOffersRepository implements IMediaWatchOffersRepository {
       return new Map();
     }
 
-    try {
-      const conditions = [inArray(mediaWatchOffers.mediaItemId, mediaItemIds)];
+    return withDbError(
+      'getOffersForMediaBatch',
+      this.logger,
+      async () => {
+        const conditions = [inArray(mediaWatchOffers.mediaItemId, mediaItemIds)];
 
-      if (options?.offerTypes?.length) {
-        conditions.push(inArray(mediaWatchOffers.offerType, options.offerTypes));
-      }
+        if (options?.offerTypes?.length) {
+          conditions.push(inArray(mediaWatchOffers.offerType, options.offerTypes));
+        }
 
-      if (options?.distributionChannels?.length) {
-        conditions.push(
-          inArray(mediaWatchOffers.distributionChannel, options.distributionChannels),
-        );
-      }
+        if (options?.distributionChannels?.length) {
+          conditions.push(
+            inArray(mediaWatchOffers.distributionChannel, options.distributionChannels),
+          );
+        }
 
-      // Conditional JOIN with provider_variants when variant info needed
-      if (options?.includeVariantInfo) {
+        if (options?.includeVariantInfo) {
+          const rows = await this.db
+            .select({
+              mediaItemId: mediaWatchOffers.mediaItemId,
+              providerId: mediaWatchOffers.providerId,
+              offerType: mediaWatchOffers.offerType,
+              distributionChannel: mediaWatchOffers.distributionChannel,
+              variantId: mediaWatchOffers.variantId,
+              isAdsTier: providerVariants.isAdsTier,
+            })
+            .from(mediaWatchOffers)
+            .leftJoin(providerVariants, eq(mediaWatchOffers.variantId, providerVariants.id))
+            .where(and(...conditions));
+
+          return this.groupOfferViewsWithVariant(rows);
+        }
+
         const rows = await this.db
           .select({
             mediaItemId: mediaWatchOffers.mediaItemId,
             providerId: mediaWatchOffers.providerId,
             offerType: mediaWatchOffers.offerType,
             distributionChannel: mediaWatchOffers.distributionChannel,
-            variantId: mediaWatchOffers.variantId,
-            isAdsTier: providerVariants.isAdsTier,
           })
           .from(mediaWatchOffers)
-          .leftJoin(providerVariants, eq(mediaWatchOffers.variantId, providerVariants.id))
           .where(and(...conditions));
 
-        return this.groupOfferViewsWithVariant(rows);
-      }
-
-      // Simple query without JOIN
-      const rows = await this.db
-        .select({
-          mediaItemId: mediaWatchOffers.mediaItemId,
-          providerId: mediaWatchOffers.providerId,
-          offerType: mediaWatchOffers.offerType,
-          distributionChannel: mediaWatchOffers.distributionChannel,
-        })
-        .from(mediaWatchOffers)
-        .where(and(...conditions));
-
-      return this.groupOfferViews(rows);
-    } catch (error) {
-      this.logger.error(`Failed to get offers for ${mediaItemIds.length} media items batch`, error);
-      throw error;
-    }
+        return this.groupOfferViews(rows);
+      },
+      { count: mediaItemIds.length },
+    );
   }
 
   private groupOfferViews(

--- a/apps/api/src/modules/reviews/application/review-votes.service.spec.ts
+++ b/apps/api/src/modules/reviews/application/review-votes.service.spec.ts
@@ -44,6 +44,12 @@ describe('ReviewVotesService', () => {
       remove: jest.fn().mockResolvedValue(true),
       countByReview: jest.fn().mockResolvedValue({ likes: 10, dislikes: 2 }),
       findUserVotesForReviews: jest.fn().mockResolvedValue(new Map()),
+      upsertAndRecount: jest
+        .fn()
+        .mockResolvedValue({ vote: mockVote, counts: { likes: 11, dislikes: 2 } }),
+      removeAndRecount: jest
+        .fn()
+        .mockResolvedValue({ removed: true, counts: { likes: 10, dislikes: 2 } }),
     };
 
     reviewRepo = {
@@ -68,14 +74,10 @@ describe('ReviewVotesService', () => {
 
       expect(result.action).toBe('added');
       expect(result.newVote).toEqual(mockVote);
-      expect(voteRepo.upsert).toHaveBeenCalledWith({
+      expect(voteRepo.upsertAndRecount).toHaveBeenCalledWith({
         userId: 'voter-id',
         reviewId: 'review-id-1',
         voteType: VOTE_TYPE.LIKE,
-      });
-      expect(reviewRepo.updateVoteCounts).toHaveBeenCalledWith('review-id-1', {
-        likesCount: 10,
-        dislikesCount: 2,
       });
     });
 
@@ -85,7 +87,10 @@ describe('ReviewVotesService', () => {
         voteType: VOTE_TYPE.LIKE,
       });
       const newVote = { ...mockVote, voteType: VOTE_TYPE.DISLIKE };
-      voteRepo.upsert.mockResolvedValue(newVote);
+      voteRepo.upsertAndRecount.mockResolvedValue({
+        vote: newVote,
+        counts: { likes: 10, dislikes: 3 },
+      });
 
       const result = await service.vote('voter-id', 'review-id-1', VOTE_TYPE.DISLIKE);
 
@@ -126,12 +131,14 @@ describe('ReviewVotesService', () => {
 
       expect(result.action).toBe('removed');
       expect(result.newVote).toBeNull();
-      expect(voteRepo.remove).toHaveBeenCalledWith('voter-id', 'review-id-1');
-      expect(reviewRepo.updateVoteCounts).toHaveBeenCalled();
+      expect(voteRepo.removeAndRecount).toHaveBeenCalledWith('voter-id', 'review-id-1');
     });
 
     it('should still return removed action when vote did not exist', async () => {
-      voteRepo.remove.mockResolvedValue(false);
+      voteRepo.removeAndRecount.mockResolvedValue({
+        removed: false,
+        counts: { likes: 10, dislikes: 2 },
+      });
 
       const result = await service.unvote('voter-id', 'review-id-1');
 
@@ -191,7 +198,10 @@ describe('ReviewVotesService', () => {
         voteType: VOTE_TYPE.LIKE,
       });
       const dislikeVote = { ...mockVote, voteType: VOTE_TYPE.DISLIKE };
-      voteRepo.upsert.mockResolvedValue(dislikeVote);
+      voteRepo.upsertAndRecount.mockResolvedValue({
+        vote: dislikeVote,
+        counts: { likes: 10, dislikes: 3 },
+      });
 
       const result = await service.vote('voter-id', 'review-id-1', VOTE_TYPE.DISLIKE);
 
@@ -206,7 +216,10 @@ describe('ReviewVotesService', () => {
         voteType: VOTE_TYPE.DISLIKE,
       });
       const likeVote = { ...mockVote, voteType: VOTE_TYPE.LIKE };
-      voteRepo.upsert.mockResolvedValue(likeVote);
+      voteRepo.upsertAndRecount.mockResolvedValue({
+        vote: likeVote,
+        counts: { likes: 11, dislikes: 2 },
+      });
 
       const result = await service.vote('voter-id', 'review-id-1', VOTE_TYPE.LIKE);
 
@@ -219,14 +232,19 @@ describe('ReviewVotesService', () => {
         ...mockVote,
         voteType: VOTE_TYPE.LIKE,
       });
-      voteRepo.countByReview.mockResolvedValue({ likes: 9, dislikes: 3 });
-      voteRepo.upsert.mockResolvedValue({ ...mockVote, voteType: VOTE_TYPE.DISLIKE });
+      const dislikeVote = { ...mockVote, voteType: VOTE_TYPE.DISLIKE };
+      voteRepo.upsertAndRecount.mockResolvedValue({
+        vote: dislikeVote,
+        counts: { likes: 9, dislikes: 3 },
+      });
 
       await service.vote('voter-id', 'review-id-1', VOTE_TYPE.DISLIKE);
 
-      expect(reviewRepo.updateVoteCounts).toHaveBeenCalledWith('review-id-1', {
-        likesCount: 9,
-        dislikesCount: 3,
+      // Counts are now updated atomically in the repository — service just calls upsertAndRecount
+      expect(voteRepo.upsertAndRecount).toHaveBeenCalledWith({
+        userId: 'voter-id',
+        reviewId: 'review-id-1',
+        voteType: VOTE_TYPE.DISLIKE,
       });
     });
   });

--- a/apps/api/src/modules/reviews/application/review-votes.service.ts
+++ b/apps/api/src/modules/reviews/application/review-votes.service.ts
@@ -65,15 +65,8 @@ export class ReviewVotesService {
       action = 'added';
     }
 
-    // Upsert vote
-    const newVote = await this.voteRepo.upsert({
-      userId,
-      reviewId,
-      voteType,
-    });
-
-    // Update denormalized counts
-    await this.updateReviewVoteCounts(reviewId);
+    // Atomically upsert vote and recount (prevents race conditions)
+    const { vote: newVote } = await this.voteRepo.upsertAndRecount({ userId, reviewId, voteType });
 
     this.logger.log(`User ${userId} ${action} vote on review ${reviewId}: ${voteType}`);
 
@@ -90,11 +83,9 @@ export class ReviewVotesService {
       throw new NotFoundException(ErrorCode.REVIEW_NOT_FOUND, 'Review not found', { reviewId });
     }
 
-    const removed = await this.voteRepo.remove(userId, reviewId);
+    const { removed } = await this.voteRepo.removeAndRecount(userId, reviewId);
 
     if (removed) {
-      // Update denormalized counts
-      await this.updateReviewVoteCounts(reviewId);
       this.logger.log(`User ${userId} removed vote from review ${reviewId}`);
     }
 
@@ -120,16 +111,5 @@ export class ReviewVotesService {
     reviewIds: string[],
   ): Promise<Map<string, ReviewVote>> {
     return this.voteRepo.findUserVotesForReviews(userId, reviewIds);
-  }
-
-  /**
-   * Updates the denormalized vote counts on a review.
-   */
-  private async updateReviewVoteCounts(reviewId: string): Promise<void> {
-    const counts = await this.voteRepo.countByReview(reviewId);
-    await this.reviewRepo.updateVoteCounts(reviewId, {
-      likesCount: counts.likes,
-      dislikesCount: counts.dislikes,
-    });
   }
 }

--- a/apps/api/src/modules/reviews/domain/repositories/review-vote.repository.interface.ts
+++ b/apps/api/src/modules/reviews/domain/repositories/review-vote.repository.interface.ts
@@ -30,4 +30,19 @@ export interface IReviewVoteRepository {
    * Find user's vote for multiple reviews (batch).
    */
   findUserVotesForReviews(userId: string, reviewIds: string[]): Promise<Map<string, ReviewVote>>;
+
+  /**
+   * Atomically upsert a vote and recount like/dislike totals in one transaction.
+   */
+  upsertAndRecount(
+    input: UpsertVoteInput,
+  ): Promise<{ vote: ReviewVote; counts: { likes: number; dislikes: number } }>;
+
+  /**
+   * Atomically remove a vote and recount like/dislike totals in one transaction.
+   */
+  removeAndRecount(
+    userId: string,
+    reviewId: string,
+  ): Promise<{ removed: boolean; counts: { likes: number; dislikes: number } }>;
 }

--- a/apps/api/src/modules/reviews/infrastructure/repositories/drizzle-review-reply.repository.ts
+++ b/apps/api/src/modules/reviews/infrastructure/repositories/drizzle-review-reply.repository.ts
@@ -1,8 +1,9 @@
-import { Injectable, Inject } from '@nestjs/common';
+import { Injectable, Inject, Logger } from '@nestjs/common';
 
 import { eq, and, asc, sql } from 'drizzle-orm';
 import { type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 
+import { withDbError } from '../../../../common/utils/db-error.utils';
 import { DATABASE_CONNECTION } from '../../../../database/database.module';
 import * as schema from '../../../../database/schema';
 import { reviewReplies, users } from '../../../../database/schema';
@@ -15,111 +16,155 @@ import type { IReviewReplyRepository } from '../../domain/repositories/review-re
 
 @Injectable()
 export class DrizzleReviewReplyRepository implements IReviewReplyRepository {
+  private readonly logger = new Logger(DrizzleReviewReplyRepository.name);
+
   constructor(
     @Inject(DATABASE_CONNECTION)
     private readonly db: PostgresJsDatabase<typeof schema>,
   ) {}
 
   async findByReview(reviewId: string): Promise<ReviewReplyWithAuthor[]> {
-    const rows = await this.db
-      .select({
-        id: reviewReplies.id,
-        reviewId: reviewReplies.reviewId,
-        userId: reviewReplies.userId,
-        parentReplyId: reviewReplies.parentReplyId,
-        replyToUsername: reviewReplies.replyToUsername,
-        content: reviewReplies.content,
-        isDeleted: reviewReplies.isDeleted,
-        createdAt: reviewReplies.createdAt,
-        updatedAt: reviewReplies.updatedAt,
-        authorId: users.id,
-        authorUsername: users.username,
-        authorAvatarUrl: users.avatarUrl,
-        authorIsProfilePublic: users.isProfilePublic,
-      })
-      .from(reviewReplies)
-      .innerJoin(users, eq(reviewReplies.userId, users.id))
-      .where(and(eq(reviewReplies.reviewId, reviewId), eq(reviewReplies.isDeleted, false)))
-      .orderBy(asc(reviewReplies.createdAt));
+    return withDbError(
+      'find replies by review',
+      this.logger,
+      async () => {
+        const rows = await this.db
+          .select({
+            id: reviewReplies.id,
+            reviewId: reviewReplies.reviewId,
+            userId: reviewReplies.userId,
+            parentReplyId: reviewReplies.parentReplyId,
+            replyToUsername: reviewReplies.replyToUsername,
+            content: reviewReplies.content,
+            isDeleted: reviewReplies.isDeleted,
+            createdAt: reviewReplies.createdAt,
+            updatedAt: reviewReplies.updatedAt,
+            authorId: users.id,
+            authorUsername: users.username,
+            authorAvatarUrl: users.avatarUrl,
+            authorIsProfilePublic: users.isProfilePublic,
+          })
+          .from(reviewReplies)
+          .innerJoin(users, eq(reviewReplies.userId, users.id))
+          .where(and(eq(reviewReplies.reviewId, reviewId), eq(reviewReplies.isDeleted, false)))
+          .orderBy(asc(reviewReplies.createdAt));
 
-    return rows.map((row) => ({
-      id: row.id,
-      reviewId: row.reviewId,
-      userId: row.userId,
-      parentReplyId: row.parentReplyId,
-      replyToUsername: row.replyToUsername,
-      content: row.content,
-      isDeleted: row.isDeleted,
-      createdAt: row.createdAt,
-      updatedAt: row.updatedAt,
-      author: {
-        id: row.authorId,
-        username: row.authorUsername,
-        avatarUrl: row.authorAvatarUrl,
-        isProfilePublic: row.authorIsProfilePublic ?? true,
+        return rows.map((row) => ({
+          id: row.id,
+          reviewId: row.reviewId,
+          userId: row.userId,
+          parentReplyId: row.parentReplyId,
+          replyToUsername: row.replyToUsername,
+          content: row.content,
+          isDeleted: row.isDeleted,
+          createdAt: row.createdAt,
+          updatedAt: row.updatedAt,
+          author: {
+            id: row.authorId,
+            username: row.authorUsername,
+            avatarUrl: row.authorAvatarUrl,
+            isProfilePublic: row.authorIsProfilePublic ?? true,
+          },
+        }));
       },
-    }));
+      { reviewId },
+    );
   }
 
   async findById(id: string): Promise<ReviewReply | null> {
-    const rows = await this.db
-      .select()
-      .from(reviewReplies)
-      .where(eq(reviewReplies.id, id))
-      .limit(1);
+    return withDbError(
+      'find reply by ID',
+      this.logger,
+      async () => {
+        const rows = await this.db
+          .select()
+          .from(reviewReplies)
+          .where(eq(reviewReplies.id, id))
+          .limit(1);
 
-    return rows[0] ?? null;
+        return rows[0] ?? null;
+      },
+      { id },
+    );
   }
 
   async create(input: CreateReplyInput): Promise<ReviewReply> {
-    const now = new Date();
-    const [reply] = await this.db
-      .insert(reviewReplies)
-      .values({
-        reviewId: input.reviewId,
-        userId: input.userId,
-        parentReplyId: input.parentReplyId ?? null,
-        replyToUsername: input.replyToUsername ?? null,
-        content: input.content,
-        createdAt: now,
-        updatedAt: now,
-      })
-      .returning();
+    return withDbError(
+      'create reply',
+      this.logger,
+      async () => {
+        const now = new Date();
+        const [reply] = await this.db
+          .insert(reviewReplies)
+          .values({
+            reviewId: input.reviewId,
+            userId: input.userId,
+            parentReplyId: input.parentReplyId ?? null,
+            replyToUsername: input.replyToUsername ?? null,
+            content: input.content,
+            createdAt: now,
+            updatedAt: now,
+          })
+          .returning();
 
-    return reply;
+        return reply;
+      },
+      { reviewId: input.reviewId, userId: input.userId },
+    );
   }
 
   async softDelete(id: string): Promise<void> {
-    await this.db
-      .update(reviewReplies)
-      .set({ isDeleted: true, updatedAt: new Date() })
-      .where(eq(reviewReplies.id, id));
+    return withDbError(
+      'soft delete reply',
+      this.logger,
+      () =>
+        this.db
+          .update(reviewReplies)
+          .set({ isDeleted: true, updatedAt: new Date() })
+          .where(eq(reviewReplies.id, id))
+          .then(() => undefined),
+      { id },
+    );
   }
 
   async countByReview(reviewId: string): Promise<number> {
-    const [result] = await this.db
-      .select({ count: sql<number>`count(*)::int` })
-      .from(reviewReplies)
-      .where(and(eq(reviewReplies.reviewId, reviewId), eq(reviewReplies.isDeleted, false)));
+    return withDbError(
+      'count replies by review',
+      this.logger,
+      async () => {
+        const [result] = await this.db
+          .select({ count: sql<number>`count(*)::int` })
+          .from(reviewReplies)
+          .where(and(eq(reviewReplies.reviewId, reviewId), eq(reviewReplies.isDeleted, false)));
 
-    return result?.count ?? 0;
+        return result?.count ?? 0;
+      },
+      { reviewId },
+    );
   }
 
   async getNestingDepth(replyId: string): Promise<number> {
-    // Simple depth calculation: check if parent has a parent
-    // MAX_REPLIES_DEPTH is 2, so we only need to check 2 levels
-    const reply = await this.findById(replyId);
-    if (!reply || !reply.parentReplyId) {
-      return 0; // Top-level reply
-    }
+    return withDbError(
+      'get reply nesting depth',
+      this.logger,
+      async () => {
+        // Simple depth calculation: check if parent has a parent
+        // MAX_REPLIES_DEPTH is 2, so we only need to check 2 levels
+        const reply = await this.findById(replyId);
+        if (!reply || !reply.parentReplyId) {
+          return 0; // Top-level reply
+        }
 
-    // Check if parent has a parent (depth 1 means parent is at root level)
-    const parent = await this.findById(reply.parentReplyId);
-    if (!parent || !parent.parentReplyId) {
-      return 1; // Reply to a top-level reply
-    }
+        // Check if parent has a parent (depth 1 means parent is at root level)
+        const parent = await this.findById(reply.parentReplyId);
+        if (!parent || !parent.parentReplyId) {
+          return 1; // Reply to a top-level reply
+        }
 
-    // Parent has a parent, so this reply would be at depth 2+
-    return 2;
+        // Parent has a parent, so this reply would be at depth 2+
+        return 2;
+      },
+      { replyId },
+    );
   }
 }

--- a/apps/api/src/modules/reviews/infrastructure/repositories/drizzle-review-report.repository.ts
+++ b/apps/api/src/modules/reviews/infrastructure/repositories/drizzle-review-report.repository.ts
@@ -1,9 +1,10 @@
-import { Injectable, Inject } from '@nestjs/common';
+import { Injectable, Inject, Logger } from '@nestjs/common';
 
 import { eq, and, asc, sql, gte } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
 import { type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 
+import { withDbError } from '../../../../common/utils/db-error.utils';
 import { DATABASE_CONNECTION } from '../../../../database/database.module';
 import * as schema from '../../../../database/schema';
 import { reviewReports, reviews, users } from '../../../../database/schema';
@@ -17,45 +18,68 @@ import type { IReviewReportRepository } from '../../domain/repositories/review-r
 
 @Injectable()
 export class DrizzleReviewReportRepository implements IReviewReportRepository {
+  private readonly logger = new Logger(DrizzleReviewReportRepository.name);
+
   constructor(
     @Inject(DATABASE_CONNECTION)
     private readonly db: PostgresJsDatabase<typeof schema>,
   ) {}
 
   async findById(id: string): Promise<ReviewReport | null> {
-    const rows = await this.db
-      .select()
-      .from(reviewReports)
-      .where(eq(reviewReports.id, id))
-      .limit(1);
+    return withDbError(
+      'find report by ID',
+      this.logger,
+      async () => {
+        const rows = await this.db
+          .select()
+          .from(reviewReports)
+          .where(eq(reviewReports.id, id))
+          .limit(1);
 
-    return rows[0] ?? null;
+        return rows[0] ?? null;
+      },
+      { id },
+    );
   }
 
   async existsByUserAndReview(userId: string, reviewId: string): Promise<boolean> {
-    const rows = await this.db
-      .select({ id: reviewReports.id })
-      .from(reviewReports)
-      .where(and(eq(reviewReports.reporterId, userId), eq(reviewReports.reviewId, reviewId)))
-      .limit(1);
+    return withDbError(
+      'check report exists',
+      this.logger,
+      async () => {
+        const rows = await this.db
+          .select({ id: reviewReports.id })
+          .from(reviewReports)
+          .where(and(eq(reviewReports.reporterId, userId), eq(reviewReports.reviewId, reviewId)))
+          .limit(1);
 
-    return rows.length > 0;
+        return rows.length > 0;
+      },
+      { userId, reviewId },
+    );
   }
 
   async create(input: CreateReportInput): Promise<ReviewReport> {
-    const [report] = await this.db
-      .insert(reviewReports)
-      .values({
-        reviewId: input.reviewId,
-        reporterId: input.reporterId,
-        reason: input.reason,
-        details: input.details ?? null,
-        status: 'pending',
-        createdAt: new Date(),
-      })
-      .returning();
+    return withDbError(
+      'create report',
+      this.logger,
+      async () => {
+        const [report] = await this.db
+          .insert(reviewReports)
+          .values({
+            reviewId: input.reviewId,
+            reporterId: input.reporterId,
+            reason: input.reason,
+            details: input.details ?? null,
+            status: 'pending',
+            createdAt: new Date(),
+          })
+          .returning();
 
-    return report;
+        return report;
+      },
+      { reviewId: input.reviewId, reporterId: input.reporterId },
+    );
   }
 
   async findForModeration(params: {
@@ -65,81 +89,95 @@ export class DrizzleReviewReportRepository implements IReviewReportRepository {
   }): Promise<ReviewReportWithReview[]> {
     const { status, limit = 20, offset = 0 } = params;
 
-    // Create proper aliases for joining users table twice
-    const authorUser = alias(users, 'author_user');
-    const reporterUser = alias(users, 'reporter_user');
+    return withDbError(
+      'find reports for moderation',
+      this.logger,
+      async () => {
+        // Create proper aliases for joining users table twice
+        const authorUser = alias(users, 'author_user');
+        const reporterUser = alias(users, 'reporter_user');
 
-    const conditions = status ? [eq(reviewReports.status, status)] : [];
+        const conditions = status ? [eq(reviewReports.status, status)] : [];
 
-    const rows = await this.db
-      .select({
-        // Report fields
-        id: reviewReports.id,
-        reviewId: reviewReports.reviewId,
-        reporterId: reviewReports.reporterId,
-        reason: reviewReports.reason,
-        details: reviewReports.details,
-        status: reviewReports.status,
-        moderatorId: reviewReports.moderatorId,
-        moderatorNotes: reviewReports.moderatorNotes,
-        resolvedAt: reviewReports.resolvedAt,
-        createdAt: reviewReports.createdAt,
-        // Review fields
-        reviewContent: reviews.content,
-        reviewHasSpoiler: reviews.hasSpoiler,
-        reviewIsDeleted: reviews.isDeleted,
-        reviewAuthorId: reviews.userId,
-        // Author username
-        reviewAuthorUsername: authorUser.username,
-        // Reporter username
-        reporterUsername: reporterUser.username,
-      })
-      .from(reviewReports)
-      .innerJoin(reviews, eq(reviewReports.reviewId, reviews.id))
-      .innerJoin(authorUser, eq(reviews.userId, authorUser.id))
-      .innerJoin(reporterUser, eq(reviewReports.reporterId, reporterUser.id))
-      .where(conditions.length > 0 ? and(...conditions) : undefined)
-      .orderBy(asc(reviewReports.createdAt))
-      .limit(limit)
-      .offset(offset);
+        const rows = await this.db
+          .select({
+            // Report fields
+            id: reviewReports.id,
+            reviewId: reviewReports.reviewId,
+            reporterId: reviewReports.reporterId,
+            reason: reviewReports.reason,
+            details: reviewReports.details,
+            status: reviewReports.status,
+            moderatorId: reviewReports.moderatorId,
+            moderatorNotes: reviewReports.moderatorNotes,
+            resolvedAt: reviewReports.resolvedAt,
+            createdAt: reviewReports.createdAt,
+            // Review fields
+            reviewContent: reviews.content,
+            reviewHasSpoiler: reviews.hasSpoiler,
+            reviewIsDeleted: reviews.isDeleted,
+            reviewAuthorId: reviews.userId,
+            // Author username
+            reviewAuthorUsername: authorUser.username,
+            // Reporter username
+            reporterUsername: reporterUser.username,
+          })
+          .from(reviewReports)
+          .innerJoin(reviews, eq(reviewReports.reviewId, reviews.id))
+          .innerJoin(authorUser, eq(reviews.userId, authorUser.id))
+          .innerJoin(reporterUser, eq(reviewReports.reporterId, reporterUser.id))
+          .where(conditions.length > 0 ? and(...conditions) : undefined)
+          .orderBy(asc(reviewReports.createdAt), asc(reviewReports.id))
+          .limit(limit)
+          .offset(offset);
 
-    return rows.map((row) => ({
-      id: row.id,
-      reviewId: row.reviewId,
-      reporterId: row.reporterId,
-      reason: row.reason,
-      details: row.details,
-      status: row.status,
-      moderatorId: row.moderatorId,
-      moderatorNotes: row.moderatorNotes,
-      resolvedAt: row.resolvedAt,
-      createdAt: row.createdAt,
-      review: {
-        id: row.reviewId,
-        content: row.reviewContent,
-        hasSpoiler: row.reviewHasSpoiler,
-        isDeleted: row.reviewIsDeleted,
-        author: {
-          id: row.reviewAuthorId,
-          username: row.reviewAuthorUsername,
-        },
+        return rows.map((row) => ({
+          id: row.id,
+          reviewId: row.reviewId,
+          reporterId: row.reporterId,
+          reason: row.reason,
+          details: row.details,
+          status: row.status,
+          moderatorId: row.moderatorId,
+          moderatorNotes: row.moderatorNotes,
+          resolvedAt: row.resolvedAt,
+          createdAt: row.createdAt,
+          review: {
+            id: row.reviewId,
+            content: row.reviewContent,
+            hasSpoiler: row.reviewHasSpoiler,
+            isDeleted: row.reviewIsDeleted,
+            author: {
+              id: row.reviewAuthorId,
+              username: row.reviewAuthorUsername,
+            },
+          },
+          reporter: {
+            id: row.reporterId,
+            username: row.reporterUsername,
+          },
+        }));
       },
-      reporter: {
-        id: row.reporterId,
-        username: row.reporterUsername,
-      },
-    }));
+      { status, limit, offset },
+    );
   }
 
   async countByStatus(status?: ReportStatus): Promise<number> {
-    const conditions = status ? [eq(reviewReports.status, status)] : [];
+    return withDbError(
+      'count reports by status',
+      this.logger,
+      async () => {
+        const conditions = status ? [eq(reviewReports.status, status)] : [];
 
-    const [result] = await this.db
-      .select({ count: sql<number>`count(*)::int` })
-      .from(reviewReports)
-      .where(conditions.length > 0 ? and(...conditions) : undefined);
+        const [result] = await this.db
+          .select({ count: sql<number>`count(*)::int` })
+          .from(reviewReports)
+          .where(conditions.length > 0 ? and(...conditions) : undefined);
 
-    return result?.count ?? 0;
+        return result?.count ?? 0;
+      },
+      { status },
+    );
   }
 
   async updateStatus(params: {
@@ -148,26 +186,40 @@ export class DrizzleReviewReportRepository implements IReviewReportRepository {
     moderatorId: string;
     moderatorNotes?: string;
   }): Promise<void> {
-    await this.db
-      .update(reviewReports)
-      .set({
-        status: params.status,
-        moderatorId: params.moderatorId,
-        moderatorNotes: params.moderatorNotes ?? null,
-        resolvedAt: new Date(),
-      })
-      .where(eq(reviewReports.id, params.reportId));
+    return withDbError(
+      'update report status',
+      this.logger,
+      () =>
+        this.db
+          .update(reviewReports)
+          .set({
+            status: params.status,
+            moderatorId: params.moderatorId,
+            moderatorNotes: params.moderatorNotes ?? null,
+            resolvedAt: new Date(),
+          })
+          .where(eq(reviewReports.id, params.reportId))
+          .then(() => undefined),
+      { reportId: params.reportId, status: params.status },
+    );
   }
 
   async countUserReportsToday(userId: string): Promise<number> {
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
+    return withDbError(
+      'count user reports today',
+      this.logger,
+      async () => {
+        const today = new Date();
+        today.setHours(0, 0, 0, 0);
 
-    const [result] = await this.db
-      .select({ count: sql<number>`count(*)::int` })
-      .from(reviewReports)
-      .where(and(eq(reviewReports.reporterId, userId), gte(reviewReports.createdAt, today)));
+        const [result] = await this.db
+          .select({ count: sql<number>`count(*)::int` })
+          .from(reviewReports)
+          .where(and(eq(reviewReports.reporterId, userId), gte(reviewReports.createdAt, today)));
 
-    return result?.count ?? 0;
+        return result?.count ?? 0;
+      },
+      { userId },
+    );
   }
 }

--- a/apps/api/src/modules/reviews/infrastructure/repositories/drizzle-review-vote.repository.ts
+++ b/apps/api/src/modules/reviews/infrastructure/repositories/drizzle-review-vote.repository.ts
@@ -3,7 +3,7 @@ import { Inject, Injectable, Logger } from '@nestjs/common';
 import { and, eq, inArray, sql } from 'drizzle-orm';
 import { type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 
-import { DatabaseException } from '../../../../common/exceptions/database.exception';
+import { withDbError } from '../../../../common/utils/db-error.utils';
 import { DATABASE_CONNECTION } from '../../../../database/database.module';
 import * as schema from '../../../../database/schema';
 import { VOTE_TYPE, type VoteType } from '../../domain/constants/review.constants';
@@ -26,101 +26,106 @@ export class DrizzleReviewVoteRepository implements IReviewVoteRepository {
    * Find a vote by user and review.
    */
   async findByUserAndReview(userId: string, reviewId: string): Promise<ReviewVote | null> {
-    try {
-      const [row] = await this.db
-        .select()
-        .from(schema.reviewVotes)
-        .where(
-          and(eq(schema.reviewVotes.userId, userId), eq(schema.reviewVotes.reviewId, reviewId)),
-        )
-        .limit(1);
+    return withDbError(
+      'find vote',
+      this.logger,
+      async () => {
+        const [row] = await this.db
+          .select()
+          .from(schema.reviewVotes)
+          .where(
+            and(eq(schema.reviewVotes.userId, userId), eq(schema.reviewVotes.reviewId, reviewId)),
+          )
+          .limit(1);
 
-      return row ? this.mapRow(row) : null;
-    } catch (error) {
-      this.logger.error(`findByUserAndReview failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to find vote', { userId, reviewId });
-    }
+        return row ? this.mapRow(row) : null;
+      },
+      { userId, reviewId },
+    );
   }
 
   /**
    * Upsert a vote (create or update).
    */
   async upsert(input: UpsertVoteInput): Promise<ReviewVote> {
-    try {
-      const [row] = await this.db
-        .insert(schema.reviewVotes)
-        .values({
-          userId: input.userId,
-          reviewId: input.reviewId,
-          voteType: input.voteType,
-        })
-        .onConflictDoUpdate({
-          target: [schema.reviewVotes.userId, schema.reviewVotes.reviewId],
-          set: {
+    return withDbError(
+      'upsert vote',
+      this.logger,
+      async () => {
+        const [row] = await this.db
+          .insert(schema.reviewVotes)
+          .values({
+            userId: input.userId,
+            reviewId: input.reviewId,
             voteType: input.voteType,
-          },
-        })
-        .returning();
+          })
+          .onConflictDoUpdate({
+            target: [schema.reviewVotes.userId, schema.reviewVotes.reviewId],
+            set: {
+              voteType: input.voteType,
+            },
+          })
+          .returning();
 
-      return this.mapRow(row);
-    } catch (error) {
-      this.logger.error(`upsert failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to upsert vote', {
-        userId: input.userId,
-        reviewId: input.reviewId,
-      });
-    }
+        return this.mapRow(row);
+      },
+      { userId: input.userId, reviewId: input.reviewId },
+    );
   }
 
   /**
    * Remove a vote.
    */
   async remove(userId: string, reviewId: string): Promise<boolean> {
-    try {
-      const result = await this.db
-        .delete(schema.reviewVotes)
-        .where(
-          and(eq(schema.reviewVotes.userId, userId), eq(schema.reviewVotes.reviewId, reviewId)),
-        )
-        .returning({ id: schema.reviewVotes.id });
+    return withDbError(
+      'remove vote',
+      this.logger,
+      async () => {
+        const result = await this.db
+          .delete(schema.reviewVotes)
+          .where(
+            and(eq(schema.reviewVotes.userId, userId), eq(schema.reviewVotes.reviewId, reviewId)),
+          )
+          .returning({ id: schema.reviewVotes.id });
 
-      return result.length > 0;
-    } catch (error) {
-      this.logger.error(`remove failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to remove vote', { userId, reviewId });
-    }
+        return result.length > 0;
+      },
+      { userId, reviewId },
+    );
   }
 
   /**
    * Count votes by review (for denormalization).
    */
   async countByReview(reviewId: string): Promise<{ likes: number; dislikes: number }> {
-    try {
-      const rows = await this.db
-        .select({
-          voteType: schema.reviewVotes.voteType,
-          count: sql<number>`count(*)`,
-        })
-        .from(schema.reviewVotes)
-        .where(eq(schema.reviewVotes.reviewId, reviewId))
-        .groupBy(schema.reviewVotes.voteType);
+    return withDbError(
+      'count votes',
+      this.logger,
+      async () => {
+        const rows = await this.db
+          .select({
+            voteType: schema.reviewVotes.voteType,
+            count: sql<number>`count(*)`,
+          })
+          .from(schema.reviewVotes)
+          .where(eq(schema.reviewVotes.reviewId, reviewId))
+          .groupBy(schema.reviewVotes.voteType);
 
-      let likes = 0;
-      let dislikes = 0;
+        let likes = 0;
+        let dislikes = 0;
 
-      for (const row of rows) {
-        if (row.voteType === VOTE_TYPE.LIKE) {
-          likes = Number(row.count);
-        } else if (row.voteType === VOTE_TYPE.DISLIKE) {
-          dislikes = Number(row.count);
+        for (const row of rows) {
+          if (row.voteType === VOTE_TYPE.LIKE) {
+            likes = Number(row.count);
+          } else if (row.voteType === VOTE_TYPE.DISLIKE) {
+            dislikes = Number(row.count);
+          }
         }
-      }
 
-      return { likes, dislikes };
-    } catch (error) {
-      this.logger.error(`countByReview failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to count votes', { reviewId });
-    }
+        return { likes, dislikes };
+      },
+      { reviewId },
+    );
   }
 
   /**
@@ -134,30 +139,112 @@ export class DrizzleReviewVoteRepository implements IReviewVoteRepository {
       return new Map();
     }
 
-    try {
-      const rows = await this.db
-        .select()
-        .from(schema.reviewVotes)
-        .where(
-          and(
-            eq(schema.reviewVotes.userId, userId),
-            inArray(schema.reviewVotes.reviewId, reviewIds),
-          ),
-        );
+    return withDbError(
+      'find user votes for reviews',
+      this.logger,
+      async () => {
+        const rows = await this.db
+          .select()
+          .from(schema.reviewVotes)
+          .where(
+            and(
+              eq(schema.reviewVotes.userId, userId),
+              inArray(schema.reviewVotes.reviewId, reviewIds),
+            ),
+          );
 
-      const result = new Map<string, ReviewVote>();
-      for (const row of rows) {
-        result.set(row.reviewId, this.mapRow(row));
-      }
+        const result = new Map<string, ReviewVote>();
+        for (const row of rows) {
+          result.set(row.reviewId, this.mapRow(row));
+        }
 
-      return result;
-    } catch (error) {
-      this.logger.error(`findUserVotesForReviews failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to find user votes for reviews', {
-        userId,
-        reviewIds: reviewIds.length,
-      });
-    }
+        return result;
+      },
+      { userId, reviewIds: reviewIds.length },
+    );
+  }
+
+  /**
+   * Atomically upsert a vote and recount totals in one transaction.
+   */
+  async upsertAndRecount(
+    input: UpsertVoteInput,
+  ): Promise<{ vote: ReviewVote; counts: { likes: number; dislikes: number } }> {
+    return withDbError(
+      'upsert vote and recount',
+      this.logger,
+      async () => {
+        return this.db.transaction(async (tx) => {
+          const [row] = await tx
+            .insert(schema.reviewVotes)
+            .values({ userId: input.userId, reviewId: input.reviewId, voteType: input.voteType })
+            .onConflictDoUpdate({
+              target: [schema.reviewVotes.userId, schema.reviewVotes.reviewId],
+              set: { voteType: input.voteType },
+            })
+            .returning();
+
+          const [updated] = await tx
+            .update(schema.reviews)
+            .set({
+              likesCount: sql`(SELECT COUNT(*) FROM ${schema.reviewVotes} WHERE review_id = ${input.reviewId} AND vote_type = 'like')`,
+              dislikesCount: sql`(SELECT COUNT(*) FROM ${schema.reviewVotes} WHERE review_id = ${input.reviewId} AND vote_type = 'dislike')`,
+            })
+            .where(eq(schema.reviews.id, input.reviewId))
+            .returning({
+              likesCount: schema.reviews.likesCount,
+              dislikesCount: schema.reviews.dislikesCount,
+            });
+
+          return {
+            vote: this.mapRow(row),
+            counts: { likes: updated.likesCount, dislikes: updated.dislikesCount },
+          };
+        });
+      },
+      { userId: input.userId, reviewId: input.reviewId },
+    );
+  }
+
+  /**
+   * Atomically remove a vote and recount totals in one transaction.
+   */
+  async removeAndRecount(
+    userId: string,
+    reviewId: string,
+  ): Promise<{ removed: boolean; counts: { likes: number; dislikes: number } }> {
+    return withDbError(
+      'remove vote and recount',
+      this.logger,
+      async () => {
+        return this.db.transaction(async (tx) => {
+          const deleted = await tx
+            .delete(schema.reviewVotes)
+            .where(
+              and(eq(schema.reviewVotes.userId, userId), eq(schema.reviewVotes.reviewId, reviewId)),
+            )
+            .returning({ id: schema.reviewVotes.id });
+
+          const [updated] = await tx
+            .update(schema.reviews)
+            .set({
+              likesCount: sql`(SELECT COUNT(*) FROM ${schema.reviewVotes} WHERE review_id = ${reviewId} AND vote_type = 'like')`,
+              dislikesCount: sql`(SELECT COUNT(*) FROM ${schema.reviewVotes} WHERE review_id = ${reviewId} AND vote_type = 'dislike')`,
+            })
+            .where(eq(schema.reviews.id, reviewId))
+            .returning({
+              likesCount: schema.reviews.likesCount,
+              dislikesCount: schema.reviews.dislikesCount,
+            });
+
+          return {
+            removed: deleted.length > 0,
+            counts: { likes: updated.likesCount, dislikes: updated.dislikesCount },
+          };
+        });
+      },
+      { userId, reviewId },
+    );
   }
 
   private mapRow(row: typeof schema.reviewVotes.$inferSelect): ReviewVote {

--- a/apps/api/src/modules/reviews/infrastructure/repositories/drizzle-review.repository.ts
+++ b/apps/api/src/modules/reviews/infrastructure/repositories/drizzle-review.repository.ts
@@ -4,6 +4,7 @@ import { and, desc, asc, eq, sql, gte } from 'drizzle-orm';
 import { type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 
 import { DatabaseException } from '../../../../common/exceptions/database.exception';
+import { withDbError } from '../../../../common/utils/db-error.utils';
 import { DATABASE_CONNECTION } from '../../../../database/database.module';
 import * as schema from '../../../../database/schema';
 import { REVIEW_SORT, type ReviewSort } from '../../domain/constants/review.constants';
@@ -39,230 +40,247 @@ export class DrizzleReviewRepository implements IReviewRepository {
   }> {
     const { mediaItemId, sort, limit, offset, hideSpoilers } = options;
 
-    try {
-      // Build where conditions
-      const conditions = [
-        eq(schema.reviews.mediaItemId, mediaItemId),
-        eq(schema.reviews.isDeleted, false),
-      ];
+    return withDbError(
+      'find reviews',
+      this.logger,
+      async () => {
+        // Build where conditions
+        const conditions = [
+          eq(schema.reviews.mediaItemId, mediaItemId),
+          eq(schema.reviews.isDeleted, false),
+        ];
 
-      if (hideSpoilers) {
-        conditions.push(eq(schema.reviews.hasSpoiler, false));
-      }
+        if (hideSpoilers) {
+          conditions.push(eq(schema.reviews.hasSpoiler, false));
+        }
 
-      // Build order by based on sort
-      const orderBy = this.getOrderBy(sort);
+        // Build order by based on sort
+        const orderBy = this.getOrderBy(sort);
 
-      // Query reviews with authors
-      const rows = await this.db
-        .select({
-          review: schema.reviews,
-          author: {
-            id: schema.users.id,
-            username: schema.users.username,
-            avatarUrl: schema.users.avatarUrl,
-            showRatings: schema.users.showRatings,
-            isProfilePublic: schema.users.isProfilePublic,
-          },
-        })
-        .from(schema.reviews)
-        .innerJoin(schema.users, eq(schema.users.id, schema.reviews.userId))
-        .where(and(...conditions))
-        .orderBy(orderBy)
-        .limit(limit)
-        .offset(offset);
+        // Query reviews with authors
+        const rows = await this.db
+          .select({
+            review: schema.reviews,
+            author: {
+              id: schema.users.id,
+              username: schema.users.username,
+              avatarUrl: schema.users.avatarUrl,
+              showRatings: schema.users.showRatings,
+              isProfilePublic: schema.users.isProfilePublic,
+            },
+          })
+          .from(schema.reviews)
+          .innerJoin(schema.users, eq(schema.users.id, schema.reviews.userId))
+          .where(and(...conditions))
+          .orderBy(orderBy)
+          .limit(limit)
+          .offset(offset);
 
-      // Count total
-      const [countRow] = await this.db
-        .select({ count: sql<number>`count(*)` })
-        .from(schema.reviews)
-        .where(and(...conditions));
+        // Count total
+        const [countRow] = await this.db
+          .select({ count: sql<number>`count(*)` })
+          .from(schema.reviews)
+          .where(and(...conditions));
 
-      return {
-        reviews: rows.map((row) => this.mapRowWithAuthor(row.review, row.author)),
-        total: Number(countRow?.count ?? 0),
-      };
-    } catch (error) {
-      this.logger.error(`findByMediaItem failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to find reviews', { mediaItemId });
-    }
+        return {
+          reviews: rows.map((row) => this.mapRowWithAuthor(row.review, row.author)),
+          total: Number(countRow?.count ?? 0),
+        };
+      },
+      { mediaItemId },
+    );
   }
 
   /**
    * Find a single review by ID.
    */
   async findById(id: string): Promise<Review | null> {
-    try {
-      const [row] = await this.db
-        .select()
-        .from(schema.reviews)
-        .where(and(eq(schema.reviews.id, id), eq(schema.reviews.isDeleted, false)))
-        .limit(1);
+    return withDbError(
+      'find review',
+      this.logger,
+      async () => {
+        const [row] = await this.db
+          .select()
+          .from(schema.reviews)
+          .where(and(eq(schema.reviews.id, id), eq(schema.reviews.isDeleted, false)))
+          .limit(1);
 
-      return row ? this.mapRow(row) : null;
-    } catch (error) {
-      this.logger.error(`findById failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to find review', { id });
-    }
+        return row ? this.mapRow(row) : null;
+      },
+      { id },
+    );
   }
 
   /**
    * Find a single review by ID with author info.
    */
   async findByIdWithAuthor(id: string): Promise<ReviewWithAuthor | null> {
-    try {
-      const [row] = await this.db
-        .select({
-          review: schema.reviews,
-          author: {
-            id: schema.users.id,
-            username: schema.users.username,
-            avatarUrl: schema.users.avatarUrl,
-            showRatings: schema.users.showRatings,
-            isProfilePublic: schema.users.isProfilePublic,
-          },
-        })
-        .from(schema.reviews)
-        .innerJoin(schema.users, eq(schema.users.id, schema.reviews.userId))
-        .where(and(eq(schema.reviews.id, id), eq(schema.reviews.isDeleted, false)))
-        .limit(1);
+    return withDbError(
+      'find review with author',
+      this.logger,
+      async () => {
+        const [row] = await this.db
+          .select({
+            review: schema.reviews,
+            author: {
+              id: schema.users.id,
+              username: schema.users.username,
+              avatarUrl: schema.users.avatarUrl,
+              showRatings: schema.users.showRatings,
+              isProfilePublic: schema.users.isProfilePublic,
+            },
+          })
+          .from(schema.reviews)
+          .innerJoin(schema.users, eq(schema.users.id, schema.reviews.userId))
+          .where(and(eq(schema.reviews.id, id), eq(schema.reviews.isDeleted, false)))
+          .limit(1);
 
-      return row ? this.mapRowWithAuthor(row.review, row.author) : null;
-    } catch (error) {
-      this.logger.error(`findByIdWithAuthor failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to find review with author', { id });
-    }
+        return row ? this.mapRowWithAuthor(row.review, row.author) : null;
+      },
+      { id },
+    );
   }
 
   /**
    * Find a review by user and media item.
    */
   async findByUserAndMedia(userId: string, mediaItemId: string): Promise<Review | null> {
-    try {
-      const [row] = await this.db
-        .select()
-        .from(schema.reviews)
-        .where(
-          and(
-            eq(schema.reviews.userId, userId),
-            eq(schema.reviews.mediaItemId, mediaItemId),
-            eq(schema.reviews.isDeleted, false),
-          ),
-        )
-        .limit(1);
+    return withDbError(
+      'find user review',
+      this.logger,
+      async () => {
+        const [row] = await this.db
+          .select()
+          .from(schema.reviews)
+          .where(
+            and(
+              eq(schema.reviews.userId, userId),
+              eq(schema.reviews.mediaItemId, mediaItemId),
+              eq(schema.reviews.isDeleted, false),
+            ),
+          )
+          .limit(1);
 
-      return row ? this.mapRow(row) : null;
-    } catch (error) {
-      this.logger.error(`findByUserAndMedia failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to find user review', { userId, mediaItemId });
-    }
+        return row ? this.mapRow(row) : null;
+      },
+      { userId, mediaItemId },
+    );
   }
 
   /**
    * Create a new review.
    */
   async create(input: CreateReviewInput): Promise<Review> {
-    try {
-      const [row] = await this.db
-        .insert(schema.reviews)
-        .values({
-          userId: input.userId,
-          mediaItemId: input.mediaItemId,
-          content: input.content,
-          rating: input.rating,
-          hasSpoiler: input.hasSpoiler,
-        })
-        .returning();
+    return withDbError(
+      'create review',
+      this.logger,
+      async () => {
+        const [row] = await this.db
+          .insert(schema.reviews)
+          .values({
+            userId: input.userId,
+            mediaItemId: input.mediaItemId,
+            content: input.content,
+            rating: input.rating,
+            hasSpoiler: input.hasSpoiler,
+          })
+          .returning();
 
-      return this.mapRow(row);
-    } catch (error) {
-      this.logger.error(`create failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to create review', {
-        userId: input.userId,
-        mediaItemId: input.mediaItemId,
-      });
-    }
+        return this.mapRow(row);
+      },
+      { userId: input.userId, mediaItemId: input.mediaItemId },
+    );
   }
 
   /**
    * Update an existing review.
    */
   async update(id: string, input: UpdateReviewInput): Promise<Review> {
-    try {
-      const updateData: Record<string, unknown> = {
-        updatedAt: new Date(),
-      };
+    return withDbError(
+      'update review',
+      this.logger,
+      async () => {
+        const updateData: Record<string, unknown> = {
+          updatedAt: new Date(),
+        };
 
-      if (input.content !== undefined) updateData.content = input.content;
-      if (input.rating !== undefined) updateData.rating = input.rating;
-      if (input.hasSpoiler !== undefined) updateData.hasSpoiler = input.hasSpoiler;
+        if (input.content !== undefined) updateData.content = input.content;
+        if (input.rating !== undefined) updateData.rating = input.rating;
+        if (input.hasSpoiler !== undefined) updateData.hasSpoiler = input.hasSpoiler;
 
-      const [row] = await this.db
-        .update(schema.reviews)
-        .set(updateData)
-        .where(eq(schema.reviews.id, id))
-        .returning();
+        const [row] = await this.db
+          .update(schema.reviews)
+          .set(updateData)
+          .where(eq(schema.reviews.id, id))
+          .returning();
 
-      if (!row) {
-        throw new DatabaseException('Review not found during update', { id });
-      }
+        if (!row) {
+          throw new DatabaseException('Review not found during update', { id });
+        }
 
-      return this.mapRow(row);
-    } catch (error) {
-      this.logger.error(`update failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to update review', { id });
-    }
+        return this.mapRow(row);
+      },
+      { id },
+    );
   }
 
   /**
    * Soft delete a review.
    */
   async softDelete(id: string): Promise<void> {
-    try {
-      await this.db
-        .update(schema.reviews)
-        .set({
-          isDeleted: true,
-          deletedAt: new Date(),
-          updatedAt: new Date(),
-        })
-        .where(eq(schema.reviews.id, id));
-    } catch (error) {
-      this.logger.error(`softDelete failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to soft delete review', { id });
-    }
+    return withDbError(
+      'soft delete review',
+      this.logger,
+      () =>
+        this.db
+          .update(schema.reviews)
+          .set({
+            isDeleted: true,
+            deletedAt: new Date(),
+            updatedAt: new Date(),
+          })
+          .where(eq(schema.reviews.id, id))
+          .then(() => undefined),
+      { id },
+    );
   }
 
   /**
    * Hard delete a review (admin only).
    */
   async hardDelete(id: string): Promise<void> {
-    try {
-      await this.db.delete(schema.reviews).where(eq(schema.reviews.id, id));
-    } catch (error) {
-      this.logger.error(`hardDelete failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to hard delete review', { id });
-    }
+    return withDbError(
+      'hard delete review',
+      this.logger,
+      () =>
+        this.db
+          .delete(schema.reviews)
+          .where(eq(schema.reviews.id, id))
+          .then(() => undefined),
+      { id },
+    );
   }
 
   /**
    * Count reviews created by user today (for rate limiting).
    */
   async countUserReviewsToday(userId: string): Promise<number> {
-    try {
-      const todayStart = new Date();
-      todayStart.setHours(0, 0, 0, 0);
+    return withDbError(
+      'count user reviews today',
+      this.logger,
+      async () => {
+        const todayStart = new Date();
+        todayStart.setHours(0, 0, 0, 0);
 
-      const [row] = await this.db
-        .select({ count: sql<number>`count(*)` })
-        .from(schema.reviews)
-        .where(and(eq(schema.reviews.userId, userId), gte(schema.reviews.createdAt, todayStart)));
+        const [row] = await this.db
+          .select({ count: sql<number>`count(*)` })
+          .from(schema.reviews)
+          .where(and(eq(schema.reviews.userId, userId), gte(schema.reviews.createdAt, todayStart)));
 
-      return Number(row?.count ?? 0);
-    } catch (error) {
-      this.logger.error(`countUserReviewsToday failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to count user reviews today', { userId });
-    }
+        return Number(row?.count ?? 0);
+      },
+      { userId },
+    );
   }
 
   /**
@@ -272,55 +290,61 @@ export class DrizzleReviewRepository implements IReviewRepository {
     reviewId: string,
     counts: { likesCount: number; dislikesCount: number },
   ): Promise<void> {
-    try {
-      await this.db
-        .update(schema.reviews)
-        .set({
-          likesCount: counts.likesCount,
-          dislikesCount: counts.dislikesCount,
-          updatedAt: new Date(),
-        })
-        .where(eq(schema.reviews.id, reviewId));
-    } catch (error) {
-      this.logger.error(`updateVoteCounts failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to update vote counts', { reviewId });
-    }
+    return withDbError(
+      'update vote counts',
+      this.logger,
+      () =>
+        this.db
+          .update(schema.reviews)
+          .set({
+            likesCount: counts.likesCount,
+            dislikesCount: counts.dislikesCount,
+            updatedAt: new Date(),
+          })
+          .where(eq(schema.reviews.id, reviewId))
+          .then(() => undefined),
+      { reviewId },
+    );
   }
 
   /**
    * Increment replies count on a review.
    */
   async incrementRepliesCount(reviewId: string): Promise<void> {
-    try {
-      await this.db
-        .update(schema.reviews)
-        .set({
-          repliesCount: sql`${schema.reviews.repliesCount} + 1`,
-          updatedAt: new Date(),
-        })
-        .where(eq(schema.reviews.id, reviewId));
-    } catch (error) {
-      this.logger.error(`incrementRepliesCount failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to increment replies count', { reviewId });
-    }
+    return withDbError(
+      'increment replies count',
+      this.logger,
+      () =>
+        this.db
+          .update(schema.reviews)
+          .set({
+            repliesCount: sql`${schema.reviews.repliesCount} + 1`,
+            updatedAt: new Date(),
+          })
+          .where(eq(schema.reviews.id, reviewId))
+          .then(() => undefined),
+      { reviewId },
+    );
   }
 
   /**
    * Decrement replies count on a review.
    */
   async decrementRepliesCount(reviewId: string): Promise<void> {
-    try {
-      await this.db
-        .update(schema.reviews)
-        .set({
-          repliesCount: sql`GREATEST(${schema.reviews.repliesCount} - 1, 0)`,
-          updatedAt: new Date(),
-        })
-        .where(eq(schema.reviews.id, reviewId));
-    } catch (error) {
-      this.logger.error(`decrementRepliesCount failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to decrement replies count', { reviewId });
-    }
+    return withDbError(
+      'decrement replies count',
+      this.logger,
+      () =>
+        this.db
+          .update(schema.reviews)
+          .set({
+            repliesCount: sql`GREATEST(${schema.reviews.repliesCount} - 1, 0)`,
+            updatedAt: new Date(),
+          })
+          .where(eq(schema.reviews.id, reviewId))
+          .then(() => undefined),
+      { reviewId },
+    );
   }
 
   private getOrderBy(sort: ReviewSort) {

--- a/apps/api/src/modules/reviews/infrastructure/repositories/drizzle-review.repository.ts
+++ b/apps/api/src/modules/reviews/infrastructure/repositories/drizzle-review.repository.ts
@@ -72,7 +72,10 @@ export class DrizzleReviewRepository implements IReviewRepository {
           .from(schema.reviews)
           .innerJoin(schema.users, eq(schema.users.id, schema.reviews.userId))
           .where(and(...conditions))
-          .orderBy(orderBy)
+          .orderBy(
+            orderBy,
+            sort === REVIEW_SORT.OLDEST ? asc(schema.reviews.id) : desc(schema.reviews.id),
+          )
           .limit(limit)
           .offset(offset);
 

--- a/apps/api/src/modules/user-actions/infrastructure/repositories/drizzle-user-media-action.repository.ts
+++ b/apps/api/src/modules/user-actions/infrastructure/repositories/drizzle-user-media-action.repository.ts
@@ -4,7 +4,7 @@ import { and, desc, eq } from 'drizzle-orm';
 import { type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 
 import { DEFAULT_BATCH_SIZE } from '../../../../common/constants';
-import { DatabaseException } from '../../../../common/exceptions/database.exception';
+import { withDbError } from '../../../../common/utils/db-error.utils';
 import { DATABASE_CONNECTION } from '../../../../database/database.module';
 import * as schema from '../../../../database/schema';
 import { type UserMediaAction } from '../../domain/entities/user-media-action.entity';
@@ -32,27 +32,25 @@ export class DrizzleUserMediaActionRepository implements IUserMediaActionReposit
    * @returns {Promise<UserMediaAction>} Created action
    */
   async create(data: CreateUserMediaActionData): Promise<UserMediaAction> {
-    try {
-      const [row] = await this.db
-        .insert(schema.userMediaActions)
-        .values({
-          userId: data.userId,
-          mediaItemId: data.mediaItemId,
-          action: data.action,
-          context: data.context ?? null,
-          reasonKey: data.reasonKey ?? null,
-          payload: data.payload ?? null,
-        })
-        .returning();
-      return this.mapRow(row);
-    } catch (error) {
-      this.logger.error(`create failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to create user media action', {
-        userId: data.userId,
-        mediaItemId: data.mediaItemId,
-        action: data.action,
-      });
-    }
+    return withDbError(
+      'create user media action',
+      this.logger,
+      async () => {
+        const [row] = await this.db
+          .insert(schema.userMediaActions)
+          .values({
+            userId: data.userId,
+            mediaItemId: data.mediaItemId,
+            action: data.action,
+            context: data.context ?? null,
+            reasonKey: data.reasonKey ?? null,
+            payload: data.payload ?? null,
+          })
+          .returning();
+        return this.mapRow(row);
+      },
+      { userId: data.userId, mediaItemId: data.mediaItemId, action: data.action },
+    );
   }
 
   /**
@@ -68,19 +66,21 @@ export class DrizzleUserMediaActionRepository implements IUserMediaActionReposit
     limit = DEFAULT_BATCH_SIZE,
     offset = 0,
   ): Promise<UserMediaAction[]> {
-    try {
-      const rows = await this.db
-        .select()
-        .from(schema.userMediaActions)
-        .where(eq(schema.userMediaActions.userId, userId))
-        .orderBy(desc(schema.userMediaActions.createdAt))
-        .limit(limit)
-        .offset(offset);
-      return rows.map((r) => this.mapRow(r));
-    } catch (error) {
-      this.logger.error(`listByUser failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to list user media actions', { userId });
-    }
+    return withDbError(
+      'list user media actions',
+      this.logger,
+      async () => {
+        const rows = await this.db
+          .select()
+          .from(schema.userMediaActions)
+          .where(eq(schema.userMediaActions.userId, userId))
+          .orderBy(desc(schema.userMediaActions.createdAt))
+          .limit(limit)
+          .offset(offset);
+        return rows.map((r) => this.mapRow(r));
+      },
+      { userId },
+    );
   }
 
   /**
@@ -91,25 +91,24 @@ export class DrizzleUserMediaActionRepository implements IUserMediaActionReposit
    * @returns {Promise<UserMediaAction[]>} Actions
    */
   async listByUserAndMedia(userId: string, mediaItemId: string): Promise<UserMediaAction[]> {
-    try {
-      const rows = await this.db
-        .select()
-        .from(schema.userMediaActions)
-        .where(
-          and(
-            eq(schema.userMediaActions.userId, userId),
-            eq(schema.userMediaActions.mediaItemId, mediaItemId),
-          ),
-        )
-        .orderBy(desc(schema.userMediaActions.createdAt));
-      return rows.map((r) => this.mapRow(r));
-    } catch (error) {
-      this.logger.error(`listByUserAndMedia failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to list user media actions for media', {
-        userId,
-        mediaItemId,
-      });
-    }
+    return withDbError(
+      'list user media actions for media',
+      this.logger,
+      async () => {
+        const rows = await this.db
+          .select()
+          .from(schema.userMediaActions)
+          .where(
+            and(
+              eq(schema.userMediaActions.userId, userId),
+              eq(schema.userMediaActions.mediaItemId, mediaItemId),
+            ),
+          )
+          .orderBy(desc(schema.userMediaActions.createdAt));
+        return rows.map((r) => this.mapRow(r));
+      },
+      { userId, mediaItemId },
+    );
   }
 
   private mapRow(row: typeof schema.userMediaActions.$inferSelect): UserMediaAction {

--- a/apps/api/src/modules/user-actions/infrastructure/repositories/drizzle-user-media-action.repository.ts
+++ b/apps/api/src/modules/user-actions/infrastructure/repositories/drizzle-user-media-action.repository.ts
@@ -74,7 +74,7 @@ export class DrizzleUserMediaActionRepository implements IUserMediaActionReposit
           .select()
           .from(schema.userMediaActions)
           .where(eq(schema.userMediaActions.userId, userId))
-          .orderBy(desc(schema.userMediaActions.createdAt))
+          .orderBy(desc(schema.userMediaActions.createdAt), desc(schema.userMediaActions.id))
           .limit(limit)
           .offset(offset);
         return rows.map((r) => this.mapRow(r));

--- a/apps/api/src/modules/user-actions/infrastructure/repositories/drizzle-user-saved-item.repository.ts
+++ b/apps/api/src/modules/user-actions/infrastructure/repositories/drizzle-user-saved-item.repository.ts
@@ -6,8 +6,8 @@ import { type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { DEFAULT_PAGE_SIZE } from '@/common/constants';
 
 import { type MediaType } from '../../../../common/enums/media-type.enum';
-import { DatabaseException } from '../../../../common/exceptions/database.exception';
 import { ImageMapper } from '../../../../common/mappers/image.mapper';
+import { withDbError } from '../../../../common/utils/db-error.utils';
 import { DATABASE_CONNECTION } from '../../../../database/database.module';
 import * as schema from '../../../../database/schema';
 import {
@@ -39,36 +39,34 @@ export class DrizzleUserSavedItemRepository implements IUserSavedItemRepository 
    * @returns {Promise<UserSavedItem>} Persisted item
    */
   async upsert(data: UpsertSavedItemData): Promise<UserSavedItem> {
-    try {
-      const [row] = await this.db
-        .insert(schema.userSavedItems)
-        .values({
-          userId: data.userId,
-          mediaItemId: data.mediaItemId,
-          list: data.list,
-          reasonKey: data.reasonKey ?? null,
-        })
-        .onConflictDoUpdate({
-          target: [
-            schema.userSavedItems.userId,
-            schema.userSavedItems.mediaItemId,
-            schema.userSavedItems.list,
-          ],
-          set: {
-            updatedAt: new Date(),
+    return withDbError(
+      'upsert saved item',
+      this.logger,
+      async () => {
+        const [row] = await this.db
+          .insert(schema.userSavedItems)
+          .values({
+            userId: data.userId,
+            mediaItemId: data.mediaItemId,
+            list: data.list,
             reasonKey: data.reasonKey ?? null,
-          },
-        })
-        .returning();
-      return this.mapRow(row);
-    } catch (error) {
-      this.logger.error(`upsert failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to upsert saved item', {
-        userId: data.userId,
-        mediaItemId: data.mediaItemId,
-        list: data.list,
-      });
-    }
+          })
+          .onConflictDoUpdate({
+            target: [
+              schema.userSavedItems.userId,
+              schema.userSavedItems.mediaItemId,
+              schema.userSavedItems.list,
+            ],
+            set: {
+              updatedAt: new Date(),
+              reasonKey: data.reasonKey ?? null,
+            },
+          })
+          .returning();
+        return this.mapRow(row);
+      },
+      { userId: data.userId, mediaItemId: data.mediaItemId, list: data.list },
+    );
   }
 
   /**
@@ -80,22 +78,24 @@ export class DrizzleUserSavedItemRepository implements IUserSavedItemRepository 
    * @returns {Promise<boolean>} True if deleted
    */
   async remove(userId: string, mediaItemId: string, list: SavedItemList): Promise<boolean> {
-    try {
-      const result = await this.db
-        .delete(schema.userSavedItems)
-        .where(
-          and(
-            eq(schema.userSavedItems.userId, userId),
-            eq(schema.userSavedItems.mediaItemId, mediaItemId),
-            eq(schema.userSavedItems.list, list),
-          ),
-        )
-        .returning({ id: schema.userSavedItems.id });
-      return result.length > 0;
-    } catch (error) {
-      this.logger.error(`remove failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to remove saved item', { userId, mediaItemId, list });
-    }
+    return withDbError(
+      'remove saved item',
+      this.logger,
+      async () => {
+        const result = await this.db
+          .delete(schema.userSavedItems)
+          .where(
+            and(
+              eq(schema.userSavedItems.userId, userId),
+              eq(schema.userSavedItems.mediaItemId, mediaItemId),
+              eq(schema.userSavedItems.list, list),
+            ),
+          )
+          .returning({ id: schema.userSavedItems.id });
+        return result.length > 0;
+      },
+      { userId, mediaItemId, list },
+    );
   }
 
   /**
@@ -111,23 +111,25 @@ export class DrizzleUserSavedItemRepository implements IUserSavedItemRepository 
     mediaItemId: string,
     list: SavedItemList,
   ): Promise<UserSavedItem | null> {
-    try {
-      const [row] = await this.db
-        .select()
-        .from(schema.userSavedItems)
-        .where(
-          and(
-            eq(schema.userSavedItems.userId, userId),
-            eq(schema.userSavedItems.mediaItemId, mediaItemId),
-            eq(schema.userSavedItems.list, list),
-          ),
-        )
-        .limit(1);
-      return row ? this.mapRow(row) : null;
-    } catch (error) {
-      this.logger.error(`findOne failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to find saved item', { userId, mediaItemId, list });
-    }
+    return withDbError(
+      'find saved item',
+      this.logger,
+      async () => {
+        const [row] = await this.db
+          .select()
+          .from(schema.userSavedItems)
+          .where(
+            and(
+              eq(schema.userSavedItems.userId, userId),
+              eq(schema.userSavedItems.mediaItemId, mediaItemId),
+              eq(schema.userSavedItems.list, list),
+            ),
+          )
+          .limit(1);
+        return row ? this.mapRow(row) : null;
+      },
+      { userId, mediaItemId, list },
+    );
   }
 
   /**
@@ -138,21 +140,23 @@ export class DrizzleUserSavedItemRepository implements IUserSavedItemRepository 
    * @returns {Promise<SavedItemList[]>} Lists where item is saved
    */
   async findListsForMedia(userId: string, mediaItemId: string): Promise<SavedItemList[]> {
-    try {
-      const rows = await this.db
-        .select({ list: schema.userSavedItems.list })
-        .from(schema.userSavedItems)
-        .where(
-          and(
-            eq(schema.userSavedItems.userId, userId),
-            eq(schema.userSavedItems.mediaItemId, mediaItemId),
-          ),
-        );
-      return rows.map((r) => r.list as SavedItemList);
-    } catch (error) {
-      this.logger.error(`findListsForMedia failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to find lists for media', { userId, mediaItemId });
-    }
+    return withDbError(
+      'find lists for media',
+      this.logger,
+      async () => {
+        const rows = await this.db
+          .select({ list: schema.userSavedItems.list })
+          .from(schema.userSavedItems)
+          .where(
+            and(
+              eq(schema.userSavedItems.userId, userId),
+              eq(schema.userSavedItems.mediaItemId, mediaItemId),
+            ),
+          );
+        return rows.map((r) => r.list as SavedItemList);
+      },
+      { userId, mediaItemId },
+    );
   }
 
   /**
@@ -171,69 +175,71 @@ export class DrizzleUserSavedItemRepository implements IUserSavedItemRepository 
     offset = 0,
     type?: MediaType,
   ): Promise<SavedItemWithMedia[]> {
-    try {
-      // Subquery to aggregate active subscription triggers per media item
-      const subscriptionTriggersSubquery = this.db
-        .select({
-          mediaItemId: schema.userSubscriptions.mediaItemId,
-          triggers: sql<string[]>`array_agg(${schema.userSubscriptions.trigger})`.as('triggers'),
-        })
-        .from(schema.userSubscriptions)
-        .where(
-          and(
-            eq(schema.userSubscriptions.userId, userId),
-            eq(schema.userSubscriptions.isActive, true),
-          ),
-        )
-        .groupBy(schema.userSubscriptions.mediaItemId)
-        .as('sub_triggers');
+    return withDbError(
+      'list saved items with media',
+      this.logger,
+      async () => {
+        // Subquery to aggregate active subscription triggers per media item
+        const subscriptionTriggersSubquery = this.db
+          .select({
+            mediaItemId: schema.userSubscriptions.mediaItemId,
+            triggers: sql<string[]>`array_agg(${schema.userSubscriptions.trigger})`.as('triggers'),
+          })
+          .from(schema.userSubscriptions)
+          .where(
+            and(
+              eq(schema.userSubscriptions.userId, userId),
+              eq(schema.userSubscriptions.isActive, true),
+            ),
+          )
+          .groupBy(schema.userSubscriptions.mediaItemId)
+          .as('sub_triggers');
 
-      const rows = await this.db
-        .select({
-          item: schema.userSavedItems,
-          media: {
-            id: schema.mediaItems.id,
-            type: schema.mediaItems.type,
-            title: schema.mediaItems.title,
-            slug: schema.mediaItems.slug,
-            posterPath: schema.mediaItems.posterPath,
-            releaseDate: schema.mediaItems.releaseDate,
+        const rows = await this.db
+          .select({
+            item: schema.userSavedItems,
+            media: {
+              id: schema.mediaItems.id,
+              type: schema.mediaItems.type,
+              title: schema.mediaItems.title,
+              slug: schema.mediaItems.slug,
+              posterPath: schema.mediaItems.posterPath,
+              releaseDate: schema.mediaItems.releaseDate,
+            },
+            triggers: subscriptionTriggersSubquery.triggers,
+          })
+          .from(schema.userSavedItems)
+          .innerJoin(schema.mediaItems, eq(schema.mediaItems.id, schema.userSavedItems.mediaItemId))
+          .leftJoin(
+            subscriptionTriggersSubquery,
+            eq(subscriptionTriggersSubquery.mediaItemId, schema.userSavedItems.mediaItemId),
+          )
+          .where(
+            and(
+              eq(schema.userSavedItems.userId, userId),
+              eq(schema.userSavedItems.list, list),
+              ...(type ? [eq(schema.mediaItems.type, type)] : []),
+            ),
+          )
+          .orderBy(desc(schema.userSavedItems.createdAt))
+          .limit(limit)
+          .offset(offset);
+
+        return rows.map((r) => ({
+          ...this.mapRow(r.item),
+          mediaSummary: {
+            id: r.media.id,
+            type: r.media.type as MediaType,
+            title: r.media.title,
+            slug: r.media.slug,
+            poster: ImageMapper.toPoster(r.media.posterPath),
+            releaseDate: r.media.releaseDate,
           },
-          triggers: subscriptionTriggersSubquery.triggers,
-        })
-        .from(schema.userSavedItems)
-        .innerJoin(schema.mediaItems, eq(schema.mediaItems.id, schema.userSavedItems.mediaItemId))
-        .leftJoin(
-          subscriptionTriggersSubquery,
-          eq(subscriptionTriggersSubquery.mediaItemId, schema.userSavedItems.mediaItemId),
-        )
-        .where(
-          and(
-            eq(schema.userSavedItems.userId, userId),
-            eq(schema.userSavedItems.list, list),
-            ...(type ? [eq(schema.mediaItems.type, type)] : []),
-          ),
-        )
-        .orderBy(desc(schema.userSavedItems.createdAt))
-        .limit(limit)
-        .offset(offset);
-
-      return rows.map((r) => ({
-        ...this.mapRow(r.item),
-        mediaSummary: {
-          id: r.media.id,
-          type: r.media.type as MediaType,
-          title: r.media.title,
-          slug: r.media.slug,
-          poster: ImageMapper.toPoster(r.media.posterPath),
-          releaseDate: r.media.releaseDate,
-        },
-        activeSubscriptionTriggers: r.triggers ?? [],
-      }));
-    } catch (error) {
-      this.logger.error(`listWithMedia failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to list saved items with media', { userId, list });
-    }
+          activeSubscriptionTriggers: r.triggers ?? [],
+        }));
+      },
+      { userId, list },
+    );
   }
 
   /**
@@ -244,26 +250,28 @@ export class DrizzleUserSavedItemRepository implements IUserSavedItemRepository 
    * @returns {Promise<number>} Count
    */
   async count(userId: string, list: SavedItemList, type?: MediaType): Promise<number> {
-    try {
-      const whereParts = [
-        eq(schema.userSavedItems.userId, userId),
-        eq(schema.userSavedItems.list, list),
-      ];
+    return withDbError(
+      'count saved items',
+      this.logger,
+      async () => {
+        const whereParts = [
+          eq(schema.userSavedItems.userId, userId),
+          eq(schema.userSavedItems.list, list),
+        ];
 
-      if (type) {
-        whereParts.push(eq(schema.mediaItems.type, type));
-      }
+        if (type) {
+          whereParts.push(eq(schema.mediaItems.type, type));
+        }
 
-      const [row] = await this.db
-        .select({ count: sql<number>`count(*)` })
-        .from(schema.userSavedItems)
-        .innerJoin(schema.mediaItems, eq(schema.mediaItems.id, schema.userSavedItems.mediaItemId))
-        .where(and(...whereParts));
-      return Number(row?.count ?? 0);
-    } catch (error) {
-      this.logger.error(`count failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to count saved items', { userId, list });
-    }
+        const [row] = await this.db
+          .select({ count: sql<number>`count(*)` })
+          .from(schema.userSavedItems)
+          .innerJoin(schema.mediaItems, eq(schema.mediaItems.id, schema.userSavedItems.mediaItemId))
+          .where(and(...whereParts));
+        return Number(row?.count ?? 0);
+      },
+      { userId, list },
+    );
   }
 
   /**
@@ -281,37 +289,36 @@ export class DrizzleUserSavedItemRepository implements IUserSavedItemRepository 
       return new Map();
     }
 
-    try {
-      const rows = await this.db
-        .select({
-          mediaItemId: schema.userSavedItems.mediaItemId,
-          list: schema.userSavedItems.list,
-        })
-        .from(schema.userSavedItems)
-        .where(
-          and(
-            eq(schema.userSavedItems.userId, userId),
-            sql`${schema.userSavedItems.mediaItemId} = ANY(ARRAY[${sql.join(
-              mediaItemIds.map((id) => sql`${id}::uuid`),
-              sql`, `,
-            )}])`,
-          ),
-        );
+    return withDbError(
+      'get batch save status',
+      this.logger,
+      async () => {
+        const rows = await this.db
+          .select({
+            mediaItemId: schema.userSavedItems.mediaItemId,
+            list: schema.userSavedItems.list,
+          })
+          .from(schema.userSavedItems)
+          .where(
+            and(
+              eq(schema.userSavedItems.userId, userId),
+              sql`${schema.userSavedItems.mediaItemId} = ANY(ARRAY[${sql.join(
+                mediaItemIds.map((id) => sql`${id}::uuid`),
+                sql`, `,
+              )}])`,
+            ),
+          );
 
-      const result = new Map<string, SavedItemList[]>();
-      for (const row of rows) {
-        const lists = result.get(row.mediaItemId) ?? [];
-        lists.push(row.list as SavedItemList);
-        result.set(row.mediaItemId, lists);
-      }
-      return result;
-    } catch (error) {
-      this.logger.error(`findListsForMediaBatch failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to get batch save status', {
-        userId,
-        count: mediaItemIds.length,
-      });
-    }
+        const result = new Map<string, SavedItemList[]>();
+        for (const row of rows) {
+          const lists = result.get(row.mediaItemId) ?? [];
+          lists.push(row.list as SavedItemList);
+          result.set(row.mediaItemId, lists);
+        }
+        return result;
+      },
+      { userId, count: mediaItemIds.length },
+    );
   }
 
   private mapRow(row: typeof schema.userSavedItems.$inferSelect): UserSavedItem {

--- a/apps/api/src/modules/user-actions/infrastructure/repositories/drizzle-user-saved-item.repository.ts
+++ b/apps/api/src/modules/user-actions/infrastructure/repositories/drizzle-user-saved-item.repository.ts
@@ -221,7 +221,7 @@ export class DrizzleUserSavedItemRepository implements IUserSavedItemRepository 
               ...(type ? [eq(schema.mediaItems.type, type)] : []),
             ),
           )
-          .orderBy(desc(schema.userSavedItems.createdAt))
+          .orderBy(desc(schema.userSavedItems.createdAt), desc(schema.userSavedItems.id))
           .limit(limit)
           .offset(offset);
 

--- a/apps/api/src/modules/user-actions/infrastructure/repositories/drizzle-user-subscription.repository.ts
+++ b/apps/api/src/modules/user-actions/infrastructure/repositories/drizzle-user-subscription.repository.ts
@@ -7,8 +7,8 @@ import { DEFAULT_PAGE_SIZE } from '@/common/constants';
 
 import { MediaType } from '../../../../common/enums/media-type.enum';
 import { ShowStatus } from '../../../../common/enums/show-status.enum';
-import { DatabaseException } from '../../../../common/exceptions/database.exception';
 import { ImageMapper } from '../../../../common/mappers/image.mapper';
+import { withDbError } from '../../../../common/utils/db-error.utils';
 import { DATABASE_CONNECTION } from '../../../../database/database.module';
 import * as schema from '../../../../database/schema';
 import {
@@ -44,49 +44,47 @@ export class DrizzleUserSubscriptionRepository implements IUserSubscriptionRepos
    * @returns {Promise<UserSubscription>} Persisted subscription
    */
   async upsert(data: UpsertSubscriptionData): Promise<UserSubscription> {
-    try {
-      const [row] = await this.db
-        .insert(schema.userSubscriptions)
-        .values({
-          userId: data.userId,
-          mediaItemId: data.mediaItemId,
-          trigger: data.trigger,
-          channel: data.channel ?? 'push',
-          isActive: true,
-          // Initialize dedup markers to prevent immediate notifications
-          lastNotifiedSeasonNumber: data.lastNotifiedSeasonNumber ?? null,
-          lastNotifiedEpisodeKey: data.lastNotifiedEpisodeKey ?? null,
-        })
-        .onConflictDoUpdate({
-          target: [
-            schema.userSubscriptions.userId,
-            schema.userSubscriptions.mediaItemId,
-            schema.userSubscriptions.trigger,
-            schema.userSubscriptions.channel,
-          ],
-          set: {
+    return withDbError(
+      'upsert subscription',
+      this.logger,
+      async () => {
+        const [row] = await this.db
+          .insert(schema.userSubscriptions)
+          .values({
+            userId: data.userId,
+            mediaItemId: data.mediaItemId,
+            trigger: data.trigger,
+            channel: data.channel ?? 'push',
             isActive: true,
-            updatedAt: new Date(),
-            // Update markers only if reactivating (was inactive)
-            // This is handled by conditional update: only set if current isActive = false
-            ...(data.lastNotifiedSeasonNumber !== undefined && {
-              lastNotifiedSeasonNumber: sql`CASE WHEN ${schema.userSubscriptions.isActive} = false THEN ${data.lastNotifiedSeasonNumber} ELSE ${schema.userSubscriptions.lastNotifiedSeasonNumber} END`,
-            }),
-            ...(data.lastNotifiedEpisodeKey !== undefined && {
-              lastNotifiedEpisodeKey: sql`CASE WHEN ${schema.userSubscriptions.isActive} = false THEN ${data.lastNotifiedEpisodeKey} ELSE ${schema.userSubscriptions.lastNotifiedEpisodeKey} END`,
-            }),
-          },
-        })
-        .returning();
-      return this.mapRow(row);
-    } catch (error) {
-      this.logger.error(`upsert failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to upsert subscription', {
-        userId: data.userId,
-        mediaItemId: data.mediaItemId,
-        trigger: data.trigger,
-      });
-    }
+            // Initialize dedup markers to prevent immediate notifications
+            lastNotifiedSeasonNumber: data.lastNotifiedSeasonNumber ?? null,
+            lastNotifiedEpisodeKey: data.lastNotifiedEpisodeKey ?? null,
+          })
+          .onConflictDoUpdate({
+            target: [
+              schema.userSubscriptions.userId,
+              schema.userSubscriptions.mediaItemId,
+              schema.userSubscriptions.trigger,
+              schema.userSubscriptions.channel,
+            ],
+            set: {
+              isActive: true,
+              updatedAt: new Date(),
+              // Update markers only if reactivating (was inactive)
+              // This is handled by conditional update: only set if current isActive = false
+              ...(data.lastNotifiedSeasonNumber !== undefined && {
+                lastNotifiedSeasonNumber: sql`CASE WHEN ${schema.userSubscriptions.isActive} = false THEN ${data.lastNotifiedSeasonNumber} ELSE ${schema.userSubscriptions.lastNotifiedSeasonNumber} END`,
+              }),
+              ...(data.lastNotifiedEpisodeKey !== undefined && {
+                lastNotifiedEpisodeKey: sql`CASE WHEN ${schema.userSubscriptions.isActive} = false THEN ${data.lastNotifiedEpisodeKey} ELSE ${schema.userSubscriptions.lastNotifiedEpisodeKey} END`,
+              }),
+            },
+          })
+          .returning();
+        return this.mapRow(row);
+      },
+      { userId: data.userId, mediaItemId: data.mediaItemId, trigger: data.trigger },
+    );
   }
 
   /**
@@ -102,27 +100,25 @@ export class DrizzleUserSubscriptionRepository implements IUserSubscriptionRepos
     mediaItemId: string,
     trigger: SubscriptionTrigger,
   ): Promise<boolean> {
-    try {
-      const result = await this.db
-        .update(schema.userSubscriptions)
-        .set({ isActive: false, updatedAt: new Date() })
-        .where(
-          and(
-            eq(schema.userSubscriptions.userId, userId),
-            eq(schema.userSubscriptions.mediaItemId, mediaItemId),
-            eq(schema.userSubscriptions.trigger, trigger),
-          ),
-        )
-        .returning({ id: schema.userSubscriptions.id });
-      return result.length > 0;
-    } catch (error) {
-      this.logger.error(`deactivate failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to deactivate subscription', {
-        userId,
-        mediaItemId,
-        trigger,
-      });
-    }
+    return withDbError(
+      'deactivate subscription',
+      this.logger,
+      async () => {
+        const result = await this.db
+          .update(schema.userSubscriptions)
+          .set({ isActive: false, updatedAt: new Date() })
+          .where(
+            and(
+              eq(schema.userSubscriptions.userId, userId),
+              eq(schema.userSubscriptions.mediaItemId, mediaItemId),
+              eq(schema.userSubscriptions.trigger, trigger),
+            ),
+          )
+          .returning({ id: schema.userSubscriptions.id });
+        return result.length > 0;
+      },
+      { userId, mediaItemId, trigger },
+    );
   }
 
   /**
@@ -138,24 +134,26 @@ export class DrizzleUserSubscriptionRepository implements IUserSubscriptionRepos
     mediaItemId: string,
     trigger: SubscriptionTrigger,
   ): Promise<UserSubscription | null> {
-    try {
-      const [row] = await this.db
-        .select()
-        .from(schema.userSubscriptions)
-        .where(
-          and(
-            eq(schema.userSubscriptions.userId, userId),
-            eq(schema.userSubscriptions.mediaItemId, mediaItemId),
-            eq(schema.userSubscriptions.trigger, trigger),
-            eq(schema.userSubscriptions.isActive, true),
-          ),
-        )
-        .limit(1);
-      return row ? this.mapRow(row) : null;
-    } catch (error) {
-      this.logger.error(`findOne failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to find subscription', { userId, mediaItemId, trigger });
-    }
+    return withDbError(
+      'find subscription',
+      this.logger,
+      async () => {
+        const [row] = await this.db
+          .select()
+          .from(schema.userSubscriptions)
+          .where(
+            and(
+              eq(schema.userSubscriptions.userId, userId),
+              eq(schema.userSubscriptions.mediaItemId, mediaItemId),
+              eq(schema.userSubscriptions.trigger, trigger),
+              eq(schema.userSubscriptions.isActive, true),
+            ),
+          )
+          .limit(1);
+        return row ? this.mapRow(row) : null;
+      },
+      { userId, mediaItemId, trigger },
+    );
   }
 
   /**
@@ -169,25 +167,24 @@ export class DrizzleUserSubscriptionRepository implements IUserSubscriptionRepos
     userId: string,
     mediaItemId: string,
   ): Promise<SubscriptionTrigger[]> {
-    try {
-      const rows = await this.db
-        .select({ trigger: schema.userSubscriptions.trigger })
-        .from(schema.userSubscriptions)
-        .where(
-          and(
-            eq(schema.userSubscriptions.userId, userId),
-            eq(schema.userSubscriptions.mediaItemId, mediaItemId),
-            eq(schema.userSubscriptions.isActive, true),
-          ),
-        );
-      return rows.map((r) => r.trigger as SubscriptionTrigger);
-    } catch (error) {
-      this.logger.error(`findActiveTriggersForMedia failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to find active triggers for media', {
-        userId,
-        mediaItemId,
-      });
-    }
+    return withDbError(
+      'find active triggers for media',
+      this.logger,
+      async () => {
+        const rows = await this.db
+          .select({ trigger: schema.userSubscriptions.trigger })
+          .from(schema.userSubscriptions)
+          .where(
+            and(
+              eq(schema.userSubscriptions.userId, userId),
+              eq(schema.userSubscriptions.mediaItemId, mediaItemId),
+              eq(schema.userSubscriptions.isActive, true),
+            ),
+          );
+        return rows.map((r) => r.trigger as SubscriptionTrigger);
+      },
+      { userId, mediaItemId },
+    );
   }
 
   /**
@@ -203,49 +200,51 @@ export class DrizzleUserSubscriptionRepository implements IUserSubscriptionRepos
     limit = DEFAULT_PAGE_SIZE,
     offset = 0,
   ): Promise<SubscriptionWithMedia[]> {
-    try {
-      const rows = await this.db
-        .select({
-          sub: schema.userSubscriptions,
-          media: {
-            id: schema.mediaItems.id,
-            type: schema.mediaItems.type,
-            title: schema.mediaItems.title,
-            slug: schema.mediaItems.slug,
-            posterPath: schema.mediaItems.posterPath,
-            releaseDate: schema.mediaItems.releaseDate,
-          },
-        })
-        .from(schema.userSubscriptions)
-        .innerJoin(
-          schema.mediaItems,
-          eq(schema.mediaItems.id, schema.userSubscriptions.mediaItemId),
-        )
-        .where(
-          and(
-            eq(schema.userSubscriptions.userId, userId),
-            eq(schema.userSubscriptions.isActive, true),
-          ),
-        )
-        .orderBy(desc(schema.userSubscriptions.createdAt))
-        .limit(limit)
-        .offset(offset);
+    return withDbError(
+      'list active subscriptions with media',
+      this.logger,
+      async () => {
+        const rows = await this.db
+          .select({
+            sub: schema.userSubscriptions,
+            media: {
+              id: schema.mediaItems.id,
+              type: schema.mediaItems.type,
+              title: schema.mediaItems.title,
+              slug: schema.mediaItems.slug,
+              posterPath: schema.mediaItems.posterPath,
+              releaseDate: schema.mediaItems.releaseDate,
+            },
+          })
+          .from(schema.userSubscriptions)
+          .innerJoin(
+            schema.mediaItems,
+            eq(schema.mediaItems.id, schema.userSubscriptions.mediaItemId),
+          )
+          .where(
+            and(
+              eq(schema.userSubscriptions.userId, userId),
+              eq(schema.userSubscriptions.isActive, true),
+            ),
+          )
+          .orderBy(desc(schema.userSubscriptions.createdAt))
+          .limit(limit)
+          .offset(offset);
 
-      return rows.map((r) => ({
-        ...this.mapRow(r.sub),
-        mediaSummary: {
-          id: r.media.id,
-          type: r.media.type as MediaType,
-          title: r.media.title,
-          slug: r.media.slug,
-          poster: ImageMapper.toPoster(r.media.posterPath),
-          releaseDate: r.media.releaseDate,
-        },
-      }));
-    } catch (error) {
-      this.logger.error(`listActiveWithMedia failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to list active subscriptions with media', { userId });
-    }
+        return rows.map((r) => ({
+          ...this.mapRow(r.sub),
+          mediaSummary: {
+            id: r.media.id,
+            type: r.media.type as MediaType,
+            title: r.media.title,
+            slug: r.media.slug,
+            poster: ImageMapper.toPoster(r.media.posterPath),
+            releaseDate: r.media.releaseDate,
+          },
+        }));
+      },
+      { userId },
+    );
   }
 
   /**
@@ -255,21 +254,23 @@ export class DrizzleUserSubscriptionRepository implements IUserSubscriptionRepos
    * @returns {Promise<number>} Count
    */
   async countActive(userId: string): Promise<number> {
-    try {
-      const [row] = await this.db
-        .select({ count: sql<number>`count(*)` })
-        .from(schema.userSubscriptions)
-        .where(
-          and(
-            eq(schema.userSubscriptions.userId, userId),
-            eq(schema.userSubscriptions.isActive, true),
-          ),
-        );
-      return Number(row?.count ?? 0);
-    } catch (error) {
-      this.logger.error(`countActive failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to count active subscriptions', { userId });
-    }
+    return withDbError(
+      'count active subscriptions',
+      this.logger,
+      async () => {
+        const [row] = await this.db
+          .select({ count: sql<number>`count(*)` })
+          .from(schema.userSubscriptions)
+          .where(
+            and(
+              eq(schema.userSubscriptions.userId, userId),
+              eq(schema.userSubscriptions.isActive, true),
+            ),
+          );
+        return Number(row?.count ?? 0);
+      },
+      { userId },
+    );
   }
 
   /**
@@ -279,15 +280,17 @@ export class DrizzleUserSubscriptionRepository implements IUserSubscriptionRepos
    * @returns {Promise<void>}
    */
   async markNotified(subscriptionId: string): Promise<void> {
-    try {
-      await this.db
-        .update(schema.userSubscriptions)
-        .set({ lastNotifiedAt: new Date(), updatedAt: new Date() })
-        .where(eq(schema.userSubscriptions.id, subscriptionId));
-    } catch (error) {
-      this.logger.error(`markNotified failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to mark subscription as notified', { subscriptionId });
-    }
+    return withDbError(
+      'mark subscription as notified',
+      this.logger,
+      () =>
+        this.db
+          .update(schema.userSubscriptions)
+          .set({ lastNotifiedAt: new Date(), updatedAt: new Date() })
+          .where(eq(schema.userSubscriptions.id, subscriptionId))
+          .then(() => undefined),
+      { subscriptionId },
+    );
   }
 
   /**
@@ -297,7 +300,7 @@ export class DrizzleUserSubscriptionRepository implements IUserSubscriptionRepos
    * @returns {Promise<number[]>} Array of TMDB IDs
    */
   async findTrackedShowTmdbIds(): Promise<number[]> {
-    try {
+    return withDbError('find tracked show TMDB IDs', this.logger, async () => {
       const rows = await this.db
         .selectDistinct({ tmdbId: schema.mediaItems.tmdbId })
         .from(schema.userSubscriptions)
@@ -325,106 +328,105 @@ export class DrizzleUserSubscriptionRepository implements IUserSubscriptionRepos
         .orderBy(schema.mediaItems.tmdbId);
 
       return rows.map((r) => r.tmdbId).filter((id): id is number => id !== null);
-    } catch (error) {
-      this.logger.error(`findTrackedShowTmdbIds failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to find tracked show TMDB IDs');
-    }
+    });
   }
 
   async atomicNotifyNewEpisode(
     mediaItemId: string,
     episodeKey: string,
   ): Promise<NotifiedSubscription[]> {
-    try {
-      return await this.db
-        .update(schema.userSubscriptions)
-        .set({
-          lastNotifiedEpisodeKey: episodeKey,
-          lastNotifiedAt: new Date(),
-          updatedAt: new Date(),
-        })
-        .where(
-          and(
-            eq(schema.userSubscriptions.mediaItemId, mediaItemId),
-            eq(schema.userSubscriptions.trigger, SUBSCRIPTION_TRIGGER.NEW_EPISODE),
-            eq(schema.userSubscriptions.isActive, true),
-            or(
-              isNull(schema.userSubscriptions.lastNotifiedEpisodeKey),
-              ne(schema.userSubscriptions.lastNotifiedEpisodeKey, episodeKey),
+    return withDbError(
+      'atomically notify new episode',
+      this.logger,
+      () =>
+        this.db
+          .update(schema.userSubscriptions)
+          .set({
+            lastNotifiedEpisodeKey: episodeKey,
+            lastNotifiedAt: new Date(),
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(schema.userSubscriptions.mediaItemId, mediaItemId),
+              eq(schema.userSubscriptions.trigger, SUBSCRIPTION_TRIGGER.NEW_EPISODE),
+              eq(schema.userSubscriptions.isActive, true),
+              or(
+                isNull(schema.userSubscriptions.lastNotifiedEpisodeKey),
+                ne(schema.userSubscriptions.lastNotifiedEpisodeKey, episodeKey),
+              ),
             ),
-          ),
-        )
-        .returning({
-          id: schema.userSubscriptions.id,
-          userId: schema.userSubscriptions.userId,
-          mediaItemId: schema.userSubscriptions.mediaItemId,
-        });
-    } catch (error) {
-      this.logger.error(`atomicNotifyNewEpisode failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to atomically notify new episode', { mediaItemId });
-    }
+          )
+          .returning({
+            id: schema.userSubscriptions.id,
+            userId: schema.userSubscriptions.userId,
+            mediaItemId: schema.userSubscriptions.mediaItemId,
+          }),
+      { mediaItemId, episodeKey },
+    );
   }
 
   async atomicNotifyNewSeason(
     mediaItemId: string,
     seasonNumber: number,
   ): Promise<NotifiedSubscription[]> {
-    try {
-      return await this.db
-        .update(schema.userSubscriptions)
-        .set({
-          lastNotifiedSeasonNumber: seasonNumber,
-          lastNotifiedAt: new Date(),
-          updatedAt: new Date(),
-        })
-        .where(
-          and(
-            eq(schema.userSubscriptions.mediaItemId, mediaItemId),
-            eq(schema.userSubscriptions.trigger, SUBSCRIPTION_TRIGGER.NEW_SEASON),
-            eq(schema.userSubscriptions.isActive, true),
-            or(
-              isNull(schema.userSubscriptions.lastNotifiedSeasonNumber),
-              lt(schema.userSubscriptions.lastNotifiedSeasonNumber, seasonNumber),
+    return withDbError(
+      'atomically notify new season',
+      this.logger,
+      () =>
+        this.db
+          .update(schema.userSubscriptions)
+          .set({
+            lastNotifiedSeasonNumber: seasonNumber,
+            lastNotifiedAt: new Date(),
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(schema.userSubscriptions.mediaItemId, mediaItemId),
+              eq(schema.userSubscriptions.trigger, SUBSCRIPTION_TRIGGER.NEW_SEASON),
+              eq(schema.userSubscriptions.isActive, true),
+              or(
+                isNull(schema.userSubscriptions.lastNotifiedSeasonNumber),
+                lt(schema.userSubscriptions.lastNotifiedSeasonNumber, seasonNumber),
+              ),
             ),
-          ),
-        )
-        .returning({
-          id: schema.userSubscriptions.id,
-          userId: schema.userSubscriptions.userId,
-          mediaItemId: schema.userSubscriptions.mediaItemId,
-        });
-    } catch (error) {
-      this.logger.error(`atomicNotifyNewSeason failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to atomically notify new season', { mediaItemId });
-    }
+          )
+          .returning({
+            id: schema.userSubscriptions.id,
+            userId: schema.userSubscriptions.userId,
+            mediaItemId: schema.userSubscriptions.mediaItemId,
+          }),
+      { mediaItemId, seasonNumber },
+    );
   }
 
   async deactivateForEndedShow(mediaItemId: string): Promise<number> {
-    try {
-      const result = await this.db
-        .update(schema.userSubscriptions)
-        .set({
-          isActive: false,
-          updatedAt: new Date(),
-        })
-        .where(
-          and(
-            eq(schema.userSubscriptions.mediaItemId, mediaItemId),
-            eq(schema.userSubscriptions.isActive, true),
-            inArray(schema.userSubscriptions.trigger, [
-              SUBSCRIPTION_TRIGGER.NEW_SEASON,
-              SUBSCRIPTION_TRIGGER.NEW_EPISODE,
-            ]),
-          ),
-        )
-        .returning({ id: schema.userSubscriptions.id });
-      return result.length;
-    } catch (error) {
-      this.logger.error(`deactivateForEndedShow failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to deactivate subscriptions for ended show', {
-        mediaItemId,
-      });
-    }
+    return withDbError(
+      'deactivate subscriptions for ended show',
+      this.logger,
+      async () => {
+        const result = await this.db
+          .update(schema.userSubscriptions)
+          .set({
+            isActive: false,
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(schema.userSubscriptions.mediaItemId, mediaItemId),
+              eq(schema.userSubscriptions.isActive, true),
+              inArray(schema.userSubscriptions.trigger, [
+                SUBSCRIPTION_TRIGGER.NEW_SEASON,
+                SUBSCRIPTION_TRIGGER.NEW_EPISODE,
+              ]),
+            ),
+          )
+          .returning({ id: schema.userSubscriptions.id });
+        return result.length;
+      },
+      { mediaItemId },
+    );
   }
 
   private mapRow(row: typeof schema.userSubscriptions.$inferSelect): UserSubscription {

--- a/apps/api/src/modules/user-actions/infrastructure/repositories/drizzle-user-subscription.repository.ts
+++ b/apps/api/src/modules/user-actions/infrastructure/repositories/drizzle-user-subscription.repository.ts
@@ -227,7 +227,7 @@ export class DrizzleUserSubscriptionRepository implements IUserSubscriptionRepos
               eq(schema.userSubscriptions.isActive, true),
             ),
           )
-          .orderBy(desc(schema.userSubscriptions.createdAt))
+          .orderBy(desc(schema.userSubscriptions.createdAt), desc(schema.userSubscriptions.id))
           .limit(limit)
           .offset(offset);
 

--- a/apps/api/src/modules/user-media/infrastructure/repositories/drizzle-episode-progress.repository.ts
+++ b/apps/api/src/modules/user-media/infrastructure/repositories/drizzle-episode-progress.repository.ts
@@ -3,7 +3,7 @@ import { Inject, Injectable, Logger } from '@nestjs/common';
 import { and, eq, inArray, lte, sql } from 'drizzle-orm';
 import { type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 
-import { DatabaseException } from '../../../../common/exceptions/database.exception';
+import { withDbError } from '../../../../common/utils/db-error.utils';
 import { DATABASE_CONNECTION } from '../../../../database/database.module';
 import * as schema from '../../../../database/schema';
 import {
@@ -23,208 +23,205 @@ export class DrizzleEpisodeProgressRepository implements IEpisodeProgressReposit
   ) {}
 
   async markWatched(userId: string, episodeId: string): Promise<void> {
-    try {
-      await this.db
-        .insert(schema.userEpisodeProgress)
-        .values({
-          userId,
-          episodeId,
-          watchedAt: new Date(),
-        })
-        .onConflictDoNothing();
-    } catch (error) {
-      this.logger.error(`markWatched failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to mark episode as watched', {
-        userId,
-        episodeId,
-      });
-    }
+    return withDbError(
+      'mark episode as watched',
+      this.logger,
+      () =>
+        this.db
+          .insert(schema.userEpisodeProgress)
+          .values({
+            userId,
+            episodeId,
+            watchedAt: new Date(),
+          })
+          .onConflictDoNothing()
+          .then(() => undefined),
+      { userId, episodeId },
+    );
   }
 
   async markUnwatched(userId: string, episodeId: string): Promise<void> {
-    try {
-      await this.db
-        .delete(schema.userEpisodeProgress)
-        .where(
-          and(
-            eq(schema.userEpisodeProgress.userId, userId),
-            eq(schema.userEpisodeProgress.episodeId, episodeId),
-          ),
-        );
-    } catch (error) {
-      this.logger.error(`markUnwatched failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to mark episode as unwatched', {
-        userId,
-        episodeId,
-      });
-    }
+    return withDbError(
+      'mark episode as unwatched',
+      this.logger,
+      () =>
+        this.db
+          .delete(schema.userEpisodeProgress)
+          .where(
+            and(
+              eq(schema.userEpisodeProgress.userId, userId),
+              eq(schema.userEpisodeProgress.episodeId, episodeId),
+            ),
+          )
+          .then(() => undefined),
+      { userId, episodeId },
+    );
   }
 
   async markManyWatched(userId: string, episodeIds: string[]): Promise<void> {
     if (episodeIds.length === 0) return;
-    try {
-      await this.db
-        .insert(schema.userEpisodeProgress)
-        .values(
-          episodeIds.map((episodeId) => ({
-            userId,
-            episodeId,
-            watchedAt: new Date(),
-          })),
-        )
-        .onConflictDoNothing();
-    } catch (error) {
-      this.logger.error(`markManyWatched failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to mark episodes as watched', {
-        userId,
-        count: episodeIds.length,
-      });
-    }
+    return withDbError(
+      'mark episodes as watched',
+      this.logger,
+      () =>
+        this.db
+          .insert(schema.userEpisodeProgress)
+          .values(
+            episodeIds.map((episodeId) => ({
+              userId,
+              episodeId,
+              watchedAt: new Date(),
+            })),
+          )
+          .onConflictDoNothing()
+          .then(() => undefined),
+      { userId, count: episodeIds.length },
+    );
   }
 
   async markManyUnwatched(userId: string, episodeIds: string[]): Promise<void> {
     if (episodeIds.length === 0) return;
-    try {
-      await this.db
-        .delete(schema.userEpisodeProgress)
-        .where(
-          and(
-            eq(schema.userEpisodeProgress.userId, userId),
-            inArray(schema.userEpisodeProgress.episodeId, episodeIds),
-          ),
-        );
-    } catch (error) {
-      this.logger.error(`markManyUnwatched failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to mark episodes as unwatched', {
-        userId,
-        count: episodeIds.length,
-      });
-    }
+    return withDbError(
+      'mark episodes as unwatched',
+      this.logger,
+      () =>
+        this.db
+          .delete(schema.userEpisodeProgress)
+          .where(
+            and(
+              eq(schema.userEpisodeProgress.userId, userId),
+              inArray(schema.userEpisodeProgress.episodeId, episodeIds),
+            ),
+          )
+          .then(() => undefined),
+      { userId, count: episodeIds.length },
+    );
   }
 
   async getWatchedEpisodeIds(userId: string, showId: string): Promise<string[]> {
-    try {
-      const rows = await this.db
-        .select({
-          episodeId: schema.userEpisodeProgress.episodeId,
-        })
-        .from(schema.userEpisodeProgress)
-        .innerJoin(schema.episodes, eq(schema.userEpisodeProgress.episodeId, schema.episodes.id))
-        .where(
-          and(eq(schema.userEpisodeProgress.userId, userId), eq(schema.episodes.showId, showId)),
-        );
+    return withDbError(
+      'get watched episode IDs',
+      this.logger,
+      async () => {
+        const rows = await this.db
+          .select({
+            episodeId: schema.userEpisodeProgress.episodeId,
+          })
+          .from(schema.userEpisodeProgress)
+          .innerJoin(schema.episodes, eq(schema.userEpisodeProgress.episodeId, schema.episodes.id))
+          .where(
+            and(eq(schema.userEpisodeProgress.userId, userId), eq(schema.episodes.showId, showId)),
+          );
 
-      return rows.map((r) => r.episodeId);
-    } catch (error) {
-      this.logger.error(`getWatchedEpisodeIds failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to get watched episode IDs', {
-        userId,
-        showId,
-      });
-    }
+        return rows.map((r) => r.episodeId);
+      },
+      { userId, showId },
+    );
   }
 
   async getShowProgress(userId: string, showId: string): Promise<SeasonProgressInfo[]> {
-    try {
-      // Single query: all episodes with watched flag via correlated subquery
-      const rows = await this.db
-        .select({
-          seasonNumber: schema.seasons.number,
-          episodeId: schema.episodes.id,
-          isWatched: sql<boolean>`
+    return withDbError(
+      'get show progress',
+      this.logger,
+      async () => {
+        // Single query: all episodes with watched flag via correlated subquery
+        const rows = await this.db
+          .select({
+            seasonNumber: schema.seasons.number,
+            episodeId: schema.episodes.id,
+            isWatched: sql<boolean>`
             EXISTS (
               SELECT 1 FROM ${schema.userEpisodeProgress}
               WHERE ${schema.userEpisodeProgress.episodeId} = ${schema.episodes.id}
               AND ${schema.userEpisodeProgress.userId} = ${userId}
             )
           `.as('is_watched'),
-        })
-        .from(schema.seasons)
-        .innerJoin(schema.episodes, eq(schema.episodes.seasonId, schema.seasons.id))
-        .where(and(eq(schema.seasons.showId, showId), lte(schema.episodes.airDate, new Date())))
-        .orderBy(schema.seasons.number, schema.episodes.number);
+          })
+          .from(schema.seasons)
+          .innerJoin(schema.episodes, eq(schema.episodes.seasonId, schema.seasons.id))
+          .where(and(eq(schema.seasons.showId, showId), lte(schema.episodes.airDate, new Date())))
+          .orderBy(schema.seasons.number, schema.episodes.number);
 
-      const seasonMap = new Map<number, { total: number; watched: number; watchedIds: string[] }>();
+        const seasonMap = new Map<
+          number,
+          { total: number; watched: number; watchedIds: string[] }
+        >();
 
-      for (const row of rows) {
-        const existing = seasonMap.get(row.seasonNumber) || {
-          total: 0,
-          watched: 0,
-          watchedIds: [],
-        };
-        existing.total++;
-        if (row.isWatched) {
-          existing.watched++;
-          existing.watchedIds.push(row.episodeId);
+        for (const row of rows) {
+          const existing = seasonMap.get(row.seasonNumber) || {
+            total: 0,
+            watched: 0,
+            watchedIds: [],
+          };
+          existing.total++;
+          if (row.isWatched) {
+            existing.watched++;
+            existing.watchedIds.push(row.episodeId);
+          }
+          seasonMap.set(row.seasonNumber, existing);
         }
-        seasonMap.set(row.seasonNumber, existing);
-      }
 
-      const result: SeasonProgressInfo[] = [];
-      for (const [seasonNumber, data] of seasonMap) {
-        result.push({
-          seasonNumber,
-          watchedCount: data.watched,
-          totalCount: data.total,
-          watchedEpisodeIds: data.watchedIds,
-        });
-      }
+        const result: SeasonProgressInfo[] = [];
+        for (const [seasonNumber, data] of seasonMap) {
+          result.push({
+            seasonNumber,
+            watchedCount: data.watched,
+            totalCount: data.total,
+            watchedEpisodeIds: data.watchedIds,
+          });
+        }
 
-      return result.sort((a, b) => a.seasonNumber - b.seasonNumber);
-    } catch (error) {
-      this.logger.error(`getShowProgress failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to get show progress', {
-        userId,
-        showId,
-      });
-    }
+        return result.sort((a, b) => a.seasonNumber - b.seasonNumber);
+      },
+      { userId, showId },
+    );
   }
 
   async validateEpisodeBatch(episodeIds: string[]): Promise<EpisodeBatchValidation> {
     if (episodeIds.length === 0) return { existingCount: 0, distinctShowCount: 0 };
-    try {
-      const [row] = await this.db
-        .select({
-          existingCount: sql<number>`count(*)`,
-          distinctShowCount: sql<number>`count(distinct ${schema.episodes.showId})`,
-        })
-        .from(schema.episodes)
-        .where(inArray(schema.episodes.id, episodeIds));
+    return withDbError(
+      'validate episode batch',
+      this.logger,
+      async () => {
+        const [row] = await this.db
+          .select({
+            existingCount: sql<number>`count(*)`,
+            distinctShowCount: sql<number>`count(distinct ${schema.episodes.showId})`,
+          })
+          .from(schema.episodes)
+          .where(inArray(schema.episodes.id, episodeIds));
 
-      return {
-        existingCount: Number(row?.existingCount ?? 0),
-        distinctShowCount: Number(row?.distinctShowCount ?? 0),
-      };
-    } catch (error) {
-      this.logger.error(`validateEpisodeBatch failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to validate episode batch', {
-        count: episodeIds.length,
-      });
-    }
+        return {
+          existingCount: Number(row?.existingCount ?? 0),
+          distinctShowCount: Number(row?.distinctShowCount ?? 0),
+        };
+      },
+      { count: episodeIds.length },
+    );
   }
 
   async getEpisodeMediaInfo(episodeId: string): Promise<EpisodeMediaInfo | null> {
-    try {
-      const rows = await this.db
-        .select({
-          episodeId: schema.episodes.id,
-          showId: schema.episodes.showId,
-          mediaItemId: schema.shows.mediaItemId,
-          seasonNumber: schema.seasons.number,
-          episodeNumber: schema.episodes.number,
-        })
-        .from(schema.episodes)
-        .innerJoin(schema.seasons, eq(schema.episodes.seasonId, schema.seasons.id))
-        .innerJoin(schema.shows, eq(schema.episodes.showId, schema.shows.id))
-        .where(eq(schema.episodes.id, episodeId))
-        .limit(1);
+    return withDbError(
+      'get episode media info',
+      this.logger,
+      async () => {
+        const rows = await this.db
+          .select({
+            episodeId: schema.episodes.id,
+            showId: schema.episodes.showId,
+            mediaItemId: schema.shows.mediaItemId,
+            seasonNumber: schema.seasons.number,
+            episodeNumber: schema.episodes.number,
+          })
+          .from(schema.episodes)
+          .innerJoin(schema.seasons, eq(schema.episodes.seasonId, schema.seasons.id))
+          .innerJoin(schema.shows, eq(schema.episodes.showId, schema.shows.id))
+          .where(eq(schema.episodes.id, episodeId))
+          .limit(1);
 
-      return rows[0] ?? null;
-    } catch (error) {
-      this.logger.error(`getEpisodeMediaInfo failed: ${error.message}`, error.stack);
-      throw new DatabaseException('Failed to get episode media info', {
-        episodeId,
-      });
-    }
+        return rows[0] ?? null;
+      },
+      { episodeId },
+    );
   }
 }


### PR DESCRIPTION
## Summary

- **2.1** `admin-catalog` `.where()` overwrite fixed — `eligibilityStatus` filter moved into the shared `conditions` array so soft-deleted records no longer leak through (CRITICAL)
- **2.2** `withDbError` gets `instanceof AppException` guard — prevents `NotFoundException`/`ForbiddenException` being swallowed as 500; 20+ repositories migrated to use it
- **2.3** Review-vote race condition fixed — `upsertAndRecount`/`removeAndRecount` are transactional repository methods; `likesCount`/`dislikesCount` updated atomically inside the same tx
- **2.4** `findByMediaId` orders by `policyVersion DESC LIMIT 1` — always returns the latest evaluation
- **2.5** Admin-catalog LEFT JOINs deduplicated with active-policy filter
- **2.6** `upsertManyByRegions` wrapped in a single transaction
- **2.7** Stable `ORDER BY … id` tiebreaker added to paginated queries
- **2.8** `BreakoutRule` sorting moved to policy-load time (once), not per-evaluation

## Test plan

- [ ] `npm run test:api` — 281 suites green
- [ ] `GET /admin/catalog?eligibilityStatus=excluded` returns no soft-deleted rows
- [ ] 100 concurrent votes on same review → `likesCount` exact
- [ ] Two consecutive pages return no duplicate items

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Зміни релізу

* **Bug Fixes**
  * Стабілізовано порядок результатів у пошуку та трендових розділах
  * Забезпечено атомарність операцій підрахунку голосів у рецензіях

* **Improvements**
  * Покращена надійність обробки помилок баз даних
  * Оптимізовано обробку запитів до бази даних для забезпечення консистентності

* **Documentation**
  * Додана документація для міграцій баз даних

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eurusik/ratingo/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->