### PR TITLE
refactor(api): unify Swagger tags into Public/Me/Admin taxonomy

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,7 +1,7 @@
 import { ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { FastifyAdapter, type NestFastifyApplication } from '@nestjs/platform-fastify';
-import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
+import { SwaggerModule } from '@nestjs/swagger';
 
 import fastifyCookie from '@fastify/cookie';
 import fastifyMultipart from '@fastify/multipart';
@@ -11,6 +11,7 @@ import { AllExceptionsFilter } from './common/filters/all-exceptions.filter';
 import { ResponseInterceptor } from './common/interceptors/response.interceptor';
 import { SlowRequestInterceptor } from './common/interceptors/slow-request.interceptor';
 import { DevTiming } from './common/utils/dev-timing';
+import { buildSwaggerConfig } from './swagger.config';
 
 /**
  * Entry point of the API application.
@@ -65,16 +66,16 @@ async function bootstrap(): Promise<void> {
   app.useGlobalFilters(new AllExceptionsFilter());
   app.useGlobalInterceptors(new SlowRequestInterceptor(), new ResponseInterceptor());
 
-  // Swagger Documentation Setup
-  const config = new DocumentBuilder()
-    .setTitle('Ratingo API')
-    .setDescription('Rest API for Ratingo mobile and web clients')
-    .setVersion('2.0')
-    .addBearerAuth()
-    .build();
-
-  const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('docs', app, document);
+  // Swagger Documentation Setup (shared config — see swagger.config.ts)
+  const document = SwaggerModule.createDocument(app, buildSwaggerConfig());
+  SwaggerModule.setup('docs', app, document, {
+    swaggerOptions: {
+      docExpansion: 'none', // collapse all groups — the tag list is the navigation
+      filter: true, // search box over tags/operations
+      persistAuthorization: true, // keep the Bearer token across page reloads
+      defaultModelsExpandDepth: 0, // hide the schemas wall at the bottom
+    },
+  });
 
   // Start server
   const port = process.env.PORT || 3001;

--- a/apps/api/src/modules/catalog-policy/presentation/controllers/dry-run.controller.ts
+++ b/apps/api/src/modules/catalog-policy/presentation/controllers/dry-run.controller.ts
@@ -21,7 +21,7 @@ import { validatePolicyOrThrow } from '../../domain/validation/policy.schema';
 import { DryRunRequestDto, DryRunResponseDto } from '../dto/dry-run.dto';
 import { DryRunExceptionFilter } from '../filters/dry-run-exception.filter';
 
-@ApiTags('Admin - Policy Activation')
+@ApiTags('Admin: Policy')
 @ApiBearerAuth()
 @UseGuards(AdminJwtGuard)
 @UseFilters(DryRunExceptionFilter)

--- a/apps/api/src/modules/catalog-policy/presentation/controllers/policy.controller.ts
+++ b/apps/api/src/modules/catalog-policy/presentation/controllers/policy.controller.ts
@@ -37,7 +37,7 @@ import {
   CreatePolicyResponseDto,
 } from '../dto';
 
-@ApiTags('Admin - Policy Activation')
+@ApiTags('Admin: Policy')
 @ApiBearerAuth()
 @UseGuards(AdminJwtGuard)
 @Controller('admin/catalog-policies')

--- a/apps/api/src/modules/catalog-policy/presentation/controllers/run.controller.ts
+++ b/apps/api/src/modules/catalog-policy/presentation/controllers/run.controller.ts
@@ -30,7 +30,7 @@ import {
   BackfillResponseDto,
 } from '../dto';
 
-@ApiTags('Admin - Policy Activation')
+@ApiTags('Admin: Policy')
 @ApiBearerAuth()
 @UseGuards(AdminJwtGuard)
 @Controller('admin/catalog-policies/runs')

--- a/apps/api/src/modules/home/presentation/home.controller.ts
+++ b/apps/api/src/modules/home/presentation/home.controller.ts
@@ -10,7 +10,7 @@ import { HeroItemMapper } from './mappers/hero-item.mapper';
 /**
  * Public home endpoints.
  */
-@ApiTags('Home')
+@ApiTags('Public: Home')
 @Controller('home')
 export class HomeController {
   constructor(private readonly homeService: HomeService) {}

--- a/apps/api/src/modules/ingestion/presentation/controllers/ingestion.controller.ts
+++ b/apps/api/src/modules/ingestion/presentation/controllers/ingestion.controller.ts
@@ -53,7 +53,7 @@ import {
  * Triggers ingestion processes.
  * Intended for admin panels and operational debugging.
  */
-@ApiTags('Service: Ingestion')
+@ApiTags('Admin: Ingestion')
 @ApiBearerAuth()
 @UseGuards(AdminJwtGuard)
 @Controller('ingestion')

--- a/apps/api/src/modules/journal/presentation/controllers/admin-journal.controller.ts
+++ b/apps/api/src/modules/journal/presentation/controllers/admin-journal.controller.ts
@@ -69,7 +69,7 @@ const DEFAULT_PAGE_LIMIT = 10;
  * Admin journal controller.
  * Provides CRUD operations for journal posts with admin authentication.
  */
-@ApiTags('Admin - Journal')
+@ApiTags('Admin: Journal')
 @ApiBearerAuth()
 @UseGuards(AdminJwtGuard)
 @Controller('admin/journal/posts')

--- a/apps/api/src/modules/provider/presentation/controllers/providers.controller.ts
+++ b/apps/api/src/modules/provider/presentation/controllers/providers.controller.ts
@@ -45,7 +45,7 @@ import {
   MappingsQueryDto,
 } from '../dto';
 
-@ApiTags('Admin - Providers')
+@ApiTags('Admin: Providers')
 @ApiBearerAuth()
 @UseGuards(AdminJwtGuard)
 @Controller('admin/providers')

--- a/apps/api/src/modules/reviews/presentation/controllers/admin-reviews.controller.ts
+++ b/apps/api/src/modules/reviews/presentation/controllers/admin-reviews.controller.ts
@@ -33,7 +33,7 @@ import {
 /** Default page limit for reports list */
 const DEFAULT_REPORTS_LIMIT = 20;
 
-@ApiTags('Admin - Reviews')
+@ApiTags('Admin: Reviews')
 @ApiBearerAuth()
 @UseGuards(AdminJwtGuard)
 @Controller('admin/reviews')

--- a/apps/api/src/modules/reviews/presentation/controllers/user-reviews.controller.ts
+++ b/apps/api/src/modules/reviews/presentation/controllers/user-reviews.controller.ts
@@ -41,7 +41,7 @@ import {
 /**
  * Authenticated endpoints for user reviews (CRUD + voting).
  */
-@ApiTags('User: Reviews')
+@ApiTags('Me: Reviews')
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
 @Controller('me/reviews')

--- a/apps/api/src/modules/stats/presentation/controllers/stats.controller.ts
+++ b/apps/api/src/modules/stats/presentation/controllers/stats.controller.ts
@@ -57,7 +57,7 @@ export class StatsController {
   @Post('sync')
   @ApiBearerAuth()
   @UseGuards(AdminJwtGuard)
-  @ApiTags('Service: Stats')
+  @ApiTags('Admin: Stats')
   @ApiOperation({
     summary: 'Sync trending stats from Trakt',
     description:
@@ -85,7 +85,7 @@ export class StatsController {
   @Post('sync-eligible-trending')
   @ApiBearerAuth()
   @UseGuards(AdminJwtGuard)
-  @ApiTags('Service: Stats')
+  @ApiTags('Admin: Stats')
   @ApiOperation({
     summary: 'Sync watchers for ELIGIBLE trending items',
     description:
@@ -137,7 +137,7 @@ export class StatsController {
   @Post('drop-off/analyze')
   @ApiBearerAuth()
   @UseGuards(AdminJwtGuard)
-  @ApiTags('Service: Stats')
+  @ApiTags('Admin: Stats')
   @ApiOperation({
     summary: 'Analyze drop-off for shows',
     description:
@@ -166,7 +166,7 @@ export class StatsController {
   @Post('drop-off/analyze/:tmdbId')
   @ApiBearerAuth()
   @UseGuards(AdminJwtGuard)
-  @ApiTags('Service: Stats')
+  @ApiTags('Admin: Stats')
   @ApiOperation({
     summary: 'Analyze drop-off for a specific show',
     description: 'Analyzes viewer drop-off for a single show by TMDB ID. Runs in background.',
@@ -215,7 +215,7 @@ export class StatsController {
   @Post('backfill/total-watchers')
   @ApiBearerAuth()
   @UseGuards(AdminJwtGuard)
-  @ApiTags('Service: Stats')
+  @ApiTags('Admin: Stats')
   @ApiOperation({
     summary: 'Backfill total_watchers for corrupted items',
     description:
@@ -244,7 +244,7 @@ export class StatsController {
   @Post('backfill/watchers-count')
   @ApiBearerAuth()
   @UseGuards(AdminJwtGuard)
-  @ApiTags('Service: Stats')
+  @ApiTags('Admin: Stats')
   @ApiOperation({
     summary: 'Queue backfill jobs for watchers_count',
     description:
@@ -277,7 +277,7 @@ export class StatsController {
   @Post('recalculate')
   @ApiBearerAuth()
   @UseGuards(AdminJwtGuard)
-  @ApiTags('Service: Stats')
+  @ApiTags('Admin: Stats')
   @ApiOperation({
     summary: 'Recalculate scores for all media items',
     description:
@@ -302,7 +302,7 @@ export class StatsController {
   @Post('reconcile-community-ratings')
   @ApiBearerAuth()
   @UseGuards(AdminJwtGuard)
-  @ApiTags('Service: Stats')
+  @ApiTags('Admin: Stats')
   @ApiOperation({
     summary: 'Reconcile community ratings',
     description:

--- a/apps/api/src/modules/user-actions/presentation/controllers/notifications.controller.ts
+++ b/apps/api/src/modules/user-actions/presentation/controllers/notifications.controller.ts
@@ -24,7 +24,7 @@ import {
 /**
  * Controller for user notifications.
  */
-@ApiTags('Notifications')
+@ApiTags('Me: Notifications')
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
 @Controller('me/notifications')

--- a/apps/api/src/modules/user-actions/presentation/controllers/saved-items.controller.ts
+++ b/apps/api/src/modules/user-actions/presentation/controllers/saved-items.controller.ts
@@ -37,7 +37,7 @@ import {
   SavedItemsListQueryDto,
 } from '../dto/saved-items.dto';
 
-@ApiTags('Saved Items')
+@ApiTags('Me: Saved Items')
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
 @Controller('me/saved-items')

--- a/apps/api/src/modules/user-actions/presentation/controllers/subscriptions.controller.ts
+++ b/apps/api/src/modules/user-actions/presentation/controllers/subscriptions.controller.ts
@@ -35,7 +35,7 @@ import {
   UnsubscribeActionResultDto,
 } from '../dto/subscriptions.dto';
 
-@ApiTags('Subscriptions')
+@ApiTags('Me: Subscriptions')
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
 @Controller('me/subscriptions')

--- a/apps/api/src/modules/user-media/presentation/controllers/episode-progress.controller.ts
+++ b/apps/api/src/modules/user-media/presentation/controllers/episode-progress.controller.ts
@@ -28,7 +28,7 @@ import { EpisodeProgressService } from '../../application/episode-progress.servi
 import { BatchEpisodeIdsDto } from '../dto/batch-episode-ids.dto';
 import { ShowProgressDto } from '../dto/episode-progress.dto';
 
-@ApiTags('Episode Progress')
+@ApiTags('Me: Episode Progress')
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
 @Controller('user-media')

--- a/apps/api/src/modules/user-media/presentation/controllers/me-lists.controller.ts
+++ b/apps/api/src/modules/user-media/presentation/controllers/me-lists.controller.ts
@@ -39,7 +39,7 @@ type UserMediaWithSummary = UserMediaState & {
 /**
  * Exposes owner-only user media list endpoints.
  */
-@ApiTags('Me')
+@ApiTags('Me: Lists')
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
 @Controller('me')

--- a/apps/api/src/modules/user-media/presentation/controllers/user-media.controller.ts
+++ b/apps/api/src/modules/user-media/presentation/controllers/user-media.controller.ts
@@ -43,7 +43,7 @@ import { CsvImportResultDto, ImportMediaDto } from '../dto/import-media.dto';
 import { SetUserMediaStateDto } from '../dto/set-user-media-state.dto';
 import { UserMediaStateDto } from '../dto/user-media-state.dto';
 
-@ApiTags('User Media')
+@ApiTags('Me: Library')
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
 @Controller('user-media')

--- a/apps/api/src/modules/users/presentation/controllers/users.controller.ts
+++ b/apps/api/src/modules/users/presentation/controllers/users.controller.ts
@@ -27,7 +27,7 @@ import { UpdateProfileDto } from '../dto/update-profile.dto';
 /**
  * Handles authenticated user profile operations.
  */
-@ApiTags('Users')
+@ApiTags('Me: Profile')
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
 @Controller('users')

--- a/apps/api/src/scripts/generate-openapi.ts
+++ b/apps/api/src/scripts/generate-openapi.ts
@@ -3,13 +3,14 @@ import * as path from 'node:path';
 
 import { BullRegistrar, getQueueToken } from '@nestjs/bullmq';
 import { FastifyAdapter, type NestFastifyApplication } from '@nestjs/platform-fastify';
-import { DocumentBuilder, SwaggerModule, type OpenAPIObject } from '@nestjs/swagger';
+import { SwaggerModule, type OpenAPIObject } from '@nestjs/swagger';
 import { Test } from '@nestjs/testing';
 
 import { AppModule } from '../app.module';
 import { DATABASE_CONNECTION } from '../database/database.module';
 import { INGESTION_QUEUE } from '../modules/ingestion/ingestion.constants';
 import { STATS_QUEUE } from '../modules/stats/stats.constants';
+import { buildSwaggerConfig } from '../swagger.config';
 
 const GLOBAL_PREFIX = 'api';
 const OUTPUT_PATH = path.resolve(__dirname, '../../../../packages/api-contract/openapi.json');
@@ -121,17 +122,6 @@ const wrapSuccessResponses = (doc: OpenAPIObject): void => {
       media.schema = wrapSchema(media.schema!);
     });
 };
-
-/**
- * Build Swagger/OpenAPI metadata.
- */
-const buildSwaggerConfig = () =>
-  new DocumentBuilder()
-    .setTitle('Ratingo API')
-    .setDescription('Rest API for Ratingo mobile and web clients')
-    .setVersion('2.0')
-    .addBearerAuth()
-    .build();
 
 /**
  * Create a Nest application instance configured for offline OpenAPI generation.

--- a/apps/api/src/swagger.config.ts
+++ b/apps/api/src/swagger.config.ts
@@ -1,0 +1,44 @@
+import { DocumentBuilder, type OpenAPIObject } from '@nestjs/swagger';
+
+/**
+ * Shared Swagger/OpenAPI metadata used by both the runtime docs endpoint
+ * (main.ts) and the offline contract generator (scripts/generate-openapi.ts).
+ *
+ * Tag taxonomy: Auth → Public (no auth) → Me (Bearer JWT) → Admin (admin role).
+ * Tags render in registration order, so keep this list grouped by audience.
+ */
+export const buildSwaggerConfig = (): Omit<OpenAPIObject, 'paths'> =>
+  new DocumentBuilder()
+    .setTitle('Ratingo API')
+    .setDescription(
+      'REST API for Ratingo mobile and web clients.\n\n' +
+        'Endpoints are grouped by audience: **Public** (no auth), ' +
+        '**Me** (authenticated user, Bearer JWT), **Admin** (admin role required).\n\n' +
+        'All responses are wrapped: `{ success: true, data }` on success, ' +
+        '`{ success: false, error: { code, message } }` on failure.',
+    )
+    .setVersion('2.0')
+    .addBearerAuth()
+    .addTag('Auth', 'Registration, login, OAuth, token refresh')
+    .addTag('Public: Catalog', 'Movies, shows, search, providers, sitemap')
+    .addTag('Public: Home', 'Homepage sections')
+    .addTag('Public: Users', 'Public user profiles')
+    .addTag('Public: Reviews', 'Reviews for a title')
+    .addTag('Public: Journal', 'Editorial posts')
+    .addTag('Public: Stats', 'Watchers and drop-off stats for a title')
+    .addTag('Public: Insights', 'Trends and movements')
+    .addTag('Me: Profile', 'Own profile and avatar')
+    .addTag('Me: Library', 'Watch states and ratings')
+    .addTag('Me: Lists', 'Watchlist, history, favorites')
+    .addTag('Me: Episode Progress', 'Per-episode watch progress')
+    .addTag('Me: Reviews', 'Own reviews')
+    .addTag('Me: Subscriptions', 'Show subscriptions and triggers')
+    .addTag('Me: Saved Items', 'Saved items')
+    .addTag('Me: Notifications', 'Notification feed')
+    .addTag('Admin: Journal', 'Editorial post management')
+    .addTag('Admin: Reviews', 'Review moderation')
+    .addTag('Admin: Providers', 'Watch-provider mappings')
+    .addTag('Admin: Policy', 'Catalog policy configuration and dry-runs')
+    .addTag('Admin: Ingestion', 'Sync and backfill jobs')
+    .addTag('Admin: Stats', 'Stats sync, recalculation, backfills')
+    .build();

--- a/packages/api-contract/openapi.json
+++ b/packages/api-contract/openapi.json
@@ -1888,7 +1888,7 @@
           }
         },
         "tags": [
-          "User Media"
+          "Me: Library"
         ],
         "security": [
           {
@@ -1955,7 +1955,7 @@
           }
         },
         "tags": [
-          "User Media"
+          "Me: Library"
         ],
         "security": [
           {
@@ -2003,7 +2003,7 @@
           }
         },
         "tags": [
-          "User Media"
+          "Me: Library"
         ],
         "security": [
           {
@@ -2061,7 +2061,7 @@
           }
         },
         "tags": [
-          "User Media"
+          "Me: Library"
         ],
         "security": [
           {
@@ -2116,7 +2116,7 @@
           }
         },
         "tags": [
-          "User Media"
+          "Me: Library"
         ],
         "security": [
           {
@@ -2179,7 +2179,7 @@
           }
         },
         "tags": [
-          "User Media"
+          "Me: Library"
         ],
         "security": [
           {
@@ -2246,7 +2246,7 @@
           }
         },
         "tags": [
-          "User Media"
+          "Me: Library"
         ],
         "security": [
           {
@@ -2304,7 +2304,7 @@
           }
         },
         "tags": [
-          "User Media"
+          "Me: Library"
         ],
         "security": [
           {
@@ -2362,7 +2362,7 @@
           }
         },
         "tags": [
-          "User Media"
+          "Me: Library"
         ],
         "security": [
           {
@@ -2420,7 +2420,7 @@
           }
         },
         "tags": [
-          "User Media"
+          "Me: Library"
         ],
         "security": [
           {
@@ -2508,7 +2508,7 @@
           }
         },
         "tags": [
-          "Me"
+          "Me: Lists"
         ],
         "security": [
           {
@@ -2596,7 +2596,7 @@
           }
         },
         "tags": [
-          "Me"
+          "Me: Lists"
         ],
         "security": [
           {
@@ -2699,7 +2699,7 @@
           }
         },
         "tags": [
-          "Me"
+          "Me: Lists"
         ],
         "security": [
           {
@@ -2787,7 +2787,7 @@
           }
         },
         "tags": [
-          "Me"
+          "Me: Lists"
         ],
         "security": [
           {
@@ -2875,7 +2875,7 @@
           }
         },
         "tags": [
-          "Me"
+          "Me: Lists"
         ],
         "security": [
           {
@@ -2963,7 +2963,7 @@
           }
         },
         "tags": [
-          "Me"
+          "Me: Lists"
         ],
         "security": [
           {
@@ -3051,7 +3051,7 @@
           }
         },
         "tags": [
-          "Me"
+          "Me: Lists"
         ],
         "security": [
           {
@@ -3093,7 +3093,7 @@
           }
         },
         "tags": [
-          "Me"
+          "Me: Lists"
         ],
         "security": [
           {
@@ -3138,7 +3138,7 @@
           }
         },
         "tags": [
-          "Me"
+          "Me: Lists"
         ],
         "security": [
           {
@@ -3177,7 +3177,7 @@
           }
         },
         "tags": [
-          "Episode Progress"
+          "Me: Episode Progress"
         ],
         "security": [
           {
@@ -3216,7 +3216,7 @@
           }
         },
         "tags": [
-          "Episode Progress"
+          "Me: Episode Progress"
         ],
         "security": [
           {
@@ -3252,7 +3252,7 @@
           }
         },
         "tags": [
-          "Episode Progress"
+          "Me: Episode Progress"
         ],
         "security": [
           {
@@ -3283,7 +3283,7 @@
           }
         },
         "tags": [
-          "Episode Progress"
+          "Me: Episode Progress"
         ],
         "security": [
           {
@@ -3338,12 +3338,2976 @@
           }
         },
         "tags": [
-          "Episode Progress"
+          "Me: Episode Progress"
         ],
         "security": [
           {
             "bearer": []
           }
+        ]
+      }
+    },
+    "/api/me/notifications": {
+      "get": {
+        "operationId": "NotificationsController_list",
+        "summary": "List notifications (auth: Bearer)",
+        "parameters": [
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 20,
+              "type": "number"
+            }
+          },
+          {
+            "name": "offset",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 0,
+              "type": "number"
+            }
+          },
+          {
+            "name": "unread",
+            "required": false,
+            "in": "query",
+            "description": "Filter by unread only",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/NotificationListResponseDto"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Me: Notifications"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/me/notifications/unread-count": {
+      "get": {
+        "operationId": "NotificationsController_getUnreadCount",
+        "summary": "Get unread notification count (auth: Bearer)",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/UnreadCountResponseDto"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Me: Notifications"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/me/notifications/{notificationId}/read": {
+      "post": {
+        "operationId": "NotificationsController_markAsRead",
+        "summary": "Mark notification as read (auth: Bearer)",
+        "parameters": [
+          {
+            "name": "notificationId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/MarkReadResponseDto"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Me: Notifications"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/me/notifications/read-all": {
+      "post": {
+        "operationId": "NotificationsController_markAllAsRead",
+        "summary": "Mark all notifications as read (auth: Bearer)",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/MarkReadResponseDto"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Me: Notifications"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/me/saved-items/{mediaItemId}": {
+      "post": {
+        "operationId": "SavedItemsController_saveItem",
+        "summary": "Save media item to a list (auth: Bearer)",
+        "parameters": [
+          {
+            "name": "mediaItemId",
+            "required": true,
+            "in": "path",
+            "description": "Media item UUID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SaveItemDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Item saved with current status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/SaveActionResultDto"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Me: Saved Items"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "SavedItemsController_unsaveItem",
+        "summary": "Remove media item from a list (auth: Bearer)",
+        "parameters": [
+          {
+            "name": "mediaItemId",
+            "required": true,
+            "in": "path",
+            "description": "Media item UUID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UnsaveItemDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Item removed with current status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/UnsaveActionResultDto"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Me: Saved Items"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/me/saved-items/status/batch": {
+      "get": {
+        "operationId": "SavedItemsController_getBatchStatus",
+        "summary": "Get save status for multiple media items (auth: Bearer)",
+        "parameters": [
+          {
+            "name": "ids",
+            "required": true,
+            "in": "query",
+            "description": "Comma-separated list of media item UUIDs (max 100)",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/BatchStatusResponseDto"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Me: Saved Items"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/me/saved-items/{mediaItemId}/status": {
+      "get": {
+        "operationId": "SavedItemsController_getStatus",
+        "summary": "Get save status for media item (auth: Bearer)",
+        "parameters": [
+          {
+            "name": "mediaItemId",
+            "required": true,
+            "in": "path",
+            "description": "Media item UUID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/MediaSaveStatusDto"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Me: Saved Items"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/me/saved-items/for-later": {
+      "get": {
+        "operationId": "SavedItemsController_listForLater",
+        "summary": "List \"for later\" saved items (auth: Bearer)",
+        "parameters": [
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 20,
+              "type": "number"
+            }
+          },
+          {
+            "name": "offset",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 0,
+              "type": "number"
+            }
+          },
+          {
+            "name": "type",
+            "required": false,
+            "in": "query",
+            "description": "Filter by media type",
+            "schema": {
+              "enum": [
+                "movie",
+                "show"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/SavedItemWithMediaResponseDto"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Me: Saved Items"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/me/saved-items/considering": {
+      "get": {
+        "operationId": "SavedItemsController_listConsidering",
+        "summary": "List \"considering\" saved items (auth: Bearer)",
+        "parameters": [
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 20,
+              "type": "number"
+            }
+          },
+          {
+            "name": "offset",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 0,
+              "type": "number"
+            }
+          },
+          {
+            "name": "type",
+            "required": false,
+            "in": "query",
+            "description": "Filter by media type",
+            "schema": {
+              "enum": [
+                "movie",
+                "show"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/SavedItemWithMediaResponseDto"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Me: Saved Items"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/me/subscriptions/{mediaItemId}": {
+      "post": {
+        "operationId": "SubscriptionsController_subscribe",
+        "summary": "Subscribe to notifications for media item (auth: Bearer)",
+        "parameters": [
+          {
+            "name": "mediaItemId",
+            "required": true,
+            "in": "path",
+            "description": "Media item UUID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubscribeDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Subscribed with current status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/SubscribeActionResultDto"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Me: Subscriptions"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "SubscriptionsController_unsubscribe",
+        "summary": "Unsubscribe from notifications for media item (auth: Bearer)",
+        "parameters": [
+          {
+            "name": "mediaItemId",
+            "required": true,
+            "in": "path",
+            "description": "Media item UUID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UnsubscribeDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Unsubscribed with current status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/UnsubscribeActionResultDto"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Me: Subscriptions"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/me/subscriptions/{mediaItemId}/status": {
+      "get": {
+        "operationId": "SubscriptionsController_getStatus",
+        "summary": "Get subscription status for media item (auth: Bearer)",
+        "parameters": [
+          {
+            "name": "mediaItemId",
+            "required": true,
+            "in": "path",
+            "description": "Media item UUID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/MediaSubscriptionStatusDto"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Me: Subscriptions"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/me/subscriptions": {
+      "get": {
+        "operationId": "SubscriptionsController_listActive",
+        "summary": "List active subscriptions (auth: Bearer)",
+        "parameters": [
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 20,
+              "type": "number"
+            }
+          },
+          {
+            "name": "offset",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 0,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/SubscriptionWithMediaResponseDto"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Me: Subscriptions"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/ingestion/jobs/{id}": {
+      "get": {
+        "operationId": "IngestionController_getJobStatus",
+        "summary": "Get ingestion job status",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ingestion job status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "queued",
+                            "processing",
+                            "ready",
+                            "failed"
+                          ]
+                        },
+                        "errorMessage": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "nullable": true
+                        },
+                        "slug": {
+                          "type": "string",
+                          "nullable": true,
+                          "description": "Media slug (available when status is ready)"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Admin: Ingestion"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/ingestion/sync": {
+      "post": {
+        "operationId": "IngestionController_sync",
+        "summary": "Manually trigger sync for a specific media item",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SyncDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Admin: Ingestion"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/ingestion/trending": {
+      "post": {
+        "operationId": "IngestionController_syncTrending",
+        "summary": "Trigger sync for trending movies and shows",
+        "description": "Syncs trending content from TMDB using dispatcher pattern. Queues page jobs for movies and shows. With syncStats=true (default), also updates Trakt stats after ingestion.",
+        "parameters": [
+          {
+            "name": "pages",
+            "required": false,
+            "in": "query",
+            "description": "Number of pages to fetch in dispatcher mode (20 items per page)",
+            "schema": {
+              "minimum": 1,
+              "maximum": 50,
+              "example": 5,
+              "type": "number"
+            }
+          },
+          {
+            "name": "type",
+            "required": false,
+            "in": "query",
+            "description": "Media type filter — sync only movies or only shows",
+            "schema": {
+              "example": "movie",
+              "enum": [
+                "movie",
+                "show"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "Single page number (legacy mode)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "syncStats",
+            "required": false,
+            "in": "query",
+            "description": "Sync Trakt stats after ingestion (default: true)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "force",
+            "required": false,
+            "in": "query",
+            "description": "Bypass dedupe",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SyncTrendingDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Admin: Ingestion"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/ingestion/movies/now-playing": {
+      "post": {
+        "operationId": "IngestionController_syncNowPlaying",
+        "summary": "Sync movies currently in theaters (ingestion only)",
+        "description": "Fetches now playing movies from TMDB and queues them for sync. Does NOT update isNowPlaying flags - use /ingestion/movies/now-playing-flags for that.",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SyncNowPlayingDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Admin: Ingestion"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/ingestion/movies/now-playing-flags": {
+      "post": {
+        "operationId": "IngestionController_updateNowPlayingFlags",
+        "summary": "Update isNowPlaying flags for movies",
+        "description": "Updates isNowPlaying flags based on current TMDB now_playing list. Run this AFTER now-playing sync has completed.",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SyncNowPlayingDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Admin: Ingestion"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/ingestion/movies/new-releases": {
+      "post": {
+        "operationId": "IngestionController_syncNewReleases",
+        "summary": "Sync new theatrical movie releases",
+        "description": "Fetches movies released in theaters within the specified period and syncs them.",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SyncNewReleasesDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Admin: Ingestion"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/ingestion/snapshots": {
+      "post": {
+        "operationId": "IngestionController_syncSnapshots",
+        "summary": "Trigger daily watchers snapshots sync",
+        "description": "Updates daily watcher counts for all media items from Trakt.",
+        "parameters": [
+          {
+            "name": "region",
+            "required": false,
+            "in": "query",
+            "description": "Region code for snapshots",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "force",
+            "required": false,
+            "in": "query",
+            "description": "Bypass daily deduplication",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Admin: Ingestion"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/ingestion/shows/tracked": {
+      "post": {
+        "operationId": "IngestionController_syncTrackedShows",
+        "summary": "Trigger tracked shows sync",
+        "description": "Syncs shows that have active subscriptions. Detects new episodes/seasons and triggers notifications.",
+        "parameters": [
+          {
+            "name": "force",
+            "required": false,
+            "in": "query",
+            "description": "Bypass hourly deduplication",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Admin: Ingestion"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/ingestion/backfill/imdb": {
+      "post": {
+        "operationId": "IngestionController_backfillImdb",
+        "summary": "Re-sync shows missing IMDb ID",
+        "description": "Finds all shows with missing IMDb ID and performs full re-sync. This fetches external_ids from TMDB (including imdb_id), then enriches each show with Trakt stats (watchers, ratings) and OMDb ratings (IMDb, Rotten Tomatoes, Metacritic). Use when shows were imported before external_ids fetching was implemented.",
+        "parameters": [
+          {
+            "name": "force",
+            "required": false,
+            "in": "query",
+            "description": "Bypass daily deduplication",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Backfill job queued",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/IngestionJobResponseDto"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Admin: Ingestion"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/ingestion/backfill/alt-titles": {
+      "post": {
+        "operationId": "IngestionController_backfillAltTitles",
+        "summary": "Backfill alternative titles from TMDB",
+        "description": "Finds all media items with missing alternative titles and fetches them from TMDB. Uses dedicated lightweight TMDB endpoints — no Trakt, OMDb, or TVMaze calls. One-time operation; future syncs populate alt titles automatically.",
+        "parameters": [
+          {
+            "name": "force",
+            "required": false,
+            "in": "query",
+            "description": "Re-fetch alt titles for items that already have them",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Backfill job queued",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/IngestionJobResponseDto"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Admin: Ingestion"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/ingestion/backfill/mdblist-ratings": {
+      "post": {
+        "operationId": "IngestionController_backfillMdblistRatings",
+        "summary": "Backfill Rotten Tomatoes ratings from MDBList (admin-only)",
+        "description": "Admin-only. Finds media items where either Rotten Tomatoes critics score or audience score is missing, or whose last MDBList check is older than the refresh window (rtFetchedAt > 90 days), and fetches critics + audience ratings from MDBList. Complements OMDb, which frequently omits RT values. Item jobs run on a dedicated rate-limited queue; dispatcher enforces an app-side daily cap of 900 items per run to fit the MDBList free-tier budget (1000 req/day; worker limiter ~40/hour).",
+        "parameters": [
+          {
+            "name": "force",
+            "required": false,
+            "in": "query",
+            "description": "Bypass daily deduplication (allows re-running within the same UTC day)",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Backfill job queued",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/IngestionJobResponseDto"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid bearer token"
+          },
+          "403": {
+            "description": "Authenticated user does not have admin role"
+          }
+        },
+        "tags": [
+          "Admin: Ingestion"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/admin/catalog-policies": {
+      "get": {
+        "operationId": "PolicyController_getPolicies",
+        "summary": "Get list of policies",
+        "description": "Returns list of all catalog policies with their status and metadata.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "List of policies",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/PoliciesListDto"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Admin: Policy"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "post": {
+        "operationId": "PolicyController_createPolicy",
+        "summary": "Create new policy",
+        "description": "Creates a new policy draft with auto-incremented version. The policy is NOT activated automatically. Use POST /:id/prepare to start evaluation.",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "description": "Policy configuration",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreatePolicyDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Policy created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/CreatePolicyResponseDto"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Admin: Policy"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/admin/catalog-policies/{id}": {
+      "get": {
+        "operationId": "PolicyController_getPolicyById",
+        "summary": "Get policy details",
+        "description": "Returns a single policy with full configuration settings.",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Policy ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Policy details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/PolicyDetailDto"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Policy not found"
+          }
+        },
+        "tags": [
+          "Admin: Policy"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/admin/catalog-policies/{id}/prepare": {
+      "post": {
+        "operationId": "PolicyController_preparePolicy",
+        "summary": "Prepare policy for activation",
+        "description": "Creates an evaluation run and starts background job to pre-compute evaluations for all media items. Returns immediately with run ID for tracking progress.",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Policy ID to prepare",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "description": "Optional batch size and concurrency settings",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PrepareOptionsDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Policy preparation started",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/PrepareResponseDto"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Admin: Policy"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/admin/catalog-policies/runs": {
+      "get": {
+        "operationId": "RunController_getRuns",
+        "summary": "Get list of evaluation runs",
+        "description": "Returns list of all evaluation runs with their status and progress.",
+        "parameters": [
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Number of runs to return (default: 20)",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "offset",
+            "required": false,
+            "in": "query",
+            "description": "Offset for pagination (default: 0)",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of evaluation runs",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/RunsListDto"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Admin: Policy"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/admin/catalog-policies/runs/{runId}": {
+      "get": {
+        "operationId": "RunController_getRunStatus",
+        "summary": "Get run status and progress",
+        "description": "Returns detailed status of an evaluation run including progress, counters, and readyToPromote flag.",
+        "parameters": [
+          {
+            "name": "runId",
+            "required": true,
+            "in": "path",
+            "description": "Run ID to check",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Run status and progress",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/RunStatusDto"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Admin: Policy"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/admin/catalog-policies/runs/{runId}/promote": {
+      "post": {
+        "operationId": "RunController_promoteRun",
+        "summary": "Promote run to activate policy",
+        "description": "Verifies run is successful and meets thresholds, then atomically activates the policy. This makes the new policy version active for the public catalog.",
+        "parameters": [
+          {
+            "name": "runId",
+            "required": true,
+            "in": "path",
+            "description": "Run ID to promote",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "description": "Optional coverage and error thresholds (defaults: 100% coverage, 0 errors)",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PromoteOptionsDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Promotion result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/ActionResponseDto"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Admin: Policy"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/admin/catalog-policies/runs/{runId}/cancel": {
+      "post": {
+        "operationId": "RunController_cancelRun",
+        "summary": "Cancel running evaluation",
+        "description": "Cancels a running evaluation. Item jobs already in queue will be skipped. Preserves cursor and counters for potential resume.",
+        "parameters": [
+          {
+            "name": "runId",
+            "required": true,
+            "in": "path",
+            "description": "Run ID to cancel",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Cancellation result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/ActionResponseDto"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Admin: Policy"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/admin/catalog-policies/runs/{runId}/diff": {
+      "get": {
+        "operationId": "RunController_getDiff",
+        "summary": "Get diff report",
+        "description": "Computes differences between current active policy and the prepared run. Shows regressions (items leaving catalog) and improvements (items entering catalog).",
+        "parameters": [
+          {
+            "name": "runId",
+            "required": true,
+            "in": "path",
+            "description": "Run ID to compute diff for",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sampleSize",
+            "required": false,
+            "in": "query",
+            "description": "Number of sample items to return (default: 50)",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Diff report",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/DiffReportDto"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Admin: Policy"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/admin/catalog-policies/runs/backfill": {
+      "post": {
+        "operationId": "RunController_backfillContext",
+        "summary": "Backfill evaluations for a specific context",
+        "description": "Triggers re-evaluation for the specified context only, using the currently active policy. Use this to populate missing evaluation data for a specific context without affecting other contexts.",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "description": "Context to backfill and optional batch size",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BackfillRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Backfill started",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/BackfillResponseDto"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid context"
+          },
+          "404": {
+            "description": "No active policy found"
+          }
+        },
+        "tags": [
+          "Admin: Policy"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/admin/catalog-policies/dry-run": {
+      "post": {
+        "operationId": "DryRunController_executeDryRun",
+        "summary": "Execute dry-run evaluation",
+        "description": "Evaluates media items against a proposed policy WITHOUT persisting results. Supports multiple selection modes: sample (random), top (by popularity), byType, byCountry. Limits: max 10000 items, 60s timeout.",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DryRunRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/DryRunResponseDto"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Admin: Policy"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/admin/catalog-policies/dry-run/diff": {
+      "post": {
+        "operationId": "DryRunController_executeDryRunDiff",
+        "summary": "Execute dry-run with diff",
+        "description": "Same as dry-run but includes comparison against current active policy version.",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DryRunRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/DryRunResponseDto"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Admin: Policy"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/admin/providers": {
+      "get": {
+        "operationId": "ProvidersController_listProviders",
+        "summary": "List providers",
+        "description": "Returns all providers from the registry with their status.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/ProvidersListDto"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Admin: Providers"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/admin/providers/unmapped": {
+      "get": {
+        "operationId": "ProvidersController_listUnmapped",
+        "summary": "List unmapped providers",
+        "description": "Returns providers seen in TMDB data that have no mapping. Sorted by seen count descending.",
+        "parameters": [
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 20,
+              "type": "number"
+            }
+          },
+          {
+            "name": "offset",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 0,
+              "type": "number"
+            }
+          },
+          {
+            "name": "sortBy",
+            "required": false,
+            "in": "query",
+            "description": "Sort by field",
+            "schema": {
+              "default": "count",
+              "example": "count",
+              "enum": [
+                "count",
+                "lastSeen"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/UnmappedProvidersListDto"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Admin: Providers"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/admin/providers/mappings": {
+      "get": {
+        "operationId": "ProvidersController_listMappings",
+        "summary": "List mappings",
+        "description": "Returns all provider mappings. Can filter by provider or region.",
+        "parameters": [
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 20,
+              "type": "number"
+            }
+          },
+          {
+            "name": "offset",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 0,
+              "type": "number"
+            }
+          },
+          {
+            "name": "providerId",
+            "required": false,
+            "in": "query",
+            "description": "Filter by provider ID",
+            "schema": {
+              "example": "netflix",
+              "type": "string"
+            }
+          },
+          {
+            "name": "region",
+            "required": false,
+            "in": "query",
+            "description": "Filter by region",
+            "schema": {
+              "example": "US",
+              "type": "string"
+            }
+          },
+          {
+            "name": "includeGlobal",
+            "required": false,
+            "in": "query",
+            "description": "Include global mappings",
+            "schema": {
+              "example": true,
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/MappingsListDto"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Admin: Providers"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "post": {
+        "operationId": "ProvidersController_createMapping",
+        "summary": "Create mapping",
+        "description": "Creates a new TMDB to canonical provider mapping. After creation, affected media will be re-normalized on next sync.",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateMappingRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/MappingDto"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid provider ID or mapping already exists"
+          }
+        },
+        "tags": [
+          "Admin: Providers"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/admin/providers/mappings/{id}": {
+      "put": {
+        "operationId": "ProvidersController_updateMapping",
+        "summary": "Update mapping",
+        "description": "Updates an existing mapping. Only provided fields are updated.",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Mapping ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateMappingRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/MappingDto"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Mapping not found"
+          }
+        },
+        "tags": [
+          "Admin: Providers"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "ProvidersController_deleteMapping",
+        "summary": "Delete mapping",
+        "description": "Deletes a mapping. The TMDB provider will become unmapped again.",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Mapping ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Mapping deleted"
+          },
+          "404": {
+            "description": "Mapping not found"
+          }
+        },
+        "tags": [
+          "Admin: Providers"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/admin/providers/resolve": {
+      "get": {
+        "operationId": "ProvidersController_resolveProvider",
+        "summary": "Debug resolution",
+        "description": "Tests how a TMDB provider ID would be resolved to canonical provider. Useful for debugging mapping issues.",
+        "parameters": [
+          {
+            "name": "tmdbId",
+            "required": true,
+            "in": "query",
+            "description": "TMDB provider ID to resolve",
+            "schema": {
+              "example": 8,
+              "type": "number"
+            }
+          },
+          {
+            "name": "region",
+            "required": false,
+            "in": "query",
+            "description": "Region for resolution",
+            "schema": {
+              "example": "US",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/ResolveResultDto"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Admin: Providers"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/stats/sync": {
+      "post": {
+        "operationId": "StatsController_syncTrendingStats",
+        "summary": "Sync trending stats from Trakt",
+        "description": "Adds a job to the queue to fetch current watchers count and trending rank from Trakt API.",
+        "parameters": [
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Number of trending items to sync per type (movies + shows)",
+            "schema": {
+              "default": 100,
+              "example": 100,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "Admin: Stats"
+        ]
+      }
+    },
+    "/api/stats/sync-eligible-trending": {
+      "post": {
+        "operationId": "StatsController_syncEligibleTrending",
+        "summary": "Sync watchers for ELIGIBLE trending items",
+        "description": "Adds a job to the queue to sync watchers data for ELIGIBLE items in trending context. Use this to backfill watchers for items that are never in Trakt trending top-100.",
+        "parameters": [
+          {
+            "name": "batchSize",
+            "required": false,
+            "in": "query",
+            "description": "Number of items per batch",
+            "schema": {
+              "default": 50,
+              "example": 50,
+              "type": "number"
+            }
+          },
+          {
+            "name": "offset",
+            "required": false,
+            "in": "query",
+            "description": "Offset for pagination",
+            "schema": {
+              "default": 0,
+              "example": 0,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "Admin: Stats"
+        ]
+      }
+    },
+    "/api/stats/tmdb/{tmdbId}": {
+      "get": {
+        "operationId": "StatsController_getStatsByTmdbId",
+        "summary": "Get stats by TMDB ID",
+        "description": "Returns current watchers count and trending rank for a media item.",
+        "parameters": [
+          {
+            "name": "tmdbId",
+            "required": true,
+            "in": "path",
+            "description": "TMDB ID of the media item",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Public: Stats"
+        ]
+      }
+    },
+    "/api/stats/drop-off/analyze": {
+      "post": {
+        "operationId": "StatsController_analyzeDropOff",
+        "summary": "Analyze drop-off for shows",
+        "description": "Adds a job to analyze viewer drop-off for shows. Can analyze a single show or all shows.",
+        "parameters": [
+          {
+            "name": "tmdbId",
+            "required": false,
+            "in": "query",
+            "description": "TMDB ID of specific show to analyze",
+            "schema": {
+              "example": 12345,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Max shows to analyze",
+            "schema": {
+              "default": 50,
+              "example": 50,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "Admin: Stats"
+        ]
+      }
+    },
+    "/api/stats/drop-off/analyze/{tmdbId}": {
+      "post": {
+        "operationId": "StatsController_analyzeDropOffById",
+        "summary": "Analyze drop-off for a specific show",
+        "description": "Analyzes viewer drop-off for a single show by TMDB ID. Runs in background.",
+        "parameters": [
+          {
+            "name": "tmdbId",
+            "required": true,
+            "in": "path",
+            "description": "TMDB ID of the show to analyze",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "Admin: Stats"
+        ]
+      }
+    },
+    "/api/stats/drop-off/tmdb/{tmdbId}": {
+      "get": {
+        "operationId": "StatsController_getDropOffAnalysis",
+        "summary": "Get drop-off analysis for a show",
+        "description": "Returns pre-calculated drop-off analysis including drop-off point, engagement metrics, and insights.",
+        "parameters": [
+          {
+            "name": "tmdbId",
+            "required": true,
+            "in": "path",
+            "description": "TMDB ID of the show",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Public: Stats"
+        ]
+      }
+    },
+    "/api/stats/backfill/total-watchers": {
+      "post": {
+        "operationId": "StatsController_backfillTotalWatchers",
+        "summary": "Backfill total_watchers for corrupted items",
+        "description": "Finds items where total_watchers = 0 but have Trakt votes, then re-fetches from Trakt API.",
+        "parameters": [
+          {
+            "name": "type",
+            "required": false,
+            "in": "query",
+            "description": "Filter by media type",
+            "schema": {
+              "example": "show",
+              "enum": [
+                "movie",
+                "show"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Max items to backfill",
+            "schema": {
+              "default": 100,
+              "example": 100,
+              "type": "number"
+            }
+          },
+          {
+            "name": "minVotes",
+            "required": false,
+            "in": "query",
+            "description": "Minimum Trakt votes to consider item as corrupted",
+            "schema": {
+              "default": 100,
+              "example": 100,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "Admin: Stats"
+        ]
+      }
+    },
+    "/api/stats/backfill/watchers-count": {
+      "post": {
+        "operationId": "StatsController_backfillWatchersCount",
+        "summary": "Queue backfill jobs for watchers_count",
+        "description": "Finds items where watchers_count = 0 but total_watchers > threshold, then queues chunk jobs to re-fetch live watchers from Trakt API with proper rate limiting and exponential backoff.",
+        "parameters": [
+          {
+            "name": "type",
+            "required": false,
+            "in": "query",
+            "description": "Filter by media type",
+            "schema": {
+              "example": "show",
+              "enum": [
+                "movie",
+                "show"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Max items to backfill",
+            "schema": {
+              "default": 100,
+              "example": 100,
+              "type": "number"
+            }
+          },
+          {
+            "name": "minTotalWatchers",
+            "required": false,
+            "in": "query",
+            "description": "Minimum total_watchers to consider item as corrupted",
+            "schema": {
+              "default": 100,
+              "example": 100,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "Admin: Stats"
+        ]
+      }
+    },
+    "/api/stats/recalculate": {
+      "post": {
+        "operationId": "StatsController_recalculateScores",
+        "summary": "Recalculate scores for all media items",
+        "description": "Recalculates ratingo_score, quality_score, popularity_score, and freshness_score for all items. Use type=show to recalculate only shows.",
+        "parameters": [
+          {
+            "name": "type",
+            "required": false,
+            "in": "query",
+            "description": "Filter by media type",
+            "schema": {
+              "example": "show",
+              "enum": [
+                "movie",
+                "show"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "name": "batchSize",
+            "required": false,
+            "in": "query",
+            "description": "Number of items per batch",
+            "schema": {
+              "default": 100,
+              "example": 100,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "Admin: Stats"
+        ]
+      }
+    },
+    "/api/stats/reconcile-community-ratings": {
+      "post": {
+        "operationId": "StatsController_reconcileCommunityRatings",
+        "summary": "Reconcile community ratings",
+        "description": "Aggregates all user ratings and updates community_average_rating / community_rating_count in media_stats.",
+        "parameters": [],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "Admin: Stats"
+        ]
+      }
+    },
+    "/api/home/hero": {
+      "get": {
+        "operationId": "HomeController_getHero",
+        "summary": "Get Hero block items (Top 4 hottest media)",
+        "parameters": [
+          {
+            "name": "type",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "enum": [
+                "movie",
+                "show"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/HeroItemDto"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Public: Home"
+        ]
+      }
+    },
+    "/api/home/watching-now": {
+      "get": {
+        "operationId": "HomeController_getWatchingNow",
+        "summary": "Get \"Watching Now\" items (Top 3 fresh content by live watchers)",
+        "description": "Returns fresh content with most live Trakt watchers. Movies: released within 45 days. Shows: last episode within 21 days or has upcoming episode.",
+        "parameters": [],
+        "responses": {
+          "default": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/HeroItemDto"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Public: Home"
+        ]
+      }
+    },
+    "/api/insights/movements": {
+      "get": {
+        "operationId": "InsightsController_getMovements",
+        "summary": "Get biggest risers and fallers",
+        "description": "Returns media items with the biggest change in watchers count over the specified window.",
+        "parameters": [
+          {
+            "name": "window",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": "30d",
+              "enum": [
+                "30d",
+                "90d",
+                "365d"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 5,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/RiseFallResponseDto"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Public: Insights"
         ]
       }
     },
@@ -3835,7 +6799,7 @@
           }
         },
         "tags": [
-          "Users"
+          "Me: Profile"
         ],
         "security": [
           {
@@ -3863,7 +6827,7 @@
           }
         },
         "tags": [
-          "Users"
+          "Me: Profile"
         ],
         "security": [
           {
@@ -3918,7 +6882,7 @@
           }
         },
         "tags": [
-          "Users"
+          "Me: Profile"
         ],
         "security": [
           {
@@ -4185,2970 +7149,6 @@
         ]
       }
     },
-    "/api/me/notifications": {
-      "get": {
-        "operationId": "NotificationsController_list",
-        "summary": "List notifications (auth: Bearer)",
-        "parameters": [
-          {
-            "name": "limit",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "default": 20,
-              "type": "number"
-            }
-          },
-          {
-            "name": "offset",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "default": 0,
-              "type": "number"
-            }
-          },
-          {
-            "name": "unread",
-            "required": false,
-            "in": "query",
-            "description": "Filter by unread only",
-            "schema": {
-              "type": "boolean"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/NotificationListResponseDto"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Notifications"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/me/notifications/unread-count": {
-      "get": {
-        "operationId": "NotificationsController_getUnreadCount",
-        "summary": "Get unread notification count (auth: Bearer)",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/UnreadCountResponseDto"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Notifications"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/me/notifications/{notificationId}/read": {
-      "post": {
-        "operationId": "NotificationsController_markAsRead",
-        "summary": "Mark notification as read (auth: Bearer)",
-        "parameters": [
-          {
-            "name": "notificationId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/MarkReadResponseDto"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Notifications"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/me/notifications/read-all": {
-      "post": {
-        "operationId": "NotificationsController_markAllAsRead",
-        "summary": "Mark all notifications as read (auth: Bearer)",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/MarkReadResponseDto"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Notifications"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/me/saved-items/{mediaItemId}": {
-      "post": {
-        "operationId": "SavedItemsController_saveItem",
-        "summary": "Save media item to a list (auth: Bearer)",
-        "parameters": [
-          {
-            "name": "mediaItemId",
-            "required": true,
-            "in": "path",
-            "description": "Media item UUID",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SaveItemDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Item saved with current status",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/SaveActionResultDto"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Saved Items"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      },
-      "delete": {
-        "operationId": "SavedItemsController_unsaveItem",
-        "summary": "Remove media item from a list (auth: Bearer)",
-        "parameters": [
-          {
-            "name": "mediaItemId",
-            "required": true,
-            "in": "path",
-            "description": "Media item UUID",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UnsaveItemDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Item removed with current status",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/UnsaveActionResultDto"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Saved Items"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/me/saved-items/status/batch": {
-      "get": {
-        "operationId": "SavedItemsController_getBatchStatus",
-        "summary": "Get save status for multiple media items (auth: Bearer)",
-        "parameters": [
-          {
-            "name": "ids",
-            "required": true,
-            "in": "query",
-            "description": "Comma-separated list of media item UUIDs (max 100)",
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/BatchStatusResponseDto"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Saved Items"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/me/saved-items/{mediaItemId}/status": {
-      "get": {
-        "operationId": "SavedItemsController_getStatus",
-        "summary": "Get save status for media item (auth: Bearer)",
-        "parameters": [
-          {
-            "name": "mediaItemId",
-            "required": true,
-            "in": "path",
-            "description": "Media item UUID",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/MediaSaveStatusDto"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Saved Items"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/me/saved-items/for-later": {
-      "get": {
-        "operationId": "SavedItemsController_listForLater",
-        "summary": "List \"for later\" saved items (auth: Bearer)",
-        "parameters": [
-          {
-            "name": "limit",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "default": 20,
-              "type": "number"
-            }
-          },
-          {
-            "name": "offset",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "default": 0,
-              "type": "number"
-            }
-          },
-          {
-            "name": "type",
-            "required": false,
-            "in": "query",
-            "description": "Filter by media type",
-            "schema": {
-              "enum": [
-                "movie",
-                "show"
-              ],
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/SavedItemWithMediaResponseDto"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Saved Items"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/me/saved-items/considering": {
-      "get": {
-        "operationId": "SavedItemsController_listConsidering",
-        "summary": "List \"considering\" saved items (auth: Bearer)",
-        "parameters": [
-          {
-            "name": "limit",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "default": 20,
-              "type": "number"
-            }
-          },
-          {
-            "name": "offset",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "default": 0,
-              "type": "number"
-            }
-          },
-          {
-            "name": "type",
-            "required": false,
-            "in": "query",
-            "description": "Filter by media type",
-            "schema": {
-              "enum": [
-                "movie",
-                "show"
-              ],
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/SavedItemWithMediaResponseDto"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Saved Items"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/me/subscriptions/{mediaItemId}": {
-      "post": {
-        "operationId": "SubscriptionsController_subscribe",
-        "summary": "Subscribe to notifications for media item (auth: Bearer)",
-        "parameters": [
-          {
-            "name": "mediaItemId",
-            "required": true,
-            "in": "path",
-            "description": "Media item UUID",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SubscribeDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Subscribed with current status",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/SubscribeActionResultDto"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Subscriptions"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      },
-      "delete": {
-        "operationId": "SubscriptionsController_unsubscribe",
-        "summary": "Unsubscribe from notifications for media item (auth: Bearer)",
-        "parameters": [
-          {
-            "name": "mediaItemId",
-            "required": true,
-            "in": "path",
-            "description": "Media item UUID",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UnsubscribeDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Unsubscribed with current status",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/UnsubscribeActionResultDto"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Subscriptions"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/me/subscriptions/{mediaItemId}/status": {
-      "get": {
-        "operationId": "SubscriptionsController_getStatus",
-        "summary": "Get subscription status for media item (auth: Bearer)",
-        "parameters": [
-          {
-            "name": "mediaItemId",
-            "required": true,
-            "in": "path",
-            "description": "Media item UUID",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/MediaSubscriptionStatusDto"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Subscriptions"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/me/subscriptions": {
-      "get": {
-        "operationId": "SubscriptionsController_listActive",
-        "summary": "List active subscriptions (auth: Bearer)",
-        "parameters": [
-          {
-            "name": "limit",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "default": 20,
-              "type": "number"
-            }
-          },
-          {
-            "name": "offset",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "default": 0,
-              "type": "number"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/SubscriptionWithMediaResponseDto"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Subscriptions"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/ingestion/jobs/{id}": {
-      "get": {
-        "operationId": "IngestionController_getJobStatus",
-        "summary": "Get ingestion job status",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Ingestion job status",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "properties": {
-                        "id": {
-                          "type": "string"
-                        },
-                        "status": {
-                          "type": "string",
-                          "enum": [
-                            "queued",
-                            "processing",
-                            "ready",
-                            "failed"
-                          ]
-                        },
-                        "errorMessage": {
-                          "type": "string",
-                          "nullable": true
-                        },
-                        "updatedAt": {
-                          "type": "string",
-                          "format": "date-time",
-                          "nullable": true
-                        },
-                        "slug": {
-                          "type": "string",
-                          "nullable": true,
-                          "description": "Media slug (available when status is ready)"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Service: Ingestion"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/ingestion/sync": {
-      "post": {
-        "operationId": "IngestionController_sync",
-        "summary": "Manually trigger sync for a specific media item",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SyncDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "202": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "Service: Ingestion"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/ingestion/trending": {
-      "post": {
-        "operationId": "IngestionController_syncTrending",
-        "summary": "Trigger sync for trending movies and shows",
-        "description": "Syncs trending content from TMDB using dispatcher pattern. Queues page jobs for movies and shows. With syncStats=true (default), also updates Trakt stats after ingestion.",
-        "parameters": [
-          {
-            "name": "pages",
-            "required": false,
-            "in": "query",
-            "description": "Number of pages to fetch in dispatcher mode (20 items per page)",
-            "schema": {
-              "minimum": 1,
-              "maximum": 50,
-              "example": 5,
-              "type": "number"
-            }
-          },
-          {
-            "name": "type",
-            "required": false,
-            "in": "query",
-            "description": "Media type filter — sync only movies or only shows",
-            "schema": {
-              "example": "movie",
-              "enum": [
-                "movie",
-                "show"
-              ],
-              "type": "string"
-            }
-          },
-          {
-            "name": "page",
-            "required": false,
-            "in": "query",
-            "description": "Single page number (legacy mode)",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "syncStats",
-            "required": false,
-            "in": "query",
-            "description": "Sync Trakt stats after ingestion (default: true)",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "force",
-            "required": false,
-            "in": "query",
-            "description": "Bypass dedupe",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SyncTrendingDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "202": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "Service: Ingestion"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/ingestion/movies/now-playing": {
-      "post": {
-        "operationId": "IngestionController_syncNowPlaying",
-        "summary": "Sync movies currently in theaters (ingestion only)",
-        "description": "Fetches now playing movies from TMDB and queues them for sync. Does NOT update isNowPlaying flags - use /ingestion/movies/now-playing-flags for that.",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SyncNowPlayingDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "202": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "Service: Ingestion"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/ingestion/movies/now-playing-flags": {
-      "post": {
-        "operationId": "IngestionController_updateNowPlayingFlags",
-        "summary": "Update isNowPlaying flags for movies",
-        "description": "Updates isNowPlaying flags based on current TMDB now_playing list. Run this AFTER now-playing sync has completed.",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SyncNowPlayingDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "202": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "Service: Ingestion"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/ingestion/movies/new-releases": {
-      "post": {
-        "operationId": "IngestionController_syncNewReleases",
-        "summary": "Sync new theatrical movie releases",
-        "description": "Fetches movies released in theaters within the specified period and syncs them.",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SyncNewReleasesDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "202": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "Service: Ingestion"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/ingestion/snapshots": {
-      "post": {
-        "operationId": "IngestionController_syncSnapshots",
-        "summary": "Trigger daily watchers snapshots sync",
-        "description": "Updates daily watcher counts for all media items from Trakt.",
-        "parameters": [
-          {
-            "name": "region",
-            "required": false,
-            "in": "query",
-            "description": "Region code for snapshots",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "force",
-            "required": false,
-            "in": "query",
-            "description": "Bypass daily deduplication",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "202": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "Service: Ingestion"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/ingestion/shows/tracked": {
-      "post": {
-        "operationId": "IngestionController_syncTrackedShows",
-        "summary": "Trigger tracked shows sync",
-        "description": "Syncs shows that have active subscriptions. Detects new episodes/seasons and triggers notifications.",
-        "parameters": [
-          {
-            "name": "force",
-            "required": false,
-            "in": "query",
-            "description": "Bypass hourly deduplication",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "202": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "Service: Ingestion"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/ingestion/backfill/imdb": {
-      "post": {
-        "operationId": "IngestionController_backfillImdb",
-        "summary": "Re-sync shows missing IMDb ID",
-        "description": "Finds all shows with missing IMDb ID and performs full re-sync. This fetches external_ids from TMDB (including imdb_id), then enriches each show with Trakt stats (watchers, ratings) and OMDb ratings (IMDb, Rotten Tomatoes, Metacritic). Use when shows were imported before external_ids fetching was implemented.",
-        "parameters": [
-          {
-            "name": "force",
-            "required": false,
-            "in": "query",
-            "description": "Bypass daily deduplication",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Backfill job queued",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/IngestionJobResponseDto"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Service: Ingestion"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/ingestion/backfill/alt-titles": {
-      "post": {
-        "operationId": "IngestionController_backfillAltTitles",
-        "summary": "Backfill alternative titles from TMDB",
-        "description": "Finds all media items with missing alternative titles and fetches them from TMDB. Uses dedicated lightweight TMDB endpoints — no Trakt, OMDb, or TVMaze calls. One-time operation; future syncs populate alt titles automatically.",
-        "parameters": [
-          {
-            "name": "force",
-            "required": false,
-            "in": "query",
-            "description": "Re-fetch alt titles for items that already have them",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Backfill job queued",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/IngestionJobResponseDto"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Service: Ingestion"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/ingestion/backfill/mdblist-ratings": {
-      "post": {
-        "operationId": "IngestionController_backfillMdblistRatings",
-        "summary": "Backfill Rotten Tomatoes ratings from MDBList (admin-only)",
-        "description": "Admin-only. Finds media items where either Rotten Tomatoes critics score or audience score is missing, or whose last MDBList check is older than the refresh window (rtFetchedAt > 90 days), and fetches critics + audience ratings from MDBList. Complements OMDb, which frequently omits RT values. Item jobs run on a dedicated rate-limited queue; dispatcher enforces an app-side daily cap of 900 items per run to fit the MDBList free-tier budget (1000 req/day; worker limiter ~40/hour).",
-        "parameters": [
-          {
-            "name": "force",
-            "required": false,
-            "in": "query",
-            "description": "Bypass daily deduplication (allows re-running within the same UTC day)",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Backfill job queued",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/IngestionJobResponseDto"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Missing or invalid bearer token"
-          },
-          "403": {
-            "description": "Authenticated user does not have admin role"
-          }
-        },
-        "tags": [
-          "Service: Ingestion"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/admin/catalog-policies": {
-      "get": {
-        "operationId": "PolicyController_getPolicies",
-        "summary": "Get list of policies",
-        "description": "Returns list of all catalog policies with their status and metadata.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "List of policies",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/PoliciesListDto"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Admin - Policy Activation"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      },
-      "post": {
-        "operationId": "PolicyController_createPolicy",
-        "summary": "Create new policy",
-        "description": "Creates a new policy draft with auto-incremented version. The policy is NOT activated automatically. Use POST /:id/prepare to start evaluation.",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "description": "Policy configuration",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreatePolicyDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Policy created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/CreatePolicyResponseDto"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Admin - Policy Activation"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/admin/catalog-policies/{id}": {
-      "get": {
-        "operationId": "PolicyController_getPolicyById",
-        "summary": "Get policy details",
-        "description": "Returns a single policy with full configuration settings.",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "description": "Policy ID",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Policy details",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/PolicyDetailDto"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Policy not found"
-          }
-        },
-        "tags": [
-          "Admin - Policy Activation"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/admin/catalog-policies/{id}/prepare": {
-      "post": {
-        "operationId": "PolicyController_preparePolicy",
-        "summary": "Prepare policy for activation",
-        "description": "Creates an evaluation run and starts background job to pre-compute evaluations for all media items. Returns immediately with run ID for tracking progress.",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "description": "Policy ID to prepare",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": false,
-          "description": "Optional batch size and concurrency settings",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PrepareOptionsDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "202": {
-            "description": "Policy preparation started",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/PrepareResponseDto"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Admin - Policy Activation"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/admin/catalog-policies/runs": {
-      "get": {
-        "operationId": "RunController_getRuns",
-        "summary": "Get list of evaluation runs",
-        "description": "Returns list of all evaluation runs with their status and progress.",
-        "parameters": [
-          {
-            "name": "limit",
-            "required": false,
-            "in": "query",
-            "description": "Number of runs to return (default: 20)",
-            "schema": {
-              "type": "number"
-            }
-          },
-          {
-            "name": "offset",
-            "required": false,
-            "in": "query",
-            "description": "Offset for pagination (default: 0)",
-            "schema": {
-              "type": "number"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "List of evaluation runs",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/RunsListDto"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Admin - Policy Activation"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/admin/catalog-policies/runs/{runId}": {
-      "get": {
-        "operationId": "RunController_getRunStatus",
-        "summary": "Get run status and progress",
-        "description": "Returns detailed status of an evaluation run including progress, counters, and readyToPromote flag.",
-        "parameters": [
-          {
-            "name": "runId",
-            "required": true,
-            "in": "path",
-            "description": "Run ID to check",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Run status and progress",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/RunStatusDto"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Admin - Policy Activation"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/admin/catalog-policies/runs/{runId}/promote": {
-      "post": {
-        "operationId": "RunController_promoteRun",
-        "summary": "Promote run to activate policy",
-        "description": "Verifies run is successful and meets thresholds, then atomically activates the policy. This makes the new policy version active for the public catalog.",
-        "parameters": [
-          {
-            "name": "runId",
-            "required": true,
-            "in": "path",
-            "description": "Run ID to promote",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": false,
-          "description": "Optional coverage and error thresholds (defaults: 100% coverage, 0 errors)",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PromoteOptionsDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Promotion result",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/ActionResponseDto"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Admin - Policy Activation"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/admin/catalog-policies/runs/{runId}/cancel": {
-      "post": {
-        "operationId": "RunController_cancelRun",
-        "summary": "Cancel running evaluation",
-        "description": "Cancels a running evaluation. Item jobs already in queue will be skipped. Preserves cursor and counters for potential resume.",
-        "parameters": [
-          {
-            "name": "runId",
-            "required": true,
-            "in": "path",
-            "description": "Run ID to cancel",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": "Cancellation result",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/ActionResponseDto"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Admin - Policy Activation"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/admin/catalog-policies/runs/{runId}/diff": {
-      "get": {
-        "operationId": "RunController_getDiff",
-        "summary": "Get diff report",
-        "description": "Computes differences between current active policy and the prepared run. Shows regressions (items leaving catalog) and improvements (items entering catalog).",
-        "parameters": [
-          {
-            "name": "runId",
-            "required": true,
-            "in": "path",
-            "description": "Run ID to compute diff for",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "sampleSize",
-            "required": false,
-            "in": "query",
-            "description": "Number of sample items to return (default: 50)",
-            "schema": {
-              "type": "number"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Diff report",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/DiffReportDto"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Admin - Policy Activation"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/admin/catalog-policies/runs/backfill": {
-      "post": {
-        "operationId": "RunController_backfillContext",
-        "summary": "Backfill evaluations for a specific context",
-        "description": "Triggers re-evaluation for the specified context only, using the currently active policy. Use this to populate missing evaluation data for a specific context without affecting other contexts.",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "description": "Context to backfill and optional batch size",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BackfillRequestDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Backfill started",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/BackfillResponseDto"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid context"
-          },
-          "404": {
-            "description": "No active policy found"
-          }
-        },
-        "tags": [
-          "Admin - Policy Activation"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/admin/catalog-policies/dry-run": {
-      "post": {
-        "operationId": "DryRunController_executeDryRun",
-        "summary": "Execute dry-run evaluation",
-        "description": "Evaluates media items against a proposed policy WITHOUT persisting results. Supports multiple selection modes: sample (random), top (by popularity), byType, byCountry. Limits: max 10000 items, 60s timeout.",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/DryRunRequestDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/DryRunResponseDto"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Admin - Policy Activation"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/admin/catalog-policies/dry-run/diff": {
-      "post": {
-        "operationId": "DryRunController_executeDryRunDiff",
-        "summary": "Execute dry-run with diff",
-        "description": "Same as dry-run but includes comparison against current active policy version.",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/DryRunRequestDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/DryRunResponseDto"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Admin - Policy Activation"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/admin/providers": {
-      "get": {
-        "operationId": "ProvidersController_listProviders",
-        "summary": "List providers",
-        "description": "Returns all providers from the registry with their status.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/ProvidersListDto"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Admin - Providers"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/admin/providers/unmapped": {
-      "get": {
-        "operationId": "ProvidersController_listUnmapped",
-        "summary": "List unmapped providers",
-        "description": "Returns providers seen in TMDB data that have no mapping. Sorted by seen count descending.",
-        "parameters": [
-          {
-            "name": "limit",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "default": 20,
-              "type": "number"
-            }
-          },
-          {
-            "name": "offset",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "default": 0,
-              "type": "number"
-            }
-          },
-          {
-            "name": "sortBy",
-            "required": false,
-            "in": "query",
-            "description": "Sort by field",
-            "schema": {
-              "default": "count",
-              "example": "count",
-              "enum": [
-                "count",
-                "lastSeen"
-              ],
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/UnmappedProvidersListDto"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Admin - Providers"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/admin/providers/mappings": {
-      "get": {
-        "operationId": "ProvidersController_listMappings",
-        "summary": "List mappings",
-        "description": "Returns all provider mappings. Can filter by provider or region.",
-        "parameters": [
-          {
-            "name": "limit",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "default": 20,
-              "type": "number"
-            }
-          },
-          {
-            "name": "offset",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "default": 0,
-              "type": "number"
-            }
-          },
-          {
-            "name": "providerId",
-            "required": false,
-            "in": "query",
-            "description": "Filter by provider ID",
-            "schema": {
-              "example": "netflix",
-              "type": "string"
-            }
-          },
-          {
-            "name": "region",
-            "required": false,
-            "in": "query",
-            "description": "Filter by region",
-            "schema": {
-              "example": "US",
-              "type": "string"
-            }
-          },
-          {
-            "name": "includeGlobal",
-            "required": false,
-            "in": "query",
-            "description": "Include global mappings",
-            "schema": {
-              "example": true,
-              "type": "boolean"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/MappingsListDto"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Admin - Providers"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      },
-      "post": {
-        "operationId": "ProvidersController_createMapping",
-        "summary": "Create mapping",
-        "description": "Creates a new TMDB to canonical provider mapping. After creation, affected media will be re-normalized on next sync.",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateMappingRequestDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/MappingDto"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid provider ID or mapping already exists"
-          }
-        },
-        "tags": [
-          "Admin - Providers"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/admin/providers/mappings/{id}": {
-      "put": {
-        "operationId": "ProvidersController_updateMapping",
-        "summary": "Update mapping",
-        "description": "Updates an existing mapping. Only provided fields are updated.",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "description": "Mapping ID",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateMappingRequestDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/MappingDto"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Mapping not found"
-          }
-        },
-        "tags": [
-          "Admin - Providers"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      },
-      "delete": {
-        "operationId": "ProvidersController_deleteMapping",
-        "summary": "Delete mapping",
-        "description": "Deletes a mapping. The TMDB provider will become unmapped again.",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "description": "Mapping ID",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Mapping deleted"
-          },
-          "404": {
-            "description": "Mapping not found"
-          }
-        },
-        "tags": [
-          "Admin - Providers"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/admin/providers/resolve": {
-      "get": {
-        "operationId": "ProvidersController_resolveProvider",
-        "summary": "Debug resolution",
-        "description": "Tests how a TMDB provider ID would be resolved to canonical provider. Useful for debugging mapping issues.",
-        "parameters": [
-          {
-            "name": "tmdbId",
-            "required": true,
-            "in": "query",
-            "description": "TMDB provider ID to resolve",
-            "schema": {
-              "example": 8,
-              "type": "number"
-            }
-          },
-          {
-            "name": "region",
-            "required": false,
-            "in": "query",
-            "description": "Region for resolution",
-            "schema": {
-              "example": "US",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/ResolveResultDto"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Admin - Providers"
-        ],
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/stats/sync": {
-      "post": {
-        "operationId": "StatsController_syncTrendingStats",
-        "summary": "Sync trending stats from Trakt",
-        "description": "Adds a job to the queue to fetch current watchers count and trending rank from Trakt API.",
-        "parameters": [
-          {
-            "name": "limit",
-            "required": false,
-            "in": "query",
-            "description": "Number of trending items to sync per type (movies + shows)",
-            "schema": {
-              "default": 100,
-              "example": 100,
-              "type": "number"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "bearer": []
-          }
-        ],
-        "tags": [
-          "Service: Stats"
-        ]
-      }
-    },
-    "/api/stats/sync-eligible-trending": {
-      "post": {
-        "operationId": "StatsController_syncEligibleTrending",
-        "summary": "Sync watchers for ELIGIBLE trending items",
-        "description": "Adds a job to the queue to sync watchers data for ELIGIBLE items in trending context. Use this to backfill watchers for items that are never in Trakt trending top-100.",
-        "parameters": [
-          {
-            "name": "batchSize",
-            "required": false,
-            "in": "query",
-            "description": "Number of items per batch",
-            "schema": {
-              "default": 50,
-              "example": 50,
-              "type": "number"
-            }
-          },
-          {
-            "name": "offset",
-            "required": false,
-            "in": "query",
-            "description": "Offset for pagination",
-            "schema": {
-              "default": 0,
-              "example": 0,
-              "type": "number"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "bearer": []
-          }
-        ],
-        "tags": [
-          "Service: Stats"
-        ]
-      }
-    },
-    "/api/stats/tmdb/{tmdbId}": {
-      "get": {
-        "operationId": "StatsController_getStatsByTmdbId",
-        "summary": "Get stats by TMDB ID",
-        "description": "Returns current watchers count and trending rank for a media item.",
-        "parameters": [
-          {
-            "name": "tmdbId",
-            "required": true,
-            "in": "path",
-            "description": "TMDB ID of the media item",
-            "schema": {
-              "type": "number"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "Public: Stats"
-        ]
-      }
-    },
-    "/api/stats/drop-off/analyze": {
-      "post": {
-        "operationId": "StatsController_analyzeDropOff",
-        "summary": "Analyze drop-off for shows",
-        "description": "Adds a job to analyze viewer drop-off for shows. Can analyze a single show or all shows.",
-        "parameters": [
-          {
-            "name": "tmdbId",
-            "required": false,
-            "in": "query",
-            "description": "TMDB ID of specific show to analyze",
-            "schema": {
-              "example": 12345,
-              "type": "number"
-            }
-          },
-          {
-            "name": "limit",
-            "required": false,
-            "in": "query",
-            "description": "Max shows to analyze",
-            "schema": {
-              "default": 50,
-              "example": 50,
-              "type": "number"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "bearer": []
-          }
-        ],
-        "tags": [
-          "Service: Stats"
-        ]
-      }
-    },
-    "/api/stats/drop-off/analyze/{tmdbId}": {
-      "post": {
-        "operationId": "StatsController_analyzeDropOffById",
-        "summary": "Analyze drop-off for a specific show",
-        "description": "Analyzes viewer drop-off for a single show by TMDB ID. Runs in background.",
-        "parameters": [
-          {
-            "name": "tmdbId",
-            "required": true,
-            "in": "path",
-            "description": "TMDB ID of the show to analyze",
-            "schema": {
-              "type": "number"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "bearer": []
-          }
-        ],
-        "tags": [
-          "Service: Stats"
-        ]
-      }
-    },
-    "/api/stats/drop-off/tmdb/{tmdbId}": {
-      "get": {
-        "operationId": "StatsController_getDropOffAnalysis",
-        "summary": "Get drop-off analysis for a show",
-        "description": "Returns pre-calculated drop-off analysis including drop-off point, engagement metrics, and insights.",
-        "parameters": [
-          {
-            "name": "tmdbId",
-            "required": true,
-            "in": "path",
-            "description": "TMDB ID of the show",
-            "schema": {
-              "type": "number"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "Public: Stats"
-        ]
-      }
-    },
-    "/api/stats/backfill/total-watchers": {
-      "post": {
-        "operationId": "StatsController_backfillTotalWatchers",
-        "summary": "Backfill total_watchers for corrupted items",
-        "description": "Finds items where total_watchers = 0 but have Trakt votes, then re-fetches from Trakt API.",
-        "parameters": [
-          {
-            "name": "type",
-            "required": false,
-            "in": "query",
-            "description": "Filter by media type",
-            "schema": {
-              "example": "show",
-              "enum": [
-                "movie",
-                "show"
-              ],
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "required": false,
-            "in": "query",
-            "description": "Max items to backfill",
-            "schema": {
-              "default": 100,
-              "example": 100,
-              "type": "number"
-            }
-          },
-          {
-            "name": "minVotes",
-            "required": false,
-            "in": "query",
-            "description": "Minimum Trakt votes to consider item as corrupted",
-            "schema": {
-              "default": 100,
-              "example": 100,
-              "type": "number"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "bearer": []
-          }
-        ],
-        "tags": [
-          "Service: Stats"
-        ]
-      }
-    },
-    "/api/stats/backfill/watchers-count": {
-      "post": {
-        "operationId": "StatsController_backfillWatchersCount",
-        "summary": "Queue backfill jobs for watchers_count",
-        "description": "Finds items where watchers_count = 0 but total_watchers > threshold, then queues chunk jobs to re-fetch live watchers from Trakt API with proper rate limiting and exponential backoff.",
-        "parameters": [
-          {
-            "name": "type",
-            "required": false,
-            "in": "query",
-            "description": "Filter by media type",
-            "schema": {
-              "example": "show",
-              "enum": [
-                "movie",
-                "show"
-              ],
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "required": false,
-            "in": "query",
-            "description": "Max items to backfill",
-            "schema": {
-              "default": 100,
-              "example": 100,
-              "type": "number"
-            }
-          },
-          {
-            "name": "minTotalWatchers",
-            "required": false,
-            "in": "query",
-            "description": "Minimum total_watchers to consider item as corrupted",
-            "schema": {
-              "default": 100,
-              "example": 100,
-              "type": "number"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "bearer": []
-          }
-        ],
-        "tags": [
-          "Service: Stats"
-        ]
-      }
-    },
-    "/api/stats/recalculate": {
-      "post": {
-        "operationId": "StatsController_recalculateScores",
-        "summary": "Recalculate scores for all media items",
-        "description": "Recalculates ratingo_score, quality_score, popularity_score, and freshness_score for all items. Use type=show to recalculate only shows.",
-        "parameters": [
-          {
-            "name": "type",
-            "required": false,
-            "in": "query",
-            "description": "Filter by media type",
-            "schema": {
-              "example": "show",
-              "enum": [
-                "movie",
-                "show"
-              ],
-              "type": "string"
-            }
-          },
-          {
-            "name": "batchSize",
-            "required": false,
-            "in": "query",
-            "description": "Number of items per batch",
-            "schema": {
-              "default": 100,
-              "example": 100,
-              "type": "number"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "bearer": []
-          }
-        ],
-        "tags": [
-          "Service: Stats"
-        ]
-      }
-    },
-    "/api/stats/reconcile-community-ratings": {
-      "post": {
-        "operationId": "StatsController_reconcileCommunityRatings",
-        "summary": "Reconcile community ratings",
-        "description": "Aggregates all user ratings and updates community_average_rating / community_rating_count in media_stats.",
-        "parameters": [],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "bearer": []
-          }
-        ],
-        "tags": [
-          "Service: Stats"
-        ]
-      }
-    },
-    "/api/home/hero": {
-      "get": {
-        "operationId": "HomeController_getHero",
-        "summary": "Get Hero block items (Top 4 hottest media)",
-        "parameters": [
-          {
-            "name": "type",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "enum": [
-                "movie",
-                "show"
-              ],
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/HeroItemDto"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Home"
-        ]
-      }
-    },
-    "/api/home/watching-now": {
-      "get": {
-        "operationId": "HomeController_getWatchingNow",
-        "summary": "Get \"Watching Now\" items (Top 3 fresh content by live watchers)",
-        "description": "Returns fresh content with most live Trakt watchers. Movies: released within 45 days. Shows: last episode within 21 days or has upcoming episode.",
-        "parameters": [],
-        "responses": {
-          "default": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/HeroItemDto"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Home"
-        ]
-      }
-    },
-    "/api/insights/movements": {
-      "get": {
-        "operationId": "InsightsController_getMovements",
-        "summary": "Get biggest risers and fallers",
-        "description": "Returns media items with the biggest change in watchers count over the specified window.",
-        "parameters": [
-          {
-            "name": "window",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "default": "30d",
-              "enum": [
-                "30d",
-                "90d",
-                "365d"
-              ],
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "default": 5,
-              "type": "number"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "data"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "enum": [
-                        true
-                      ]
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/RiseFallResponseDto"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Public: Insights"
-        ]
-      }
-    },
     "/api/journal/posts": {
       "get": {
         "operationId": "JournalPostsController_getPosts",
@@ -7375,7 +7375,7 @@
           }
         },
         "tags": [
-          "Admin - Journal"
+          "Admin: Journal"
         ],
         "security": [
           {
@@ -7426,7 +7426,7 @@
           }
         },
         "tags": [
-          "Admin - Journal"
+          "Admin: Journal"
         ],
         "security": [
           {
@@ -7479,7 +7479,7 @@
           }
         },
         "tags": [
-          "Admin - Journal"
+          "Admin: Journal"
         ],
         "security": [
           {
@@ -7540,7 +7540,7 @@
           }
         },
         "tags": [
-          "Admin - Journal"
+          "Admin: Journal"
         ],
         "security": [
           {
@@ -7596,7 +7596,7 @@
           }
         },
         "tags": [
-          "Admin - Journal"
+          "Admin: Journal"
         ],
         "security": [
           {
@@ -7649,7 +7649,7 @@
           }
         },
         "tags": [
-          "Admin - Journal"
+          "Admin: Journal"
         ],
         "security": [
           {
@@ -7702,7 +7702,7 @@
           }
         },
         "tags": [
-          "Admin - Journal"
+          "Admin: Journal"
         ],
         "security": [
           {
@@ -7765,7 +7765,7 @@
           }
         },
         "tags": [
-          "Admin - Journal"
+          "Admin: Journal"
         ],
         "security": [
           {
@@ -8049,7 +8049,7 @@
           }
         },
         "tags": [
-          "User: Reviews"
+          "Me: Reviews"
         ],
         "security": [
           {
@@ -8101,7 +8101,7 @@
           }
         },
         "tags": [
-          "User: Reviews"
+          "Me: Reviews"
         ],
         "security": [
           {
@@ -8163,7 +8163,7 @@
           }
         },
         "tags": [
-          "User: Reviews"
+          "Me: Reviews"
         ],
         "security": [
           {
@@ -8191,7 +8191,7 @@
           }
         },
         "tags": [
-          "User: Reviews"
+          "Me: Reviews"
         ],
         "security": [
           {
@@ -8253,7 +8253,7 @@
           }
         },
         "tags": [
-          "User: Reviews"
+          "Me: Reviews"
         ],
         "security": [
           {
@@ -8303,7 +8303,7 @@
           }
         },
         "tags": [
-          "User: Reviews"
+          "Me: Reviews"
         ],
         "security": [
           {
@@ -8365,7 +8365,7 @@
           }
         },
         "tags": [
-          "User: Reviews"
+          "Me: Reviews"
         ],
         "security": [
           {
@@ -8395,7 +8395,7 @@
           }
         },
         "tags": [
-          "User: Reviews"
+          "Me: Reviews"
         ],
         "security": [
           {
@@ -8457,7 +8457,7 @@
           }
         },
         "tags": [
-          "User: Reviews"
+          "Me: Reviews"
         ],
         "security": [
           {
@@ -8536,7 +8536,7 @@
           }
         },
         "tags": [
-          "Admin - Reviews"
+          "Admin: Reviews"
         ],
         "security": [
           {
@@ -8604,7 +8604,7 @@
           }
         },
         "tags": [
-          "Admin - Reviews"
+          "Admin: Reviews"
         ],
         "security": [
           {
@@ -8662,7 +8662,7 @@
           }
         },
         "tags": [
-          "Admin - Reviews"
+          "Admin: Reviews"
         ],
         "security": [
           {
@@ -8674,11 +8674,100 @@
   },
   "info": {
     "title": "Ratingo API",
-    "description": "Rest API for Ratingo mobile and web clients",
+    "description": "REST API for Ratingo mobile and web clients.\n\nEndpoints are grouped by audience: **Public** (no auth), **Me** (authenticated user, Bearer JWT), **Admin** (admin role required).\n\nAll responses are wrapped: `{ success: true, data }` on success, `{ success: false, error: { code, message } }` on failure.",
     "version": "2.0",
     "contact": {}
   },
-  "tags": [],
+  "tags": [
+    {
+      "name": "Auth",
+      "description": "Registration, login, OAuth, token refresh"
+    },
+    {
+      "name": "Public: Catalog",
+      "description": "Movies, shows, search, providers, sitemap"
+    },
+    {
+      "name": "Public: Home",
+      "description": "Homepage sections"
+    },
+    {
+      "name": "Public: Users",
+      "description": "Public user profiles"
+    },
+    {
+      "name": "Public: Reviews",
+      "description": "Reviews for a title"
+    },
+    {
+      "name": "Public: Journal",
+      "description": "Editorial posts"
+    },
+    {
+      "name": "Public: Stats",
+      "description": "Watchers and drop-off stats for a title"
+    },
+    {
+      "name": "Public: Insights",
+      "description": "Trends and movements"
+    },
+    {
+      "name": "Me: Profile",
+      "description": "Own profile and avatar"
+    },
+    {
+      "name": "Me: Library",
+      "description": "Watch states and ratings"
+    },
+    {
+      "name": "Me: Lists",
+      "description": "Watchlist, history, favorites"
+    },
+    {
+      "name": "Me: Episode Progress",
+      "description": "Per-episode watch progress"
+    },
+    {
+      "name": "Me: Reviews",
+      "description": "Own reviews"
+    },
+    {
+      "name": "Me: Subscriptions",
+      "description": "Show subscriptions and triggers"
+    },
+    {
+      "name": "Me: Saved Items",
+      "description": "Saved items"
+    },
+    {
+      "name": "Me: Notifications",
+      "description": "Notification feed"
+    },
+    {
+      "name": "Admin: Journal",
+      "description": "Editorial post management"
+    },
+    {
+      "name": "Admin: Reviews",
+      "description": "Review moderation"
+    },
+    {
+      "name": "Admin: Providers",
+      "description": "Watch-provider mappings"
+    },
+    {
+      "name": "Admin: Policy",
+      "description": "Catalog policy configuration and dry-runs"
+    },
+    {
+      "name": "Admin: Ingestion",
+      "description": "Sync and backfill jobs"
+    },
+    {
+      "name": "Admin: Stats",
+      "description": "Stats sync, recalculation, backfills"
+    }
+  ],
   "servers": [],
   "components": {
     "securitySchemes": {
@@ -11483,534 +11572,6 @@
           "watchedEpisodeIds"
         ]
       },
-      "RegisterDto": {
-        "type": "object",
-        "properties": {
-          "email": {
-            "type": "string",
-            "example": "user@example.com"
-          },
-          "username": {
-            "type": "string",
-            "example": "ratingo_fan"
-          },
-          "password": {
-            "type": "string",
-            "example": "S3curePassw0rd"
-          },
-          "avatarUrl": {
-            "type": "string",
-            "example": "https://cdn.example.com/avatar.png"
-          }
-        },
-        "required": [
-          "email",
-          "username",
-          "password"
-        ]
-      },
-      "AuthTokensDto": {
-        "type": "object",
-        "properties": {
-          "accessToken": {
-            "type": "string",
-            "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2YmQ1NGU2Mi1iYWMzLTQ5ZGQtYTBkNC0wNWVmZDc3NjE3MDAiLCJlbWFpbCI6InVzZXJAZXhhbXBsZS5jb20iLCJyb2xlIjoidXNlciIsImlhdCI6MTc2NTQ1ODE3NCwiZXhwIjoxNzY1NDU5MDc0fQ.JYlxU9C9P_DJOJTeN_tosd5Dds5H5u3U9_y_AQdLtDU",
-            "description": "JWT access token"
-          },
-          "refreshToken": {
-            "type": "string",
-            "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2YmQ1NGU2Mi1iYWMzLTQ5ZGQtYTBkNC0wNWVmZDc3NjE3MDAiLCJqdGkiOiJmYmUwYTQxOC05ZWVkLTRjNmEtOTU2MS00MDRmZDFiMTFhOTciLCJ0eXBlIjoicmVmcmVzaCIsImlhdCI6MTc2NTQ1ODE3NCwiZXhwIjoxNzY4MDUwMTc0fQ.Jra2xAp4OeKcm5ZSalwwMrqwoQngn8Js9ql_rK0VjFQ",
-            "description": "Refresh token"
-          }
-        },
-        "required": [
-          "accessToken",
-          "refreshToken"
-        ]
-      },
-      "LoginDto": {
-        "type": "object",
-        "properties": {
-          "email": {
-            "type": "string",
-            "example": "user@example.com"
-          },
-          "password": {
-            "type": "string",
-            "example": "S3curePassw0rd"
-          }
-        },
-        "required": [
-          "email",
-          "password"
-        ]
-      },
-      "RefreshDto": {
-        "type": "object",
-        "properties": {
-          "refreshToken": {
-            "type": "string",
-            "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
-          }
-        },
-        "required": [
-          "refreshToken"
-        ]
-      },
-      "ChangePasswordDto": {
-        "type": "object",
-        "properties": {
-          "currentPassword": {
-            "type": "string",
-            "example": "OldPass123"
-          },
-          "newPassword": {
-            "type": "string",
-            "example": "NewPass456"
-          }
-        },
-        "required": [
-          "currentPassword",
-          "newPassword"
-        ]
-      },
-      "PrivacyDto": {
-        "type": "object",
-        "properties": {
-          "isProfilePublic": {
-            "type": "boolean",
-            "example": true
-          },
-          "showWatchHistory": {
-            "type": "boolean",
-            "example": false
-          },
-          "showRatings": {
-            "type": "boolean",
-            "example": true
-          },
-          "allowFollowers": {
-            "type": "boolean",
-            "example": true
-          },
-          "autoSubscribeOnWatch": {
-            "type": "boolean",
-            "example": true
-          }
-        },
-        "required": [
-          "isProfilePublic",
-          "showWatchHistory",
-          "showRatings",
-          "allowFollowers",
-          "autoSubscribeOnWatch"
-        ]
-      },
-      "ProfileDto": {
-        "type": "object",
-        "properties": {
-          "bio": {
-            "type": "string",
-            "example": "Люблю жахи та sci-fi",
-            "nullable": true
-          },
-          "location": {
-            "type": "string",
-            "example": "Kyiv",
-            "nullable": true
-          },
-          "website": {
-            "type": "string",
-            "example": "https://instagram.com/me",
-            "nullable": true
-          },
-          "preferredLanguage": {
-            "type": "string",
-            "example": "uk",
-            "nullable": true
-          },
-          "preferredRegion": {
-            "type": "string",
-            "example": "UA",
-            "nullable": true
-          },
-          "privacy": {
-            "$ref": "#/components/schemas/PrivacyDto"
-          }
-        },
-        "required": [
-          "bio",
-          "location",
-          "website",
-          "preferredLanguage",
-          "preferredRegion",
-          "privacy"
-        ]
-      },
-      "StatsDto": {
-        "type": "object",
-        "properties": {
-          "moviesRated": {
-            "type": "number",
-            "example": 24
-          },
-          "showsRated": {
-            "type": "number",
-            "example": 10
-          },
-          "watchlistCount": {
-            "type": "number",
-            "example": 42
-          }
-        },
-        "required": [
-          "moviesRated",
-          "showsRated",
-          "watchlistCount"
-        ]
-      },
-      "MeDto": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "example": "6bd54e62-bac3-49dd-a0d4-05efd7761700"
-          },
-          "email": {
-            "type": "string",
-            "example": "user@example.com"
-          },
-          "username": {
-            "type": "string",
-            "example": "ratingo_fan"
-          },
-          "avatarUrl": {
-            "type": "string",
-            "example": "https://cdn.ratingo/avatar.png",
-            "nullable": true
-          },
-          "role": {
-            "type": "string",
-            "example": "user",
-            "enum": [
-              "user",
-              "admin"
-            ]
-          },
-          "profile": {
-            "$ref": "#/components/schemas/ProfileDto"
-          },
-          "hasPassword": {
-            "type": "boolean",
-            "description": "Whether the user has a password set (false for OAuth-only accounts)"
-          },
-          "linkedProviders": {
-            "description": "List of linked OAuth provider names",
-            "example": [
-              "google"
-            ],
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "stats": {
-            "$ref": "#/components/schemas/StatsDto"
-          }
-        },
-        "required": [
-          "id",
-          "email",
-          "username",
-          "avatarUrl",
-          "role",
-          "profile",
-          "hasPassword",
-          "linkedProviders",
-          "stats"
-        ]
-      },
-      "ExchangeCodeDto": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string",
-            "description": "One-time exchange code from OAuth callback",
-            "example": "abc123xyz..."
-          }
-        },
-        "required": [
-          "code"
-        ]
-      },
-      "LinkedAccountDto": {
-        "type": "object",
-        "properties": {
-          "provider": {
-            "type": "string",
-            "example": "google",
-            "description": "OAuth provider name"
-          },
-          "email": {
-            "type": "string",
-            "example": "user@gmail.com",
-            "nullable": true,
-            "description": "Email from OAuth provider"
-          },
-          "displayName": {
-            "type": "string",
-            "example": "John Doe",
-            "nullable": true,
-            "description": "Display name from OAuth provider"
-          },
-          "linkedAt": {
-            "type": "string",
-            "format": "date-time",
-            "example": "2025-01-15T10:30:00.000Z",
-            "description": "When the account was linked"
-          }
-        },
-        "required": [
-          "provider",
-          "linkedAt"
-        ]
-      },
-      "ProviderConfigDto": {
-        "type": "object",
-        "properties": {
-          "enabled": {
-            "type": "boolean",
-            "description": "Whether this OAuth provider is enabled"
-          }
-        },
-        "required": [
-          "enabled"
-        ]
-      },
-      "AuthConfigDto": {
-        "type": "object",
-        "properties": {
-          "google": {
-            "description": "Google OAuth configuration",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ProviderConfigDto"
-              }
-            ]
-          },
-          "facebook": {
-            "description": "Facebook OAuth configuration",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ProviderConfigDto"
-              }
-            ]
-          }
-        },
-        "required": [
-          "google",
-          "facebook"
-        ]
-      },
-      "UpdateProfileDto": {
-        "type": "object",
-        "properties": {
-          "username": {
-            "type": "string",
-            "example": "ratingo_fan"
-          },
-          "avatarUrl": {
-            "type": "string",
-            "example": "https://cdn.example.com/avatar.png"
-          },
-          "bio": {
-            "type": "string",
-            "example": "Люблю фільми жахів та наукову фантастику"
-          },
-          "location": {
-            "type": "string",
-            "example": "Kyiv, Ukraine"
-          },
-          "website": {
-            "type": "string",
-            "example": "https://instagram.com/myprofile"
-          },
-          "preferredLanguage": {
-            "type": "string",
-            "example": "uk"
-          },
-          "preferredRegion": {
-            "type": "string",
-            "example": "UA"
-          },
-          "isProfilePublic": {
-            "type": "boolean",
-            "example": true
-          },
-          "showWatchHistory": {
-            "type": "boolean",
-            "example": false
-          },
-          "showRatings": {
-            "type": "boolean",
-            "example": true
-          },
-          "allowFollowers": {
-            "type": "boolean",
-            "example": true
-          },
-          "autoSubscribeOnWatch": {
-            "type": "boolean",
-            "example": true
-          }
-        }
-      },
-      "CreateAvatarUploadUrlDto": {
-        "type": "object",
-        "properties": {
-          "contentType": {
-            "type": "string",
-            "enum": [
-              "image/jpeg",
-              "image/png",
-              "image/webp"
-            ]
-          }
-        },
-        "required": [
-          "contentType"
-        ]
-      },
-      "AvatarUploadUrlDto": {
-        "type": "object",
-        "properties": {
-          "uploadUrl": {
-            "type": "string"
-          },
-          "publicUrl": {
-            "type": "string"
-          },
-          "key": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "uploadUrl",
-          "publicUrl",
-          "key"
-        ]
-      },
-      "PublicUserMediaSummaryDto": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "movie",
-              "show"
-            ]
-          },
-          "title": {
-            "type": "string"
-          },
-          "slug": {
-            "type": "string"
-          },
-          "poster": {
-            "nullable": true,
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Function"
-              }
-            ]
-          },
-          "releaseDate": {
-            "format": "date-time",
-            "type": "string",
-            "nullable": true
-          }
-        },
-        "required": [
-          "id",
-          "type",
-          "title",
-          "slug",
-          "poster"
-        ]
-      },
-      "PublicUserMediaListItemDto": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "state": {
-            "type": "string",
-            "enum": [
-              "watching",
-              "completed",
-              "planned",
-              "dropped",
-              "paused",
-              "caught_up"
-            ]
-          },
-          "rating": {
-            "type": "number",
-            "nullable": true,
-            "description": "0-100 rating"
-          },
-          "progress": {
-            "type": "object",
-            "nullable": true,
-            "description": "Arbitrary progress payload (JSON)"
-          },
-          "notes": {
-            "type": "string",
-            "nullable": true
-          },
-          "createdAt": {
-            "format": "date-time",
-            "type": "string"
-          },
-          "updatedAt": {
-            "format": "date-time",
-            "type": "string"
-          },
-          "mediaSummary": {
-            "$ref": "#/components/schemas/PublicUserMediaSummaryDto"
-          }
-        },
-        "required": [
-          "id",
-          "state",
-          "rating",
-          "createdAt",
-          "updatedAt",
-          "mediaSummary"
-        ]
-      },
-      "PaginatedPublicUserMediaResponseDto": {
-        "type": "object",
-        "properties": {
-          "data": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PublicUserMediaListItemDto"
-            }
-          },
-          "meta": {
-            "$ref": "#/components/schemas/OffsetPaginationMetaDto"
-          }
-        },
-        "required": [
-          "data",
-          "meta"
-        ]
-      },
       "NotificationPayloadDto": {
         "type": "object",
         "properties": {
@@ -14787,6 +14348,534 @@
           "metric",
           "risers",
           "fallers"
+        ]
+      },
+      "RegisterDto": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "example": "user@example.com"
+          },
+          "username": {
+            "type": "string",
+            "example": "ratingo_fan"
+          },
+          "password": {
+            "type": "string",
+            "example": "S3curePassw0rd"
+          },
+          "avatarUrl": {
+            "type": "string",
+            "example": "https://cdn.example.com/avatar.png"
+          }
+        },
+        "required": [
+          "email",
+          "username",
+          "password"
+        ]
+      },
+      "AuthTokensDto": {
+        "type": "object",
+        "properties": {
+          "accessToken": {
+            "type": "string",
+            "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2YmQ1NGU2Mi1iYWMzLTQ5ZGQtYTBkNC0wNWVmZDc3NjE3MDAiLCJlbWFpbCI6InVzZXJAZXhhbXBsZS5jb20iLCJyb2xlIjoidXNlciIsImlhdCI6MTc2NTQ1ODE3NCwiZXhwIjoxNzY1NDU5MDc0fQ.JYlxU9C9P_DJOJTeN_tosd5Dds5H5u3U9_y_AQdLtDU",
+            "description": "JWT access token"
+          },
+          "refreshToken": {
+            "type": "string",
+            "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2YmQ1NGU2Mi1iYWMzLTQ5ZGQtYTBkNC0wNWVmZDc3NjE3MDAiLCJqdGkiOiJmYmUwYTQxOC05ZWVkLTRjNmEtOTU2MS00MDRmZDFiMTFhOTciLCJ0eXBlIjoicmVmcmVzaCIsImlhdCI6MTc2NTQ1ODE3NCwiZXhwIjoxNzY4MDUwMTc0fQ.Jra2xAp4OeKcm5ZSalwwMrqwoQngn8Js9ql_rK0VjFQ",
+            "description": "Refresh token"
+          }
+        },
+        "required": [
+          "accessToken",
+          "refreshToken"
+        ]
+      },
+      "LoginDto": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "example": "user@example.com"
+          },
+          "password": {
+            "type": "string",
+            "example": "S3curePassw0rd"
+          }
+        },
+        "required": [
+          "email",
+          "password"
+        ]
+      },
+      "RefreshDto": {
+        "type": "object",
+        "properties": {
+          "refreshToken": {
+            "type": "string",
+            "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+          }
+        },
+        "required": [
+          "refreshToken"
+        ]
+      },
+      "ChangePasswordDto": {
+        "type": "object",
+        "properties": {
+          "currentPassword": {
+            "type": "string",
+            "example": "OldPass123"
+          },
+          "newPassword": {
+            "type": "string",
+            "example": "NewPass456"
+          }
+        },
+        "required": [
+          "currentPassword",
+          "newPassword"
+        ]
+      },
+      "PrivacyDto": {
+        "type": "object",
+        "properties": {
+          "isProfilePublic": {
+            "type": "boolean",
+            "example": true
+          },
+          "showWatchHistory": {
+            "type": "boolean",
+            "example": false
+          },
+          "showRatings": {
+            "type": "boolean",
+            "example": true
+          },
+          "allowFollowers": {
+            "type": "boolean",
+            "example": true
+          },
+          "autoSubscribeOnWatch": {
+            "type": "boolean",
+            "example": true
+          }
+        },
+        "required": [
+          "isProfilePublic",
+          "showWatchHistory",
+          "showRatings",
+          "allowFollowers",
+          "autoSubscribeOnWatch"
+        ]
+      },
+      "ProfileDto": {
+        "type": "object",
+        "properties": {
+          "bio": {
+            "type": "string",
+            "example": "Люблю жахи та sci-fi",
+            "nullable": true
+          },
+          "location": {
+            "type": "string",
+            "example": "Kyiv",
+            "nullable": true
+          },
+          "website": {
+            "type": "string",
+            "example": "https://instagram.com/me",
+            "nullable": true
+          },
+          "preferredLanguage": {
+            "type": "string",
+            "example": "uk",
+            "nullable": true
+          },
+          "preferredRegion": {
+            "type": "string",
+            "example": "UA",
+            "nullable": true
+          },
+          "privacy": {
+            "$ref": "#/components/schemas/PrivacyDto"
+          }
+        },
+        "required": [
+          "bio",
+          "location",
+          "website",
+          "preferredLanguage",
+          "preferredRegion",
+          "privacy"
+        ]
+      },
+      "StatsDto": {
+        "type": "object",
+        "properties": {
+          "moviesRated": {
+            "type": "number",
+            "example": 24
+          },
+          "showsRated": {
+            "type": "number",
+            "example": 10
+          },
+          "watchlistCount": {
+            "type": "number",
+            "example": 42
+          }
+        },
+        "required": [
+          "moviesRated",
+          "showsRated",
+          "watchlistCount"
+        ]
+      },
+      "MeDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "6bd54e62-bac3-49dd-a0d4-05efd7761700"
+          },
+          "email": {
+            "type": "string",
+            "example": "user@example.com"
+          },
+          "username": {
+            "type": "string",
+            "example": "ratingo_fan"
+          },
+          "avatarUrl": {
+            "type": "string",
+            "example": "https://cdn.ratingo/avatar.png",
+            "nullable": true
+          },
+          "role": {
+            "type": "string",
+            "example": "user",
+            "enum": [
+              "user",
+              "admin"
+            ]
+          },
+          "profile": {
+            "$ref": "#/components/schemas/ProfileDto"
+          },
+          "hasPassword": {
+            "type": "boolean",
+            "description": "Whether the user has a password set (false for OAuth-only accounts)"
+          },
+          "linkedProviders": {
+            "description": "List of linked OAuth provider names",
+            "example": [
+              "google"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "stats": {
+            "$ref": "#/components/schemas/StatsDto"
+          }
+        },
+        "required": [
+          "id",
+          "email",
+          "username",
+          "avatarUrl",
+          "role",
+          "profile",
+          "hasPassword",
+          "linkedProviders",
+          "stats"
+        ]
+      },
+      "ExchangeCodeDto": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "One-time exchange code from OAuth callback",
+            "example": "abc123xyz..."
+          }
+        },
+        "required": [
+          "code"
+        ]
+      },
+      "LinkedAccountDto": {
+        "type": "object",
+        "properties": {
+          "provider": {
+            "type": "string",
+            "example": "google",
+            "description": "OAuth provider name"
+          },
+          "email": {
+            "type": "string",
+            "example": "user@gmail.com",
+            "nullable": true,
+            "description": "Email from OAuth provider"
+          },
+          "displayName": {
+            "type": "string",
+            "example": "John Doe",
+            "nullable": true,
+            "description": "Display name from OAuth provider"
+          },
+          "linkedAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2025-01-15T10:30:00.000Z",
+            "description": "When the account was linked"
+          }
+        },
+        "required": [
+          "provider",
+          "linkedAt"
+        ]
+      },
+      "ProviderConfigDto": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether this OAuth provider is enabled"
+          }
+        },
+        "required": [
+          "enabled"
+        ]
+      },
+      "AuthConfigDto": {
+        "type": "object",
+        "properties": {
+          "google": {
+            "description": "Google OAuth configuration",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProviderConfigDto"
+              }
+            ]
+          },
+          "facebook": {
+            "description": "Facebook OAuth configuration",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProviderConfigDto"
+              }
+            ]
+          }
+        },
+        "required": [
+          "google",
+          "facebook"
+        ]
+      },
+      "UpdateProfileDto": {
+        "type": "object",
+        "properties": {
+          "username": {
+            "type": "string",
+            "example": "ratingo_fan"
+          },
+          "avatarUrl": {
+            "type": "string",
+            "example": "https://cdn.example.com/avatar.png"
+          },
+          "bio": {
+            "type": "string",
+            "example": "Люблю фільми жахів та наукову фантастику"
+          },
+          "location": {
+            "type": "string",
+            "example": "Kyiv, Ukraine"
+          },
+          "website": {
+            "type": "string",
+            "example": "https://instagram.com/myprofile"
+          },
+          "preferredLanguage": {
+            "type": "string",
+            "example": "uk"
+          },
+          "preferredRegion": {
+            "type": "string",
+            "example": "UA"
+          },
+          "isProfilePublic": {
+            "type": "boolean",
+            "example": true
+          },
+          "showWatchHistory": {
+            "type": "boolean",
+            "example": false
+          },
+          "showRatings": {
+            "type": "boolean",
+            "example": true
+          },
+          "allowFollowers": {
+            "type": "boolean",
+            "example": true
+          },
+          "autoSubscribeOnWatch": {
+            "type": "boolean",
+            "example": true
+          }
+        }
+      },
+      "CreateAvatarUploadUrlDto": {
+        "type": "object",
+        "properties": {
+          "contentType": {
+            "type": "string",
+            "enum": [
+              "image/jpeg",
+              "image/png",
+              "image/webp"
+            ]
+          }
+        },
+        "required": [
+          "contentType"
+        ]
+      },
+      "AvatarUploadUrlDto": {
+        "type": "object",
+        "properties": {
+          "uploadUrl": {
+            "type": "string"
+          },
+          "publicUrl": {
+            "type": "string"
+          },
+          "key": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "uploadUrl",
+          "publicUrl",
+          "key"
+        ]
+      },
+      "PublicUserMediaSummaryDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "movie",
+              "show"
+            ]
+          },
+          "title": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "poster": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Function"
+              }
+            ]
+          },
+          "releaseDate": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "title",
+          "slug",
+          "poster"
+        ]
+      },
+      "PublicUserMediaListItemDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "watching",
+              "completed",
+              "planned",
+              "dropped",
+              "paused",
+              "caught_up"
+            ]
+          },
+          "rating": {
+            "type": "number",
+            "nullable": true,
+            "description": "0-100 rating"
+          },
+          "progress": {
+            "type": "object",
+            "nullable": true,
+            "description": "Arbitrary progress payload (JSON)"
+          },
+          "notes": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "updatedAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "mediaSummary": {
+            "$ref": "#/components/schemas/PublicUserMediaSummaryDto"
+          }
+        },
+        "required": [
+          "id",
+          "state",
+          "rating",
+          "createdAt",
+          "updatedAt",
+          "mediaSummary"
+        ]
+      },
+      "PaginatedPublicUserMediaResponseDto": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PublicUserMediaListItemDto"
+            }
+          },
+          "meta": {
+            "$ref": "#/components/schemas/OffsetPaginationMetaDto"
+          }
+        },
+        "required": [
+          "data",
+          "meta"
         ]
       },
       "PostListItemDto": {

--- a/packages/api-contract/src/api-types.ts
+++ b/packages/api-contract/src/api-types.ts
@@ -748,313 +748,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/auth/register": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Register new user */
-        post: operations["AuthController_register"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/auth/login": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Login with email/password */
-        post: operations["AuthController_login"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/auth/refresh": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Refresh tokens */
-        post: operations["AuthController_refresh"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/auth/logout": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Logout (revoke refresh tokens) */
-        post: operations["AuthController_logout"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/auth/password": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /** Change current user password */
-        patch: operations["AuthController_changePassword"];
-        trace?: never;
-    };
-    "/api/auth/me": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get current user profile */
-        get: operations["AuthController_me"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/auth/google": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Initiate Google OAuth flow */
-        get: operations["AuthController_googleAuth"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/auth/facebook": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Initiate Facebook OAuth flow */
-        get: operations["AuthController_facebookAuth"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/auth/oauth/exchange": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Exchange one-time code for tokens */
-        post: operations["AuthController_exchangeCode"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/auth/providers": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get linked OAuth providers */
-        get: operations["AuthController_getLinkedAccounts"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/auth/providers/{provider}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /** Unlink OAuth provider */
-        delete: operations["AuthController_unlinkProvider"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/auth/config": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get auth configuration */
-        get: operations["AuthController_getConfig"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/users/me": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get current user profile (auth: Bearer) */
-        get: operations["UsersController_me"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /** Update current user profile (auth: Bearer) */
-        patch: operations["UsersController_updateProfile"];
-        trace?: never;
-    };
-    "/api/users/me/avatar/upload-url": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Create presigned upload URL for avatar (auth: Bearer) */
-        post: operations["UsersController_createAvatarUploadUrl"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/users/{username}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get public user profile by username (auth optional, privacy aware) */
-        get: operations["PublicUsersController_getPublicProfile"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/users/{username}/ratings": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get public user ratings (auth optional, privacy aware) */
-        get: operations["PublicUsersController_getRatings"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/users/{username}/watchlist": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get public user watchlist (auth optional, privacy aware) */
-        get: operations["PublicUsersController_getWatchlist"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/users/{username}/history": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get public user watch history (auth optional, privacy aware) */
-        get: operations["PublicUsersController_getHistory"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/api/me/notifications": {
         parameters: {
             query?: never;
@@ -2056,6 +1749,313 @@ export interface paths {
          * @description Returns media items with the biggest change in watchers count over the specified window.
          */
         get: operations["InsightsController_getMovements"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/register": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Register new user */
+        post: operations["AuthController_register"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Login with email/password */
+        post: operations["AuthController_login"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Refresh tokens */
+        post: operations["AuthController_refresh"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/logout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Logout (revoke refresh tokens) */
+        post: operations["AuthController_logout"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/password": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Change current user password */
+        patch: operations["AuthController_changePassword"];
+        trace?: never;
+    };
+    "/api/auth/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get current user profile */
+        get: operations["AuthController_me"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/google": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Initiate Google OAuth flow */
+        get: operations["AuthController_googleAuth"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/facebook": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Initiate Facebook OAuth flow */
+        get: operations["AuthController_facebookAuth"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/oauth/exchange": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Exchange one-time code for tokens */
+        post: operations["AuthController_exchangeCode"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/providers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get linked OAuth providers */
+        get: operations["AuthController_getLinkedAccounts"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/providers/{provider}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Unlink OAuth provider */
+        delete: operations["AuthController_unlinkProvider"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get auth configuration */
+        get: operations["AuthController_getConfig"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/users/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get current user profile (auth: Bearer) */
+        get: operations["UsersController_me"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Update current user profile (auth: Bearer) */
+        patch: operations["UsersController_updateProfile"];
+        trace?: never;
+    };
+    "/api/users/me/avatar/upload-url": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create presigned upload URL for avatar (auth: Bearer) */
+        post: operations["UsersController_createAvatarUploadUrl"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/users/{username}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get public user profile by username (auth optional, privacy aware) */
+        get: operations["PublicUsersController_getPublicProfile"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/users/{username}/ratings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get public user ratings (auth optional, privacy aware) */
+        get: operations["PublicUsersController_getRatings"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/users/{username}/watchlist": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get public user watchlist (auth optional, privacy aware) */
+        get: operations["PublicUsersController_getWatchlist"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/users/{username}/history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get public user watch history (auth optional, privacy aware) */
+        get: operations["PublicUsersController_getHistory"];
         put?: never;
         post?: never;
         delete?: never;
@@ -3657,207 +3657,6 @@ export interface components {
              */
             watchedEpisodeIds: string[];
         };
-        RegisterDto: {
-            /** @example user@example.com */
-            email: string;
-            /** @example ratingo_fan */
-            username: string;
-            /** @example S3curePassw0rd */
-            password: string;
-            /** @example https://cdn.example.com/avatar.png */
-            avatarUrl?: string;
-        };
-        AuthTokensDto: {
-            /**
-             * @description JWT access token
-             * @example eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2YmQ1NGU2Mi1iYWMzLTQ5ZGQtYTBkNC0wNWVmZDc3NjE3MDAiLCJlbWFpbCI6InVzZXJAZXhhbXBsZS5jb20iLCJyb2xlIjoidXNlciIsImlhdCI6MTc2NTQ1ODE3NCwiZXhwIjoxNzY1NDU5MDc0fQ.JYlxU9C9P_DJOJTeN_tosd5Dds5H5u3U9_y_AQdLtDU
-             */
-            accessToken: string;
-            /**
-             * @description Refresh token
-             * @example eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2YmQ1NGU2Mi1iYWMzLTQ5ZGQtYTBkNC0wNWVmZDc3NjE3MDAiLCJqdGkiOiJmYmUwYTQxOC05ZWVkLTRjNmEtOTU2MS00MDRmZDFiMTFhOTciLCJ0eXBlIjoicmVmcmVzaCIsImlhdCI6MTc2NTQ1ODE3NCwiZXhwIjoxNzY4MDUwMTc0fQ.Jra2xAp4OeKcm5ZSalwwMrqwoQngn8Js9ql_rK0VjFQ
-             */
-            refreshToken: string;
-        };
-        LoginDto: {
-            /** @example user@example.com */
-            email: string;
-            /** @example S3curePassw0rd */
-            password: string;
-        };
-        RefreshDto: {
-            /** @example eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9... */
-            refreshToken: string;
-        };
-        ChangePasswordDto: {
-            /** @example OldPass123 */
-            currentPassword: string;
-            /** @example NewPass456 */
-            newPassword: string;
-        };
-        PrivacyDto: {
-            /** @example true */
-            isProfilePublic: boolean;
-            /** @example false */
-            showWatchHistory: boolean;
-            /** @example true */
-            showRatings: boolean;
-            /** @example true */
-            allowFollowers: boolean;
-            /** @example true */
-            autoSubscribeOnWatch: boolean;
-        };
-        ProfileDto: {
-            /** @example Люблю жахи та sci-fi */
-            bio: string | null;
-            /** @example Kyiv */
-            location: string | null;
-            /** @example https://instagram.com/me */
-            website: string | null;
-            /** @example uk */
-            preferredLanguage: string | null;
-            /** @example UA */
-            preferredRegion: string | null;
-            privacy: components["schemas"]["PrivacyDto"];
-        };
-        StatsDto: {
-            /** @example 24 */
-            moviesRated: number;
-            /** @example 10 */
-            showsRated: number;
-            /** @example 42 */
-            watchlistCount: number;
-        };
-        MeDto: {
-            /** @example 6bd54e62-bac3-49dd-a0d4-05efd7761700 */
-            id: string;
-            /** @example user@example.com */
-            email: string;
-            /** @example ratingo_fan */
-            username: string;
-            /** @example https://cdn.ratingo/avatar.png */
-            avatarUrl: string | null;
-            /**
-             * @example user
-             * @enum {string}
-             */
-            role: "user" | "admin";
-            profile: components["schemas"]["ProfileDto"];
-            /** @description Whether the user has a password set (false for OAuth-only accounts) */
-            hasPassword: boolean;
-            /**
-             * @description List of linked OAuth provider names
-             * @example [
-             *       "google"
-             *     ]
-             */
-            linkedProviders: string[];
-            stats: components["schemas"]["StatsDto"];
-        };
-        ExchangeCodeDto: {
-            /**
-             * @description One-time exchange code from OAuth callback
-             * @example abc123xyz...
-             */
-            code: string;
-        };
-        LinkedAccountDto: {
-            /**
-             * @description OAuth provider name
-             * @example google
-             */
-            provider: string;
-            /**
-             * @description Email from OAuth provider
-             * @example user@gmail.com
-             */
-            email?: string | null;
-            /**
-             * @description Display name from OAuth provider
-             * @example John Doe
-             */
-            displayName?: string | null;
-            /**
-             * Format: date-time
-             * @description When the account was linked
-             * @example 2025-01-15T10:30:00.000Z
-             */
-            linkedAt: string;
-        };
-        ProviderConfigDto: {
-            /** @description Whether this OAuth provider is enabled */
-            enabled: boolean;
-        };
-        AuthConfigDto: {
-            /** @description Google OAuth configuration */
-            google: components["schemas"]["ProviderConfigDto"];
-            /** @description Facebook OAuth configuration */
-            facebook: components["schemas"]["ProviderConfigDto"];
-        };
-        UpdateProfileDto: {
-            /** @example ratingo_fan */
-            username?: string;
-            /** @example https://cdn.example.com/avatar.png */
-            avatarUrl?: string;
-            /** @example Люблю фільми жахів та наукову фантастику */
-            bio?: string;
-            /** @example Kyiv, Ukraine */
-            location?: string;
-            /** @example https://instagram.com/myprofile */
-            website?: string;
-            /** @example uk */
-            preferredLanguage?: string;
-            /** @example UA */
-            preferredRegion?: string;
-            /** @example true */
-            isProfilePublic?: boolean;
-            /** @example false */
-            showWatchHistory?: boolean;
-            /** @example true */
-            showRatings?: boolean;
-            /** @example true */
-            allowFollowers?: boolean;
-            /** @example true */
-            autoSubscribeOnWatch?: boolean;
-        };
-        CreateAvatarUploadUrlDto: {
-            /** @enum {string} */
-            contentType: "image/jpeg" | "image/png" | "image/webp";
-        };
-        AvatarUploadUrlDto: {
-            uploadUrl: string;
-            publicUrl: string;
-            key: string;
-        };
-        PublicUserMediaSummaryDto: {
-            id: string;
-            /** @enum {string} */
-            type: "movie" | "show";
-            title: string;
-            slug: string;
-            poster: components["schemas"]["Function"] | null;
-            /** Format: date-time */
-            releaseDate?: string | null;
-        };
-        PublicUserMediaListItemDto: {
-            id: string;
-            /** @enum {string} */
-            state: "watching" | "completed" | "planned" | "dropped" | "paused" | "caught_up";
-            /** @description 0-100 rating */
-            rating: number | null;
-            /** @description Arbitrary progress payload (JSON) */
-            progress?: Record<string, never> | null;
-            notes?: string | null;
-            /** Format: date-time */
-            createdAt: string;
-            /** Format: date-time */
-            updatedAt: string;
-            mediaSummary: components["schemas"]["PublicUserMediaSummaryDto"];
-        };
-        PaginatedPublicUserMediaResponseDto: {
-            data: components["schemas"]["PublicUserMediaListItemDto"][];
-            meta: components["schemas"]["OffsetPaginationMetaDto"];
-        };
         NotificationPayloadDto: {
             /** @example 3 */
             seasonNumber?: number;
@@ -5438,6 +5237,207 @@ export interface components {
             metric: string;
             risers: components["schemas"]["RiseFallItemDto"][];
             fallers: components["schemas"]["RiseFallItemDto"][];
+        };
+        RegisterDto: {
+            /** @example user@example.com */
+            email: string;
+            /** @example ratingo_fan */
+            username: string;
+            /** @example S3curePassw0rd */
+            password: string;
+            /** @example https://cdn.example.com/avatar.png */
+            avatarUrl?: string;
+        };
+        AuthTokensDto: {
+            /**
+             * @description JWT access token
+             * @example eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2YmQ1NGU2Mi1iYWMzLTQ5ZGQtYTBkNC0wNWVmZDc3NjE3MDAiLCJlbWFpbCI6InVzZXJAZXhhbXBsZS5jb20iLCJyb2xlIjoidXNlciIsImlhdCI6MTc2NTQ1ODE3NCwiZXhwIjoxNzY1NDU5MDc0fQ.JYlxU9C9P_DJOJTeN_tosd5Dds5H5u3U9_y_AQdLtDU
+             */
+            accessToken: string;
+            /**
+             * @description Refresh token
+             * @example eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2YmQ1NGU2Mi1iYWMzLTQ5ZGQtYTBkNC0wNWVmZDc3NjE3MDAiLCJqdGkiOiJmYmUwYTQxOC05ZWVkLTRjNmEtOTU2MS00MDRmZDFiMTFhOTciLCJ0eXBlIjoicmVmcmVzaCIsImlhdCI6MTc2NTQ1ODE3NCwiZXhwIjoxNzY4MDUwMTc0fQ.Jra2xAp4OeKcm5ZSalwwMrqwoQngn8Js9ql_rK0VjFQ
+             */
+            refreshToken: string;
+        };
+        LoginDto: {
+            /** @example user@example.com */
+            email: string;
+            /** @example S3curePassw0rd */
+            password: string;
+        };
+        RefreshDto: {
+            /** @example eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9... */
+            refreshToken: string;
+        };
+        ChangePasswordDto: {
+            /** @example OldPass123 */
+            currentPassword: string;
+            /** @example NewPass456 */
+            newPassword: string;
+        };
+        PrivacyDto: {
+            /** @example true */
+            isProfilePublic: boolean;
+            /** @example false */
+            showWatchHistory: boolean;
+            /** @example true */
+            showRatings: boolean;
+            /** @example true */
+            allowFollowers: boolean;
+            /** @example true */
+            autoSubscribeOnWatch: boolean;
+        };
+        ProfileDto: {
+            /** @example Люблю жахи та sci-fi */
+            bio: string | null;
+            /** @example Kyiv */
+            location: string | null;
+            /** @example https://instagram.com/me */
+            website: string | null;
+            /** @example uk */
+            preferredLanguage: string | null;
+            /** @example UA */
+            preferredRegion: string | null;
+            privacy: components["schemas"]["PrivacyDto"];
+        };
+        StatsDto: {
+            /** @example 24 */
+            moviesRated: number;
+            /** @example 10 */
+            showsRated: number;
+            /** @example 42 */
+            watchlistCount: number;
+        };
+        MeDto: {
+            /** @example 6bd54e62-bac3-49dd-a0d4-05efd7761700 */
+            id: string;
+            /** @example user@example.com */
+            email: string;
+            /** @example ratingo_fan */
+            username: string;
+            /** @example https://cdn.ratingo/avatar.png */
+            avatarUrl: string | null;
+            /**
+             * @example user
+             * @enum {string}
+             */
+            role: "user" | "admin";
+            profile: components["schemas"]["ProfileDto"];
+            /** @description Whether the user has a password set (false for OAuth-only accounts) */
+            hasPassword: boolean;
+            /**
+             * @description List of linked OAuth provider names
+             * @example [
+             *       "google"
+             *     ]
+             */
+            linkedProviders: string[];
+            stats: components["schemas"]["StatsDto"];
+        };
+        ExchangeCodeDto: {
+            /**
+             * @description One-time exchange code from OAuth callback
+             * @example abc123xyz...
+             */
+            code: string;
+        };
+        LinkedAccountDto: {
+            /**
+             * @description OAuth provider name
+             * @example google
+             */
+            provider: string;
+            /**
+             * @description Email from OAuth provider
+             * @example user@gmail.com
+             */
+            email?: string | null;
+            /**
+             * @description Display name from OAuth provider
+             * @example John Doe
+             */
+            displayName?: string | null;
+            /**
+             * Format: date-time
+             * @description When the account was linked
+             * @example 2025-01-15T10:30:00.000Z
+             */
+            linkedAt: string;
+        };
+        ProviderConfigDto: {
+            /** @description Whether this OAuth provider is enabled */
+            enabled: boolean;
+        };
+        AuthConfigDto: {
+            /** @description Google OAuth configuration */
+            google: components["schemas"]["ProviderConfigDto"];
+            /** @description Facebook OAuth configuration */
+            facebook: components["schemas"]["ProviderConfigDto"];
+        };
+        UpdateProfileDto: {
+            /** @example ratingo_fan */
+            username?: string;
+            /** @example https://cdn.example.com/avatar.png */
+            avatarUrl?: string;
+            /** @example Люблю фільми жахів та наукову фантастику */
+            bio?: string;
+            /** @example Kyiv, Ukraine */
+            location?: string;
+            /** @example https://instagram.com/myprofile */
+            website?: string;
+            /** @example uk */
+            preferredLanguage?: string;
+            /** @example UA */
+            preferredRegion?: string;
+            /** @example true */
+            isProfilePublic?: boolean;
+            /** @example false */
+            showWatchHistory?: boolean;
+            /** @example true */
+            showRatings?: boolean;
+            /** @example true */
+            allowFollowers?: boolean;
+            /** @example true */
+            autoSubscribeOnWatch?: boolean;
+        };
+        CreateAvatarUploadUrlDto: {
+            /** @enum {string} */
+            contentType: "image/jpeg" | "image/png" | "image/webp";
+        };
+        AvatarUploadUrlDto: {
+            uploadUrl: string;
+            publicUrl: string;
+            key: string;
+        };
+        PublicUserMediaSummaryDto: {
+            id: string;
+            /** @enum {string} */
+            type: "movie" | "show";
+            title: string;
+            slug: string;
+            poster: components["schemas"]["Function"] | null;
+            /** Format: date-time */
+            releaseDate?: string | null;
+        };
+        PublicUserMediaListItemDto: {
+            id: string;
+            /** @enum {string} */
+            state: "watching" | "completed" | "planned" | "dropped" | "paused" | "caught_up";
+            /** @description 0-100 rating */
+            rating: number | null;
+            /** @description Arbitrary progress payload (JSON) */
+            progress?: Record<string, never> | null;
+            notes?: string | null;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+            mediaSummary: components["schemas"]["PublicUserMediaSummaryDto"];
+        };
+        PaginatedPublicUserMediaResponseDto: {
+            data: components["schemas"]["PublicUserMediaListItemDto"][];
+            meta: components["schemas"]["OffsetPaginationMetaDto"];
         };
         PostListItemDto: {
             /**
@@ -7635,542 +7635,6 @@ export interface operations {
             };
         };
     };
-    AuthController_register: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["RegisterDto"];
-            };
-        };
-        responses: {
-            /** @description Tokens pair */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @enum {boolean} */
-                        success: true;
-                        data: components["schemas"]["AuthTokensDto"];
-                    };
-                };
-            };
-            /** @description Too many registration attempts */
-            429: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    AuthController_login: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["LoginDto"];
-            };
-        };
-        responses: {
-            /** @description Tokens pair */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @enum {boolean} */
-                        success: true;
-                        data: components["schemas"]["AuthTokensDto"];
-                    };
-                };
-            };
-            /** @description Invalid credentials */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Too many login attempts */
-            429: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    AuthController_refresh: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["RefreshDto"];
-            };
-        };
-        responses: {
-            /** @description Tokens pair */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @enum {boolean} */
-                        success: true;
-                        data: components["schemas"]["AuthTokensDto"];
-                    };
-                };
-            };
-            /** @description Too many refresh attempts */
-            429: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    AuthController_logout: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    AuthController_changePassword: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ChangePasswordDto"];
-            };
-        };
-        responses: {
-            /** @description Password changed successfully */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Not authenticated */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Invalid current password */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    AuthController_me: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Current authenticated user */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @enum {boolean} */
-                        success: true;
-                        data: components["schemas"]["MeDto"];
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    AuthController_googleAuth: {
-        parameters: {
-            query?: {
-                /** @description URL to redirect after auth */
-                returnTo?: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Redirect to Google */
-            302: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    AuthController_facebookAuth: {
-        parameters: {
-            query?: {
-                /** @description URL to redirect after auth */
-                returnTo?: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Redirect to Facebook */
-            302: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    AuthController_exchangeCode: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ExchangeCodeDto"];
-            };
-        };
-        responses: {
-            /** @description Tokens pair */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @enum {boolean} */
-                        success: true;
-                        data: components["schemas"]["AuthTokensDto"];
-                    };
-                };
-            };
-            /** @description OAUTH_EXCHANGE_EXPIRED or OAUTH_EXCHANGE_USED */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Too many exchange attempts */
-            429: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    AuthController_getLinkedAccounts: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Linked accounts */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @enum {boolean} */
-                        success: true;
-                        data: components["schemas"]["LinkedAccountDto"][];
-                    };
-                };
-            };
-        };
-    };
-    AuthController_unlinkProvider: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description OAuth provider to unlink */
-                provider: "google" | "facebook";
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Provider unlinked */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Cannot unlink last authentication method */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    AuthController_getConfig: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Auth configuration */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @enum {boolean} */
-                        success: true;
-                        data: components["schemas"]["AuthConfigDto"];
-                    };
-                };
-            };
-        };
-    };
-    UsersController_me: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    UsersController_updateProfile: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["UpdateProfileDto"];
-            };
-        };
-        responses: {
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    UsersController_createAvatarUploadUrl: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CreateAvatarUploadUrlDto"];
-            };
-        };
-        responses: {
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @enum {boolean} */
-                        success: true;
-                        data: components["schemas"]["AvatarUploadUrlDto"];
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    PublicUsersController_getPublicProfile: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                username: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    PublicUsersController_getRatings: {
-        parameters: {
-            query?: {
-                limit?: number;
-                offset?: number;
-                sort?: "recent" | "rating" | "releaseDate";
-            };
-            header?: never;
-            path: {
-                username: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @enum {boolean} */
-                        success: true;
-                        data: components["schemas"]["PaginatedPublicUserMediaResponseDto"];
-                    };
-                };
-            };
-        };
-    };
-    PublicUsersController_getWatchlist: {
-        parameters: {
-            query?: {
-                limit?: number;
-                offset?: number;
-                sort?: "recent" | "rating" | "releaseDate";
-            };
-            header?: never;
-            path: {
-                username: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @enum {boolean} */
-                        success: true;
-                        data: components["schemas"]["PaginatedPublicUserMediaResponseDto"];
-                    };
-                };
-            };
-        };
-    };
-    PublicUsersController_getHistory: {
-        parameters: {
-            query?: {
-                limit?: number;
-                offset?: number;
-                sort?: "recent" | "rating" | "releaseDate";
-            };
-            header?: never;
-            path: {
-                username: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @enum {boolean} */
-                        success: true;
-                        data: components["schemas"]["PaginatedPublicUserMediaResponseDto"];
-                    };
-                };
-            };
-        };
-    };
     NotificationsController_list: {
         parameters: {
             query?: {
@@ -9685,6 +9149,542 @@ export interface operations {
                         /** @enum {boolean} */
                         success: true;
                         data: components["schemas"]["RiseFallResponseDto"];
+                    };
+                };
+            };
+        };
+    };
+    AuthController_register: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RegisterDto"];
+            };
+        };
+        responses: {
+            /** @description Tokens pair */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {boolean} */
+                        success: true;
+                        data: components["schemas"]["AuthTokensDto"];
+                    };
+                };
+            };
+            /** @description Too many registration attempts */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    AuthController_login: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LoginDto"];
+            };
+        };
+        responses: {
+            /** @description Tokens pair */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {boolean} */
+                        success: true;
+                        data: components["schemas"]["AuthTokensDto"];
+                    };
+                };
+            };
+            /** @description Invalid credentials */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Too many login attempts */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    AuthController_refresh: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RefreshDto"];
+            };
+        };
+        responses: {
+            /** @description Tokens pair */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {boolean} */
+                        success: true;
+                        data: components["schemas"]["AuthTokensDto"];
+                    };
+                };
+            };
+            /** @description Too many refresh attempts */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    AuthController_logout: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    AuthController_changePassword: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ChangePasswordDto"];
+            };
+        };
+        responses: {
+            /** @description Password changed successfully */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Not authenticated */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Invalid current password */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    AuthController_me: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Current authenticated user */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {boolean} */
+                        success: true;
+                        data: components["schemas"]["MeDto"];
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    AuthController_googleAuth: {
+        parameters: {
+            query?: {
+                /** @description URL to redirect after auth */
+                returnTo?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Redirect to Google */
+            302: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    AuthController_facebookAuth: {
+        parameters: {
+            query?: {
+                /** @description URL to redirect after auth */
+                returnTo?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Redirect to Facebook */
+            302: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    AuthController_exchangeCode: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ExchangeCodeDto"];
+            };
+        };
+        responses: {
+            /** @description Tokens pair */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {boolean} */
+                        success: true;
+                        data: components["schemas"]["AuthTokensDto"];
+                    };
+                };
+            };
+            /** @description OAUTH_EXCHANGE_EXPIRED or OAUTH_EXCHANGE_USED */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Too many exchange attempts */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    AuthController_getLinkedAccounts: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Linked accounts */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {boolean} */
+                        success: true;
+                        data: components["schemas"]["LinkedAccountDto"][];
+                    };
+                };
+            };
+        };
+    };
+    AuthController_unlinkProvider: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description OAuth provider to unlink */
+                provider: "google" | "facebook";
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Provider unlinked */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Cannot unlink last authentication method */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    AuthController_getConfig: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Auth configuration */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {boolean} */
+                        success: true;
+                        data: components["schemas"]["AuthConfigDto"];
+                    };
+                };
+            };
+        };
+    };
+    UsersController_me: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    UsersController_updateProfile: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateProfileDto"];
+            };
+        };
+        responses: {
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    UsersController_createAvatarUploadUrl: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateAvatarUploadUrlDto"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {boolean} */
+                        success: true;
+                        data: components["schemas"]["AvatarUploadUrlDto"];
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    PublicUsersController_getPublicProfile: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                username: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    PublicUsersController_getRatings: {
+        parameters: {
+            query?: {
+                limit?: number;
+                offset?: number;
+                sort?: "recent" | "rating" | "releaseDate";
+            };
+            header?: never;
+            path: {
+                username: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {boolean} */
+                        success: true;
+                        data: components["schemas"]["PaginatedPublicUserMediaResponseDto"];
+                    };
+                };
+            };
+        };
+    };
+    PublicUsersController_getWatchlist: {
+        parameters: {
+            query?: {
+                limit?: number;
+                offset?: number;
+                sort?: "recent" | "rating" | "releaseDate";
+            };
+            header?: never;
+            path: {
+                username: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {boolean} */
+                        success: true;
+                        data: components["schemas"]["PaginatedPublicUserMediaResponseDto"];
+                    };
+                };
+            };
+        };
+    };
+    PublicUsersController_getHistory: {
+        parameters: {
+            query?: {
+                limit?: number;
+                offset?: number;
+                sort?: "recent" | "rating" | "releaseDate";
+            };
+            header?: never;
+            path: {
+                username: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {boolean} */
+                        success: true;
+                        data: components["schemas"]["PaginatedPublicUserMediaResponseDto"];
                     };
                 };
             };


### PR DESCRIPTION
## Summary

Fixes the "garbage bin" Swagger UI: 22 tags had four different naming styles (`Public: X`, `Admin - X`, `Service: X`, and bare `Me`/`Users`/`Home`/`Subscriptions`) rendered in random encounter order with no descriptions.

**New taxonomy — one scheme, ordered by audience:**

| Group | Tags |
|---|---|
| `Auth` | registration, login, OAuth, tokens |
| `Public: *` | Catalog, Home, Users, Reviews, Journal, Stats, Insights — no auth |
| `Me: *` | Profile, Library, Lists, Episode Progress, Reviews, Subscriptions, Saved Items, Notifications — Bearer JWT |
| `Admin: *` | Journal, Reviews, Providers, Policy, Ingestion, Stats — admin role |

- Shared `buildSwaggerConfig()` in `swagger.config.ts` — runtime `/docs` and the offline contract generator now produce identical metadata; `openapi.json` carries the ordered tag list with descriptions
- Swagger UI quality-of-life: groups collapsed by default (`docExpansion: 'none'`), search box (`filter: true`), Bearer token persists across reloads, schemas wall hidden
- API description documents the `{ success, data }` / `{ success: false, error }` wrapper
- `contracts:update` regenerated — diff is tag metadata + path ordering, types unchanged

## Verification

- `npm run build:api` ✅, `npm run lint:api` ✅ 0 errors
- `npm run test:api` ✅ 282/282 suites, 3936/3936
- `npm run test:client` ✅ 67/67 suites, 921/921 (api-contract consumers unaffected)

Based on #116 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
