### PR TITLE
fix(ingestion): correct totalEpisodes after TVMaze/TMDB enrichment

### DIFF
--- a/apps/api/src/modules/catalog/infrastructure/queries/show-details.query.spec.ts
+++ b/apps/api/src/modules/catalog/infrastructure/queries/show-details.query.spec.ts
@@ -153,6 +153,10 @@ describe('ShowDetailsQuery', () => {
     expect(res?.seasons).toHaveLength(2);
     expect(res?.seasons[0].episodes).toHaveLength(2);
     expect(res?.seasons[0].episodes![0].title).toBe('Ep1');
+    // episodeCount should reflect actual rows, not stored value (10 stored, 2 rows)
+    expect(res?.seasons[0].episodeCount).toBe(2);
+    // season with no rows keeps stored episodeCount
+    expect(res?.seasons[1].episodeCount).toBe(10);
     expect(CreditsMapper.toDto).toHaveBeenCalled();
     expect(MediaWatchOffersMapper.toAvailability).toHaveBeenCalled();
   });

--- a/apps/api/src/modules/catalog/infrastructure/queries/show-details.query.ts
+++ b/apps/api/src/modules/catalog/infrastructure/queries/show-details.query.ts
@@ -126,12 +126,16 @@ export class ShowDetailsQuery {
       episodesBySeason.set(ep.seasonNumber, existing);
     }
 
-    // Attach episodes to seasons
-    return seasonsData.map((season) => ({
-      ...season,
-      episodes: (episodesBySeason.get(season.number) ?? []).map(
+    // Attach episodes to seasons; override stored episodeCount with actual row count
+    return seasonsData.map((season) => {
+      const episodes = (episodesBySeason.get(season.number) ?? []).map(
         ({ seasonNumber: _seasonNumber, ...ep }) => ep,
-      ),
-    }));
+      );
+      return {
+        ...season,
+        episodeCount: episodes.length > 0 ? episodes.length : season.episodeCount,
+        episodes,
+      };
+    });
   }
 }

--- a/apps/api/src/modules/ingestion/application/services/sync-media.service.spec.ts
+++ b/apps/api/src/modules/ingestion/application/services/sync-media.service.spec.ts
@@ -563,6 +563,41 @@ describe('SyncMediaService', () => {
 
       expect(tmdbAdapter.getSeasonEpisodes).not.toHaveBeenCalled();
     });
+
+    it('should update totalEpisodes after TMDB episode fallback', async () => {
+      const showWithStaleTotalEpisodes: any = {
+        ...mockShowWithEmptyEpisodes,
+        details: {
+          totalEpisodes: 4,
+          seasons: [{ number: 1, name: 'Сезон 1', tmdbId: 101, episodeCount: 8, episodes: [] }],
+        },
+      };
+
+      tmdbAdapter.getShow.mockResolvedValue({ ...showWithStaleTotalEpisodes });
+      tvMazeEnrichment.enrich.mockResolvedValue({ ...showWithStaleTotalEpisodes });
+
+      const tmdbEpisodes = Array.from({ length: 8 }, (_, i) => ({
+        tmdbId: 1000 + i,
+        number: i + 1,
+        title: `Episode ${i + 1}`,
+        airDate: new Date('2026-01-15'),
+        runtime: 50,
+        overview: null,
+        stillPath: null,
+        rating: null,
+      }));
+      tmdbAdapter.getSeasonEpisodes.mockResolvedValue(tmdbEpisodes);
+
+      await service.syncShow(310537);
+
+      expect(mediaRepository.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          details: expect.objectContaining({
+            totalEpisodes: 8,
+          }),
+        }),
+      );
+    });
   });
 
   describe('provider normalization', () => {

--- a/apps/api/src/modules/ingestion/application/services/sync-media.service.ts
+++ b/apps/api/src/modules/ingestion/application/services/sync-media.service.ts
@@ -266,11 +266,19 @@ export class SyncMediaService {
         `${logPrefix} TMDB episode fallback: filled ${emptySeasons.length} season(s)`,
       );
 
+      const totalEpisodesFromSeasons = updatedSeasons
+        .filter((s) => s.number > 0)
+        .reduce((sum, s) => sum + (s.episodeCount ?? 0), 0);
+
       return {
         ...media,
         details: {
           ...media.details,
           seasons: updatedSeasons,
+          totalEpisodes:
+            totalEpisodesFromSeasons > (media.details?.totalEpisodes ?? 0)
+              ? totalEpisodesFromSeasons
+              : media.details?.totalEpisodes,
           // TMDB is lower priority than TVMaze for air dates.
           // Existing value (set by TVMaze) takes precedence — only use TMDB if nothing else available.
           lastAirDate: media.details?.lastAirDate ?? lastAirDate,

--- a/apps/api/src/modules/ingestion/application/services/tvmaze-enrichment.service.spec.ts
+++ b/apps/api/src/modules/ingestion/application/services/tvmaze-enrichment.service.spec.ts
@@ -457,6 +457,76 @@ describe('TvMazeEnrichmentService', () => {
       expect(result.details?.seasons?.[0].episodes).toHaveLength(1);
     });
 
+    it('should update totalEpisodes when TVMaze finds more episodes than TMDB metadata', async () => {
+      const showWithStaleTmdbCount = {
+        ...mockShow,
+        details: {
+          ...mockShow.details,
+          totalEpisodes: 6,
+          seasons: [{ number: 1, name: 'Season 1', tmdbId: 101, episodeCount: 6, episodes: [] }],
+        },
+      };
+
+      tvMazeAdapter.getEpisodesByImdbId.mockResolvedValue(
+        Array.from({ length: 12 }, (_, i) => ({
+          seasonNumber: 1,
+          number: i + 1,
+          title: `Episode ${i + 1}`,
+          airDate: new Date('2024-01-01'),
+          runtime: 60,
+          overview: null,
+          stillPath: null,
+          rating: null,
+        })),
+      );
+
+      const result = await service.enrich(showWithStaleTmdbCount);
+
+      expect(result.details?.totalEpisodes).toBe(12);
+      expect(result.details?.seasons?.[0].episodeCount).toBe(12);
+    });
+
+    it('should exclude Season 0 from totalEpisodes calculation', async () => {
+      const showWithSpecialsAndSeason = {
+        ...mockShow,
+        details: {
+          totalEpisodes: 12,
+          seasons: [
+            { number: 0, name: 'Specials', tmdbId: 100, episodeCount: 3, episodes: [] },
+            { number: 1, name: 'Season 1', tmdbId: 101, episodeCount: 12, episodes: [] },
+          ],
+        },
+      };
+
+      tvMazeAdapter.getEpisodesByImdbId.mockResolvedValue([
+        ...Array.from({ length: 3 }, (_, i) => ({
+          seasonNumber: 0,
+          number: i + 1,
+          title: `Special ${i + 1}`,
+          airDate: new Date('2020-01-01'),
+          runtime: 60,
+          overview: null,
+          stillPath: null,
+          rating: null,
+        })),
+        ...Array.from({ length: 12 }, (_, i) => ({
+          seasonNumber: 1,
+          number: i + 1,
+          title: `Episode ${i + 1}`,
+          airDate: new Date('2024-01-01'),
+          runtime: 60,
+          overview: null,
+          stillPath: null,
+          rating: null,
+        })),
+      ]);
+
+      const result = await service.enrich(showWithSpecialsAndSeason);
+
+      // Season 0 must not inflate totalEpisodes
+      expect(result.details?.totalEpisodes).toBe(12);
+    });
+
     it('should deduplicate when originalTitle equals title', async () => {
       const mediaWithSameNames = {
         ...mockShow,

--- a/apps/api/src/modules/ingestion/application/services/tvmaze-enrichment.service.ts
+++ b/apps/api/src/modules/ingestion/application/services/tvmaze-enrichment.service.ts
@@ -42,11 +42,19 @@ export class TvMazeEnrichmentService {
       const nextAirDate = this.findNextAirDate(episodes);
       const lastAirDate = this.findLastAirDate(episodes);
 
+      const tvmazeTotalEpisodes = mergedSeasons
+        .filter((s) => s.number > 0)
+        .reduce((sum, s) => sum + (s.episodeCount ?? 0), 0);
+
       return {
         ...media,
         details: {
           ...media.details,
           seasons: mergedSeasons,
+          totalEpisodes:
+            tvmazeTotalEpisodes > (media.details?.totalEpisodes ?? 0)
+              ? tvmazeTotalEpisodes
+              : media.details?.totalEpisodes,
           nextAirDate: nextAirDate ?? media.details?.nextAirDate,
           // TVMaze overrides TMDB's lastAirDate as TVMaze is "time authority"
           lastAirDate: lastAirDate ?? media.details?.lastAirDate,


### PR DESCRIPTION
Closes #102

## Root cause

Two distinct bugs found via production DB investigation:

**Bug 1 — `shows.total_episodes` stale after TVMaze enrichment** (nebuvali showing "6 episodes"):

`TvMazeEnrichmentService.enrich()` correctly merged seasons with TVMaze data (updating `seasons.episode_count`), but never recalculated the show-level `details.totalEpisodes`. TMDB's value from initial import stayed forever. Same gap existed in `SyncMediaService.enrichWithTmdbEpisodes()`.

**Bug 2 — 4 shows with 0 episode rows** (spiymaty-kaydasha, i-budut-lyudy, kinets-yioho-svitu, show-278927):

These shows were imported in **January 2026**, before `enrichWithTmdbEpisodes` was added (**2026-02-18**, commit `f39b5f34`). Re-syncs since then likely had transient failures. TMDB API does have the data — it just never got persisted for these shows.

> ⚠️ **These 4 shows will NOT self-heal after deploy.** `sync-tracked-shows` (runs 2×/day) only processes shows with active user subscriptions. If nobody is tracking these shows, they never enter the sync queue. Requires manual `SYNC_SHOW` trigger for TMDB IDs: `101504, 105507, 278927, 74577`.

## Changes

### `tvmaze-enrichment.service.ts`
After `mergeSeasons()`, calculates `tvmazeTotalEpisodes` (Season 0 excluded) and overrides `media.details.totalEpisodes` when TVMaze count exceeds stored value. `mergeSeasons()` line 145 (`episodeCount: cleanEpisodes.length`) left unchanged — TVMaze actual episodes are the source of truth.

### `sync-media.service.ts`
Same `totalEpisodes` recalculation in `enrichWithTmdbEpisodes()` return block (same Season 0 exclusion filter).

### `show-details.query.ts`
Read-side safety net: `episodeCount` is now overridden with actual episode row count when rows exist, so any future denormalization mismatch won't surface to clients.

## Tests

- **`tvmaze-enrichment.service.spec.ts`**: +2 tests — totalEpisodes override when TVMaze > TMDB, Season 0 exclusion from sum
- **`sync-media.service.spec.ts`**: +1 test — totalEpisodes updated after TMDB fallback
- **`show-details.query.spec.ts`**: +2 assertions — stored `episodeCount: 10` with 2 actual rows returns `2`; season with no rows keeps stored value

## Post-deploy action required

```
Manually trigger SYNC_SHOW for TMDB IDs: 101504, 105507, 278927, 74577
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Виправлено обчислення кількості епізодів на рівні сезонів: тепер коректно відображається фактична кількість епізодів у результатах запитів.
  * Вдосконалено логіку оновлення загальної кількості епізодів при обогащенні даних від зовнішніх джерел: система тепер правильно враховує епізоди з різних сервісів.

* **Tests**
  * Додано тестові випадки для перевірки коректності обчислення кількості епізодів в різних сценаріях.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eurusik/ratingo/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->