### PR TITLE
fix(user-media): rating update no longer reorders list, new ratings appear immediately (#107)

### DIFF
--- a/apps/api/src/modules/user-media/infrastructure/repositories/drizzle-user-media-state.repository.spec.ts
+++ b/apps/api/src/modules/user-media/infrastructure/repositories/drizzle-user-media-state.repository.spec.ts
@@ -1,5 +1,6 @@
 import { DrizzleUserMediaStateRepository } from './drizzle-user-media-state.repository';
 import { ImageMapper } from '../../../../common/mappers/image.mapper';
+import * as schema from '../../../../database/schema';
 
 describe('DrizzleUserMediaStateRepository', () => {
   const posterPath = '/poster.jpg';
@@ -225,6 +226,37 @@ describe('DrizzleUserMediaStateRepository', () => {
       const result = await repo.listWithMedia('u1', 10, 0);
 
       expect(result[0].progressSummary).toEqual({ watched: 5, total: 42 });
+    });
+  });
+
+  describe('buildListOrderBy', () => {
+    it('RECENT sort uses createdAt column as the single sort expression', () => {
+      const repo = new DrizzleUserMediaStateRepository(makeDbMock() as any, mockQuery);
+      const result = (repo as any).buildListOrderBy('recent');
+
+      expect(result).toHaveLength(1);
+      // Drizzle desc(col) wraps col in SQL queryChunks — verify it's createdAt not updatedAt
+      const chunks: unknown[] = (result[0] as any).queryChunks ?? [];
+      expect(chunks).toContain(schema.userMediaState.createdAt);
+      expect(chunks).not.toContain(schema.userMediaState.updatedAt);
+    });
+
+    it('RATING sort uses createdAt as the tiebreaker (second arg)', () => {
+      const repo = new DrizzleUserMediaStateRepository(makeDbMock() as any, mockQuery);
+      const [, tiebreaker] = (repo as any).buildListOrderBy('rating');
+
+      const chunks: unknown[] = (tiebreaker as any).queryChunks ?? [];
+      expect(chunks).toContain(schema.userMediaState.createdAt);
+      expect(chunks).not.toContain(schema.userMediaState.updatedAt);
+    });
+
+    it('RELEASE_DATE sort uses createdAt as the tiebreaker (second arg)', () => {
+      const repo = new DrizzleUserMediaStateRepository(makeDbMock() as any, mockQuery);
+      const [, tiebreaker] = (repo as any).buildListOrderBy('releaseDate');
+
+      const chunks: unknown[] = (tiebreaker as any).queryChunks ?? [];
+      expect(chunks).toContain(schema.userMediaState.createdAt);
+      expect(chunks).not.toContain(schema.userMediaState.updatedAt);
     });
   });
 

--- a/apps/api/src/modules/user-media/infrastructure/repositories/drizzle-user-media-state.repository.ts
+++ b/apps/api/src/modules/user-media/infrastructure/repositories/drizzle-user-media-state.repository.ts
@@ -488,12 +488,12 @@ export class DrizzleUserMediaStateRepository implements IUserMediaStateRepositor
   private buildListOrderBy(sort?: ListWithMediaOptions['sort']): SQL[] {
     switch (sort) {
       case USER_MEDIA_LIST_SORT.RATING:
-        return [desc(schema.userMediaState.rating), desc(schema.userMediaState.updatedAt)];
+        return [desc(schema.userMediaState.rating), desc(schema.userMediaState.createdAt)];
       case USER_MEDIA_LIST_SORT.RELEASE_DATE:
-        return [desc(schema.mediaItems.releaseDate), desc(schema.userMediaState.updatedAt)];
+        return [desc(schema.mediaItems.releaseDate), desc(schema.userMediaState.createdAt)];
       case USER_MEDIA_LIST_SORT.RECENT:
       default:
-        return [desc(schema.userMediaState.updatedAt)];
+        return [desc(schema.userMediaState.createdAt)];
     }
   }
 

--- a/apps/web-client/src/modules/saved/hooks/__tests__/use-me-lists.test.tsx
+++ b/apps/web-client/src/modules/saved/hooks/__tests__/use-me-lists.test.tsx
@@ -950,6 +950,41 @@ describe('useSetRating', () => {
 
     invalidateSpy.mockRestore();
   });
+
+  it('invalidates historyAll, activityAll, ratingsAll and counts on settled (fix for #107)', async () => {
+    mockGetState.mockResolvedValue(makeHistoryItem({ rating: null }));
+    mockSetRating.mockResolvedValue(makeHistoryItem({ rating: 80 }));
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+    renderWithClient(<SetRatingConsumer />, queryClient);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('query-status').textContent).toBe('success');
+    });
+
+    await act(async () => {
+      screen.getByTestId('set-rating').click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mutation-status').textContent).toBe('success');
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: queryKeys.meLists.historyAll }),
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: queryKeys.meLists.activityAll }),
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: queryKeys.meLists.ratingsAll }),
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: queryKeys.meLists.counts }),
+    );
+
+    invalidateSpy.mockRestore();
+  });
 });
 
 describe('usePauseMedia', () => {

--- a/apps/web-client/src/modules/saved/hooks/use-me-lists.ts
+++ b/apps/web-client/src/modules/saved/hooks/use-me-lists.ts
@@ -209,10 +209,6 @@ export function useUserMediaState(mediaItemId: string, enabled = true) {
   });
 }
 
-// Rating does not move items between list buckets (watching/paused/dropped/
-// completed/forLater/considering), so `meLists.counts` is not invalidated.
-// Revisit if the backend ever auto-transitions state on rating (e.g. sets
-// state=completed when user rates an unrated movie).
 export function useSetRating(mediaItemId: string) {
   const queryClient = useQueryClient();
 
@@ -254,20 +250,18 @@ export function useSetRating(mediaItemId: string) {
 
     onSettled: () => {
       // Backend syncs standalone rating → review rating
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.reviews.myReview(mediaItemId),
-      });
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.reviews.mediaBase(mediaItemId),
-      });
+      queryClient.invalidateQueries({ queryKey: queryKeys.reviews.myReview(mediaItemId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.reviews.mediaBase(mediaItemId) });
       // Refresh batch ratings so badges update immediately
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.userMedia.batchRatingsAll,
-      });
+      queryClient.invalidateQueries({ queryKey: queryKeys.userMedia.batchRatingsAll });
       // Rating changes may affect favorite updates (e.g. new show becomes favorite)
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.meLists.favoriteUpdates,
-      });
+      queryClient.invalidateQueries({ queryKey: queryKeys.meLists.favoriteUpdates });
+      // First-time ratings auto-create a user_media_state row (completed for movies,
+      // watching for shows). Refresh all affected list views so new entries appear immediately.
+      queryClient.invalidateQueries({ queryKey: queryKeys.meLists.historyAll });
+      queryClient.invalidateQueries({ queryKey: queryKeys.meLists.activityAll });
+      queryClient.invalidateQueries({ queryKey: queryKeys.meLists.ratingsAll });
+      queryClient.invalidateQueries({ queryKey: queryKeys.meLists.counts });
     },
   });
 }


### PR DESCRIPTION
## Summary

Fixes two bugs reported in #107:

- **Bug 1 — Imported item jumps to top after rating update**: `buildListOrderBy()` was sorting by `updatedAt`, which is bumped on every upsert including rating-only changes. Switched to `createdAt` so the "recently added" order reflects when the item entered the list, not when it was last touched.

- **Bug 2 — Newly rated item doesn't appear in list**: `useSetRating` never invalidated the list caches, so first-time ratings (which auto-create a `user_media_state` row with `state=completed/watching`) didn't appear in the history/activity/ratings tabs until the 5-minute `staleTime` expired. Added invalidation of `historyAll`, `activityAll`, `ratingsAll`, and `counts` on every settled mutation — consistent with `usePauseMedia`/`useDropMedia`.

## Changes

| File | Change |
|------|--------|
| `drizzle-user-media-state.repository.ts` | `buildListOrderBy()` — sort by `createdAt` instead of `updatedAt` in all 3 sort modes |
| `drizzle-user-media-state.repository.spec.ts` | New `buildListOrderBy` describe block — verifies `createdAt` column is referenced via Drizzle queryChunks |
| `use-me-lists.ts` | `useSetRating.onSettled` — add `historyAll`, `activityAll`, `ratingsAll`, `counts` invalidations; remove stale comment |
| `use-me-lists.test.tsx` | New test — verifies all 4 list keys are invalidated on settled |

## Test plan

- [ ] `npm run test:api` passes (15 tests in repository spec, including 3 new `buildListOrderBy` cases)
- [ ] `npm run test:client` passes (47 tests in `use-me-lists`, including 1 new invalidation case)
- [ ] Manual: add a movie to watched, note position, update rating → position unchanged
- [ ] Manual: rate a brand-new movie → appears immediately in Переглянуто (completed) tab
- [ ] Manual: rate a brand-new show → appears immediately in Дивлюся (watching) tab and Ratings tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Виправлено оновлення дисплея при змінах рейтингу медіа — тепер коректно оновлюються списки історії, активності, рейтингів і глобальний лічильник.

* **Improvements**
  * Поліпшено логіку сортування медіа — змінено критерії розв'язання однакових значень при сортуванні за рейтингом і датою випуску.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eurusik/ratingo/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->