### PR TITLE
fix(sync): remove router.refresh() — caused 404 after queuing

### DIFF
--- a/apps/web-client/src/modules/details/hooks/use-show-sync.ts
+++ b/apps/web-client/src/modules/details/hooks/use-show-sync.ts
@@ -1,19 +1,9 @@
-import { useRouter } from 'next/navigation';
-
 import { useMutation } from '@tanstack/react-query';
 
 import { catalogApi, type SyncRequestResponseDto } from '@/core/api/catalog.client';
 
 export function useShowSync(slug: string) {
-  const router = useRouter();
-
   return useMutation({
     mutationFn: () => catalogApi.requestShowSync(slug),
-    onSuccess: (data: SyncRequestResponseDto) => {
-      if (data.queued) {
-        // Refresh the server component so lastSyncedAt reflects the new value after sync completes
-        router.refresh();
-      }
-    },
   });
 }


### PR DESCRIPTION
## Summary

- After clicking sync, `router.refresh()` triggered a server-side re-render of the show page
- If `getShowBySlug()` threw during that re-render the page showed "Сторінку не знайдено"
- The refresh was unnecessary: cooldown is tracked via `localStorage` immediately; `lastSyncedAt` propagates via ISR (`revalidate: 3600s`) after the BullMQ job completes

## Root cause

`useShowSync` called `router.refresh()` on `queued: true`. In Next.js App Router this invalidates the route cache and triggers a full server-side re-render. If `getShowBySlug()` throws during that re-render, `NotFoundView` is returned — showing "Сторінку не знайдено".

## Fix

Removed `router.refresh()` and the `useRouter` import from `use-show-sync.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Зміни**
  * Видалено автоматичне оновлення сторінки після успішного синхронізування шоу-контенту.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eurusik/ratingo/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->