### PR TITLE
feat(person): сторінки акторів/персон з фільмографією (#87)

### DIFF
--- a/apps/api/drizzle_v2/0029_many_molecule_man.sql
+++ b/apps/api/drizzle_v2/0029_many_molecule_man.sql
@@ -1,0 +1,37 @@
+CREATE TYPE "public"."person_credit_type" AS ENUM('cast', 'crew');--> statement-breakpoint
+CREATE TABLE "media_credits" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"media_item_id" uuid NOT NULL,
+	"person_id" uuid NOT NULL,
+	"credit_type" "person_credit_type" NOT NULL,
+	"character" text,
+	"job" text,
+	"department" text,
+	"order" integer DEFAULT 0 NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "persons" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tmdb_id" integer NOT NULL,
+	"slug" text NOT NULL,
+	"name" text NOT NULL,
+	"profile_path" text,
+	"known_for_department" text,
+	"popularity" double precision DEFAULT 0,
+	"biography" text,
+	"birthday" timestamp,
+	"deathday" timestamp,
+	"place_of_birth" text,
+	"details_fetched_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "persons_tmdb_id_unique" UNIQUE("tmdb_id")
+);
+--> statement-breakpoint
+ALTER TABLE "media_credits" ADD CONSTRAINT "media_credits_media_item_id_media_items_id_fk" FOREIGN KEY ("media_item_id") REFERENCES "public"."media_items"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "media_credits" ADD CONSTRAINT "media_credits_person_id_persons_id_fk" FOREIGN KEY ("person_id") REFERENCES "public"."persons"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "media_credits_uniq" ON "media_credits" USING btree ("media_item_id","person_id","credit_type",coalesce("job", ''));--> statement-breakpoint
+CREATE INDEX "media_credits_person_idx" ON "media_credits" USING btree ("person_id");--> statement-breakpoint
+CREATE INDEX "media_credits_media_item_idx" ON "media_credits" USING btree ("media_item_id");--> statement-breakpoint
+CREATE INDEX "persons_popularity_idx" ON "persons" USING btree ("popularity");--> statement-breakpoint
+CREATE INDEX "persons_slug_idx" ON "persons" USING btree ("slug");

--- a/apps/api/drizzle_v2/meta/0029_snapshot.json
+++ b/apps/api/drizzle_v2/meta/0029_snapshot.json
@@ -1,0 +1,5560 @@
+{
+  "id": "b0f65d8c-bcdc-4f7c-8326-e934b3872473",
+  "prevId": "1f7dc718-0b8d-469b-b340-3e4c847e3545",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.episodes": {
+      "name": "episodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "show_id": {
+          "name": "show_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "air_date": {
+          "name": "air_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "still_path": {
+          "name": "still_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vote_average": {
+          "name": "vote_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "episodes_season_number_uniq": {
+          "name": "episodes_season_number_uniq",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "episodes_season_idx": {
+          "name": "episodes_season_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "episodes_air_date_idx": {
+          "name": "episodes_air_date_idx",
+          "columns": [
+            {
+              "expression": "air_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "episodes_show_idx": {
+          "name": "episodes_show_idx",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "episodes_show_air_date_idx": {
+          "name": "episodes_show_air_date_idx",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "air_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "episodes_show_air_date_number_idx": {
+          "name": "episodes_show_air_date_number_idx",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "air_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "episodes_season_id_seasons_id_fk": {
+          "name": "episodes_season_id_seasons_id_fk",
+          "tableFrom": "episodes",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "episodes_show_id_shows_id_fk": {
+          "name": "episodes_show_id_shows_id_fk",
+          "tableFrom": "episodes",
+          "tableTo": "shows",
+          "columnsFrom": [
+            "show_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.genres": {
+      "name": "genres",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "genres_tmdb_id_unique": {
+          "name": "genres_tmdb_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tmdb_id"
+          ]
+        },
+        "genres_slug_unique": {
+          "name": "genres_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_genres": {
+      "name": "media_genres",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "media_genres_uniq": {
+          "name": "media_genres_uniq",
+          "columns": [
+            {
+              "expression": "media_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_genres_genre_idx": {
+          "name": "media_genres_genre_idx",
+          "columns": [
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_genres_media_item_id_media_items_id_fk": {
+          "name": "media_genres_media_item_id_media_items_id_fk",
+          "tableFrom": "media_genres",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_genres_genre_id_genres_id_fk": {
+          "name": "media_genres_genre_id_genres_id_fk",
+          "tableFrom": "media_genres",
+          "tableTo": "genres",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_items": {
+      "name": "media_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "media_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imdb_id": {
+          "name": "imdb_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_title": {
+          "name": "original_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alternative_titles": {
+          "name": "alternative_titles",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backdrop_path": {
+          "name": "backdrop_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "videos": {
+          "name": "videos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "credits": {
+          "name": "credits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"cast\":[],\"crew\":[]}'::jsonb"
+        },
+        "watch_providers_raw": {
+          "name": "watch_providers_raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "trending_score": {
+          "name": "trending_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "trending_rank": {
+          "name": "trending_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trending_updated_at": {
+          "name": "trending_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "popularity": {
+          "name": "popularity",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "rating": {
+          "name": "rating",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "rating_imdb": {
+          "name": "rating_imdb",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vote_count_imdb": {
+          "name": "vote_count_imdb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_metacritic": {
+          "name": "rating_metacritic",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_rotten_tomatoes": {
+          "name": "rating_rotten_tomatoes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_rotten_tomatoes_audience": {
+          "name": "rating_rotten_tomatoes_audience",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rt_fetched_at": {
+          "name": "rt_fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_trakt": {
+          "name": "rating_trakt",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vote_count_trakt": {
+          "name": "vote_count_trakt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_countries": {
+          "name": "origin_countries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "original_language": {
+          "name": "original_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingestion_status": {
+          "name": "ingestion_status",
+          "type": "ingestion_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ready'"
+        },
+        "content_class": {
+          "name": "content_class",
+          "type": "content_class",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mainstream'"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(original_title, '') || ' ' || coalesce(overview, '') || ' ' || coalesce(immutable_array_to_string(alternative_titles, ' '), ''))",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "media_type_tmdb_idx": {
+          "name": "media_type_tmdb_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tmdb_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_imdb_idx": {
+          "name": "media_imdb_idx",
+          "columns": [
+            {
+              "expression": "imdb_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_trending_idx": {
+          "name": "media_trending_idx",
+          "columns": [
+            {
+              "expression": "trending_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_trending_rank_idx": {
+          "name": "media_trending_rank_idx",
+          "columns": [
+            {
+              "expression": "trending_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_popularity_idx": {
+          "name": "media_popularity_idx",
+          "columns": [
+            {
+              "expression": "popularity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_release_date_idx": {
+          "name": "media_release_date_idx",
+          "columns": [
+            {
+              "expression": "release_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_type_slug_idx": {
+          "name": "media_type_slug_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_slug_idx": {
+          "name": "media_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_active_idx": {
+          "name": "media_active_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"media_items\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_search_idx": {
+          "name": "media_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_content_class_idx": {
+          "name": "media_content_class_idx",
+          "columns": [
+            {
+              "expression": "content_class",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_mdblist_pending_idx": {
+          "name": "media_mdblist_pending_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"media_items\".\"rt_fetched_at\" IS NULL AND \"media_items\".\"tmdb_id\" IS NOT NULL AND \"media_items\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_stats": {
+      "name": "media_stats",
+      "schema": "",
+      "columns": {
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watchers_count": {
+          "name": "watchers_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "total_watchers": {
+          "name": "total_watchers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "trending_rank": {
+          "name": "trending_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "popularity_24h": {
+          "name": "popularity_24h",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ratingo_score": {
+          "name": "ratingo_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "popularity_score": {
+          "name": "popularity_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "freshness_score": {
+          "name": "freshness_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "community_average_rating": {
+          "name": "community_average_rating",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "community_rating_count": {
+          "name": "community_rating_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_stats_ratingo_score_idx": {
+          "name": "media_stats_ratingo_score_idx",
+          "columns": [
+            {
+              "expression": "ratingo_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_stats_watchers_idx": {
+          "name": "media_stats_watchers_idx",
+          "columns": [
+            {
+              "expression": "watchers_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_stats_media_item_id_media_items_id_fk": {
+          "name": "media_stats_media_item_id_media_items_id_fk",
+          "tableFrom": "media_stats",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_watchers_snapshots": {
+      "name": "media_watchers_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_watchers": {
+          "name": "total_watchers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'global'"
+        }
+      },
+      "indexes": {
+        "media_watchers_media_date_region_uniq": {
+          "name": "media_watchers_media_date_region_uniq",
+          "columns": [
+            {
+              "expression": "media_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "snapshot_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_watchers_date_idx": {
+          "name": "media_watchers_date_idx",
+          "columns": [
+            {
+              "expression": "snapshot_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_watchers_snapshots_media_item_id_media_items_id_fk": {
+          "name": "media_watchers_snapshots_media_item_id_media_items_id_fk",
+          "tableFrom": "media_watchers_snapshots",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.movies": {
+      "name": "movies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "budget": {
+          "name": "budget",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revenue": {
+          "name": "revenue",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theatrical_release_date": {
+          "name": "theatrical_release_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "digital_release_date": {
+          "name": "digital_release_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_now_playing": {
+          "name": "is_now_playing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "releases": {
+          "name": "releases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "movies_now_playing_idx": {
+          "name": "movies_now_playing_idx",
+          "columns": [
+            {
+              "expression": "is_now_playing",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"movies\".\"is_now_playing\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "movies_theatrical_idx": {
+          "name": "movies_theatrical_idx",
+          "columns": [
+            {
+              "expression": "theatrical_release_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "movies_digital_idx": {
+          "name": "movies_digital_idx",
+          "columns": [
+            {
+              "expression": "digital_release_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "movies_media_item_idx": {
+          "name": "movies_media_item_idx",
+          "columns": [
+            {
+              "expression": "media_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "movies_media_item_id_media_items_id_fk": {
+          "name": "movies_media_item_id_media_items_id_fk",
+          "tableFrom": "movies",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "movies_media_item_id_unique": {
+          "name": "movies_media_item_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "media_item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seasons": {
+      "name": "seasons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "show_id": {
+          "name": "show_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "air_date": {
+          "name": "air_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "episode_count": {
+          "name": "episode_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "seasons_show_number_uniq": {
+          "name": "seasons_show_number_uniq",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "seasons_show_idx": {
+          "name": "seasons_show_idx",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "seasons_show_id_shows_id_fk": {
+          "name": "seasons_show_id_shows_id_fk",
+          "tableFrom": "seasons",
+          "tableTo": "shows",
+          "columnsFrom": [
+            "show_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shows": {
+      "name": "shows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_seasons": {
+          "name": "total_seasons",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_episodes": {
+          "name": "total_episodes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_air_date": {
+          "name": "last_air_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_air_date": {
+          "name": "next_air_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drop_off_analysis": {
+          "name": "drop_off_analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "shows_media_item_idx": {
+          "name": "shows_media_item_idx",
+          "columns": [
+            {
+              "expression": "media_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shows_media_item_id_media_items_id_fk": {
+          "name": "shows_media_item_id_media_items_id_fk",
+          "tableFrom": "shows",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "shows_media_item_id_unique": {
+          "name": "shows_media_item_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "media_item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_credits": {
+      "name": "media_credits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credit_type": {
+          "name": "credit_type",
+          "type": "person_credit_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character": {
+          "name": "character",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job": {
+          "name": "job",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "media_credits_uniq": {
+          "name": "media_credits_uniq",
+          "columns": [
+            {
+              "expression": "media_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "credit_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"job\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_credits_person_idx": {
+          "name": "media_credits_person_idx",
+          "columns": [
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_credits_media_item_idx": {
+          "name": "media_credits_media_item_idx",
+          "columns": [
+            {
+              "expression": "media_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_credits_media_item_id_media_items_id_fk": {
+          "name": "media_credits_media_item_id_media_items_id_fk",
+          "tableFrom": "media_credits",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_credits_person_id_persons_id_fk": {
+          "name": "media_credits_person_id_persons_id_fk",
+          "tableFrom": "media_credits",
+          "tableTo": "persons",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.persons": {
+      "name": "persons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_path": {
+          "name": "profile_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "known_for_department": {
+          "name": "known_for_department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "popularity": {
+          "name": "popularity",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "biography": {
+          "name": "biography",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birthday": {
+          "name": "birthday",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deathday": {
+          "name": "deathday",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "place_of_birth": {
+          "name": "place_of_birth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details_fetched_at": {
+          "name": "details_fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "persons_popularity_idx": {
+          "name": "persons_popularity_idx",
+          "columns": [
+            {
+              "expression": "popularity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "persons_slug_idx": {
+          "name": "persons_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "persons_tmdb_id_unique": {
+          "name": "persons_tmdb_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tmdb_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_language": {
+          "name": "preferred_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_region": {
+          "name": "preferred_region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_profile_public": {
+          "name": "is_profile_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "show_watch_history": {
+          "name": "show_watch_history",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "show_ratings": {
+          "name": "show_ratings",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "allow_followers": {
+          "name": "allow_followers",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "auto_subscribe_on_watch": {
+          "name": "auto_subscribe_on_watch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_accounts": {
+      "name": "oauth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_accounts_provider_account_uniq": {
+          "name": "oauth_accounts_provider_account_uniq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_accounts_user_provider_uniq": {
+          "name": "oauth_accounts_user_provider_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_accounts_user_idx": {
+          "name": "oauth_accounts_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_accounts_provider_idx": {
+          "name": "oauth_accounts_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_exchange_codes": {
+      "name": "oauth_exchange_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_exchange_codes_hash_idx": {
+          "name": "oauth_exchange_codes_hash_idx",
+          "columns": [
+            {
+              "expression": "code_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_exchange_codes_expires_idx": {
+          "name": "oauth_exchange_codes_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_exchange_codes_user_id_users_id_fk": {
+          "name": "oauth_exchange_codes_user_id_users_id_fk",
+          "tableFrom": "oauth_exchange_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_user_idx": {
+          "name": "refresh_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_expires_idx": {
+          "name": "refresh_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_episode_progress": {
+      "name": "user_episode_progress",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "episode_id": {
+          "name": "episode_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "watched_at": {
+          "name": "watched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_episode_progress_user_idx": {
+          "name": "user_episode_progress_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_episode_progress_episode_idx": {
+          "name": "user_episode_progress_episode_idx",
+          "columns": [
+            {
+              "expression": "episode_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_episode_progress_user_id_users_id_fk": {
+          "name": "user_episode_progress_user_id_users_id_fk",
+          "tableFrom": "user_episode_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_episode_progress_episode_id_episodes_id_fk": {
+          "name": "user_episode_progress_episode_id_episodes_id_fk",
+          "tableFrom": "user_episode_progress",
+          "tableTo": "episodes",
+          "columnsFrom": [
+            "episode_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_episode_progress_user_id_episode_id_pk": {
+          "name": "user_episode_progress_user_id_episode_id_pk",
+          "columns": [
+            "user_id",
+            "episode_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_media_actions": {
+      "name": "user_media_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_key": {
+          "name": "reason_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_media_actions_user_idx": {
+          "name": "user_media_actions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_media_actions_media_idx": {
+          "name": "user_media_actions_media_idx",
+          "columns": [
+            {
+              "expression": "media_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_media_actions_action_idx": {
+          "name": "user_media_actions_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_media_actions_created_at_idx": {
+          "name": "user_media_actions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_media_actions_user_id_users_id_fk": {
+          "name": "user_media_actions_user_id_users_id_fk",
+          "tableFrom": "user_media_actions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_media_actions_media_item_id_media_items_id_fk": {
+          "name": "user_media_actions_media_item_id_media_items_id_fk",
+          "tableFrom": "user_media_actions",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_media_state": {
+      "name": "user_media_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "user_media_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_media_state_user_media_uniq": {
+          "name": "user_media_state_user_media_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_media_state_user_idx": {
+          "name": "user_media_state_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_media_state_media_idx": {
+          "name": "user_media_state_media_idx",
+          "columns": [
+            {
+              "expression": "media_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_media_state_user_id_users_id_fk": {
+          "name": "user_media_state_user_id_users_id_fk",
+          "tableFrom": "user_media_state",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_media_state_media_item_id_media_items_id_fk": {
+          "name": "user_media_state_media_item_id_media_items_id_fk",
+          "tableFrom": "user_media_state",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notifications": {
+      "name": "user_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "subscription_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_notifications_user_idx": {
+          "name": "user_notifications_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_notifications_user_unread_idx": {
+          "name": "user_notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_notifications_created_at_idx": {
+          "name": "user_notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_notifications_dedup_idx": {
+          "name": "user_notifications_dedup_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payload",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_notifications_user_id_users_id_fk": {
+          "name": "user_notifications_user_id_users_id_fk",
+          "tableFrom": "user_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_notifications_media_item_id_media_items_id_fk": {
+          "name": "user_notifications_media_item_id_media_items_id_fk",
+          "tableFrom": "user_notifications",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_notifications_subscription_id_user_subscriptions_id_fk": {
+          "name": "user_notifications_subscription_id_user_subscriptions_id_fk",
+          "tableFrom": "user_notifications",
+          "tableTo": "user_subscriptions",
+          "columnsFrom": [
+            "subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_saved_items": {
+      "name": "user_saved_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list": {
+          "name": "list",
+          "type": "saved_item_list",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_key": {
+          "name": "reason_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_saved_items_user_media_list_uniq": {
+          "name": "user_saved_items_user_media_list_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "list",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_saved_items_user_idx": {
+          "name": "user_saved_items_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_saved_items_user_list_idx": {
+          "name": "user_saved_items_user_list_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "list",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_saved_items_user_id_users_id_fk": {
+          "name": "user_saved_items_user_id_users_id_fk",
+          "tableFrom": "user_saved_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_saved_items_media_item_id_media_items_id_fk": {
+          "name": "user_saved_items_media_item_id_media_items_id_fk",
+          "tableFrom": "user_saved_items",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_subscriptions": {
+      "name": "user_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "subscription_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'push'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_notified_at": {
+          "name": "last_notified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_notified_episode_key": {
+          "name": "last_notified_episode_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_notified_season_number": {
+          "name": "last_notified_season_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_subscriptions_user_media_trigger_channel_uniq": {
+          "name": "user_subscriptions_user_media_trigger_channel_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_subscriptions_user_idx": {
+          "name": "user_subscriptions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_subscriptions_user_active_idx": {
+          "name": "user_subscriptions_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_subscriptions_trigger_idx": {
+          "name": "user_subscriptions_trigger_idx",
+          "columns": [
+            {
+              "expression": "trigger",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_subscriptions_user_id_users_id_fk": {
+          "name": "user_subscriptions_user_id_users_id_fk",
+          "tableFrom": "user_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_subscriptions_media_item_id_media_items_id_fk": {
+          "name": "user_subscriptions_media_item_id_media_items_id_fk",
+          "tableFrom": "user_subscriptions",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.import_batches": {
+      "name": "import_batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_items": {
+          "name": "total_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_count": {
+          "name": "completed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "import_batch_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "import_batches_user_status_created_at_idx": {
+          "name": "import_batches_user_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "import_batches_user_id_users_id_fk": {
+          "name": "import_batches_user_id_users_id_fk",
+          "tableFrom": "import_batches",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.import_pending_items": {
+      "name": "import_pending_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imdb_id": {
+          "name": "imdb_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_tmdb_id": {
+          "name": "resolved_tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "import_pending_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_pending_batch_status": {
+          "name": "idx_pending_batch_status",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pending_resolved_tmdb": {
+          "name": "idx_pending_resolved_tmdb",
+          "columns": [
+            {
+              "expression": "resolved_tmdb_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "import_pending_items_batch_id_import_batches_id_fk": {
+          "name": "import_pending_items_batch_id_import_batches_id_fk",
+          "tableFrom": "import_pending_items",
+          "tableTo": "import_batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_watch_offers": {
+      "name": "media_watch_offers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distribution_channel": {
+          "name": "distribution_channel",
+          "type": "distribution_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'direct'"
+        },
+        "offer_type": {
+          "name": "offer_type",
+          "type": "offer_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tmdb_provider_id": {
+          "name": "tmdb_provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_watch_offers_media_idx": {
+          "name": "media_watch_offers_media_idx",
+          "columns": [
+            {
+              "expression": "media_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_watch_offers_provider_idx": {
+          "name": "media_watch_offers_provider_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_watch_offers_offer_type_idx": {
+          "name": "media_watch_offers_offer_type_idx",
+          "columns": [
+            {
+              "expression": "offer_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_watch_offers_region_idx": {
+          "name": "media_watch_offers_region_idx",
+          "columns": [
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_watch_offers_provider_offer_idx": {
+          "name": "media_watch_offers_provider_offer_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "offer_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_watch_offers_tmdb_idx": {
+          "name": "media_watch_offers_tmdb_idx",
+          "columns": [
+            {
+              "expression": "tmdb_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_watch_offers_media_item_id_media_items_id_fk": {
+          "name": "media_watch_offers_media_item_id_media_items_id_fk",
+          "tableFrom": "media_watch_offers",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_watch_offers_provider_id_provider_registry_id_fk": {
+          "name": "media_watch_offers_provider_id_provider_registry_id_fk",
+          "tableFrom": "media_watch_offers",
+          "tableTo": "provider_registry",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "media_watch_offers_variant_id_provider_variants_id_fk": {
+          "name": "media_watch_offers_variant_id_provider_variants_id_fk",
+          "tableFrom": "media_watch_offers",
+          "tableTo": "provider_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_mappings": {
+      "name": "provider_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tmdb_provider_id": {
+          "name": "tmdb_provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distribution_channel": {
+          "name": "distribution_channel",
+          "type": "distribution_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'direct'"
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provider_mappings_tmdb_region_uniq": {
+          "name": "provider_mappings_tmdb_region_uniq",
+          "columns": [
+            {
+              "expression": "tmdb_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_mappings_tmdb_idx": {
+          "name": "provider_mappings_tmdb_idx",
+          "columns": [
+            {
+              "expression": "tmdb_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_mappings_provider_id_provider_registry_id_fk": {
+          "name": "provider_mappings_provider_id_provider_registry_id_fk",
+          "tableFrom": "provider_mappings",
+          "tableTo": "provider_registry",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "provider_mappings_variant_id_provider_variants_id_fk": {
+          "name": "provider_mappings_variant_id_provider_variants_id_fk",
+          "tableFrom": "provider_mappings",
+          "tableTo": "provider_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_registry": {
+      "name": "provider_registry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_group": {
+          "name": "brand_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_path": {
+          "name": "logo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 100
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_unmapped": {
+      "name": "provider_unmapped",
+      "schema": "",
+      "columns": {
+        "tmdb_provider_id": {
+          "name": "tmdb_provider_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_seen_name": {
+          "name": "last_seen_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_names": {
+          "name": "sample_names",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "seen_count": {
+          "name": "seen_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "sample_regions": {
+          "name": "sample_regions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_variants": {
+      "name": "provider_variants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_label": {
+          "name": "display_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_ads_tier": {
+          "name": "is_ads_tier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_premium_tier": {
+          "name": "is_premium_tier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provider_variants_provider_idx": {
+          "name": "provider_variants_provider_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_variants_provider_id_provider_registry_id_fk": {
+          "name": "provider_variants_provider_id_provider_registry_id_fk",
+          "tableFrom": "provider_variants",
+          "tableTo": "provider_registry",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_evaluation_runs": {
+      "name": "catalog_evaluation_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "evaluation_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counters": {
+          "name": "counters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"processed\":0,\"eligible\":0,\"ineligible\":0,\"review\":0,\"reasonBreakdown\":{}}'::jsonb"
+        },
+        "target_policy_id": {
+          "name": "target_policy_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_policy_version": {
+          "name": "target_policy_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "baseline_policy_version": {
+          "name": "baseline_policy_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_ready_snapshot": {
+          "name": "total_ready_snapshot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "snapshot_cutoff": {
+          "name": "snapshot_cutoff",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed": {
+          "name": "processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "eligible": {
+          "name": "eligible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "ineligible": {
+          "name": "ineligible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "pending": {
+          "name": "pending",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "errors": {
+          "name": "errors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "error_sample": {
+          "name": "error_sample",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promoted_by": {
+          "name": "promoted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_eval_runs_policy_version_idx": {
+          "name": "catalog_eval_runs_policy_version_idx",
+          "columns": [
+            {
+              "expression": "policy_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_eval_runs_status_idx": {
+          "name": "catalog_eval_runs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_eval_runs_target_policy_idx": {
+          "name": "catalog_eval_runs_target_policy_idx",
+          "columns": [
+            {
+              "expression": "target_policy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "catalog_evaluation_runs_target_policy_id_catalog_policies_id_fk": {
+          "name": "catalog_evaluation_runs_target_policy_id_catalog_policies_id_fk",
+          "tableFrom": "catalog_evaluation_runs",
+          "tableTo": "catalog_policies",
+          "columnsFrom": [
+            "target_policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_policies": {
+      "name": "catalog_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_policies_version_idx": {
+          "name": "catalog_policies_version_idx",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_policies_active_idx": {
+          "name": "catalog_policies_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"catalog_policies\".\"is_active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_catalog_evaluations": {
+      "name": "media_catalog_evaluations",
+      "schema": "",
+      "columns": {
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "eligibility_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reasons": {
+          "name": "reasons",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "relevance_score": {
+          "name": "relevance_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakout_rule_id": {
+          "name": "breakout_rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluated_at": {
+          "name": "evaluated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "evaluation_context",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'catalog'"
+        }
+      },
+      "indexes": {
+        "media_catalog_eval_status_idx": {
+          "name": "media_catalog_eval_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_catalog_eval_status_relevance_idx": {
+          "name": "media_catalog_eval_status_relevance_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relevance_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_catalog_eval_policy_version_idx": {
+          "name": "media_catalog_eval_policy_version_idx",
+          "columns": [
+            {
+              "expression": "policy_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_catalog_eval_run_id_idx": {
+          "name": "media_catalog_eval_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_catalog_eval_context_idx": {
+          "name": "media_catalog_eval_context_idx",
+          "columns": [
+            {
+              "expression": "context",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_catalog_eval_context_status_idx": {
+          "name": "media_catalog_eval_context_status_idx",
+          "columns": [
+            {
+              "expression": "context",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relevance_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_catalog_evaluations_media_item_id_media_items_id_fk": {
+          "name": "media_catalog_evaluations_media_item_id_media_items_id_fk",
+          "tableFrom": "media_catalog_evaluations",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "media_catalog_evaluations_run_id_catalog_evaluation_runs_id_fk": {
+          "name": "media_catalog_evaluations_run_id_catalog_evaluation_runs_id_fk",
+          "tableFrom": "media_catalog_evaluations",
+          "tableTo": "catalog_evaluation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_catalog_evaluations_media_item_id_policy_version_context_pk": {
+          "name": "media_catalog_evaluations_media_item_id_policy_version_context_pk",
+          "columns": [
+            "media_item_id",
+            "policy_version",
+            "context"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_replies": {
+      "name": "review_replies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_reply_id": {
+          "name": "parent_reply_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_username": {
+          "name": "reply_to_username",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar(280)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_replies_review_idx": {
+          "name": "review_replies_review_idx",
+          "columns": [
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_replies_parent_idx": {
+          "name": "review_replies_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_reply_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_replies_review_id_reviews_id_fk": {
+          "name": "review_replies_review_id_reviews_id_fk",
+          "tableFrom": "review_replies",
+          "tableTo": "reviews",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_replies_user_id_users_id_fk": {
+          "name": "review_replies_user_id_users_id_fk",
+          "tableFrom": "review_replies",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_reports": {
+      "name": "review_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "review_report_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "review_report_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "moderator_id": {
+          "name": "moderator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderator_notes": {
+          "name": "moderator_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_reports_reporter_review_uniq": {
+          "name": "review_reports_reporter_review_uniq",
+          "columns": [
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_reports_status_idx": {
+          "name": "review_reports_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_reports_review_id_reviews_id_fk": {
+          "name": "review_reports_review_id_reviews_id_fk",
+          "tableFrom": "review_reports",
+          "tableTo": "reviews",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_reports_reporter_id_users_id_fk": {
+          "name": "review_reports_reporter_id_users_id_fk",
+          "tableFrom": "review_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_reports_moderator_id_users_id_fk": {
+          "name": "review_reports_moderator_id_users_id_fk",
+          "tableFrom": "review_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "moderator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_votes": {
+      "name": "review_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "review_vote_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_votes_user_review_uniq": {
+          "name": "review_votes_user_review_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_votes_review_idx": {
+          "name": "review_votes_review_idx",
+          "columns": [
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_votes_review_id_reviews_id_fk": {
+          "name": "review_votes_review_id_reviews_id_fk",
+          "tableFrom": "review_votes",
+          "tableTo": "reviews",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_votes_user_id_users_id_fk": {
+          "name": "review_votes_user_id_users_id_fk",
+          "tableFrom": "review_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar(280)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_spoiler": {
+          "name": "has_spoiler",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "likes_count": {
+          "name": "likes_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dislikes_count": {
+          "name": "dislikes_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "replies_count": {
+          "name": "replies_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "reviews_user_media_uniq": {
+          "name": "reviews_user_media_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "media_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"reviews\".\"is_deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_media_idx": {
+          "name": "reviews_media_idx",
+          "columns": [
+            {
+              "expression": "media_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_user_idx": {
+          "name": "reviews_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviews_user_id_users_id_fk": {
+          "name": "reviews_user_id_users_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reviews_media_item_id_media_items_id_fk": {
+          "name": "reviews_media_item_id_media_items_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "media_items",
+          "columnsFrom": [
+            "media_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_posts": {
+      "name": "journal_posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_html": {
+          "name": "body_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "post_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured_image_url": {
+          "name": "featured_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_title": {
+          "name": "meta_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_journal_posts_type": {
+          "name": "idx_journal_posts_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_journal_posts_context": {
+          "name": "idx_journal_posts_context",
+          "columns": [
+            {
+              "expression": "context_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"journal_posts\".\"context_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_journal_posts_published": {
+          "name": "idx_journal_posts_published",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"journal_posts\".\"is_draft\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "journal_posts_author_id_users_id_fk": {
+          "name": "journal_posts_author_id_users_id_fk",
+          "tableFrom": "journal_posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "journal_posts_slug_unique": {
+          "name": "journal_posts_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.content_class": {
+      "name": "content_class",
+      "schema": "public",
+      "values": [
+        "mainstream",
+        "anime",
+        "documentary",
+        "reality",
+        "kids"
+      ]
+    },
+    "public.ingestion_status": {
+      "name": "ingestion_status",
+      "schema": "public",
+      "values": [
+        "importing",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.media_type": {
+      "name": "media_type",
+      "schema": "public",
+      "values": [
+        "movie",
+        "show"
+      ]
+    },
+    "public.person_credit_type": {
+      "name": "person_credit_type",
+      "schema": "public",
+      "values": [
+        "cast",
+        "crew"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin"
+      ]
+    },
+    "public.saved_item_list": {
+      "name": "saved_item_list",
+      "schema": "public",
+      "values": [
+        "for_later",
+        "considering"
+      ]
+    },
+    "public.subscription_trigger": {
+      "name": "subscription_trigger",
+      "schema": "public",
+      "values": [
+        "release",
+        "new_season",
+        "new_episode",
+        "on_streaming",
+        "status_changed"
+      ]
+    },
+    "public.user_media_status": {
+      "name": "user_media_status",
+      "schema": "public",
+      "values": [
+        "watching",
+        "completed",
+        "planned",
+        "dropped",
+        "paused",
+        "caught_up"
+      ]
+    },
+    "public.import_batch_status": {
+      "name": "import_batch_status",
+      "schema": "public",
+      "values": [
+        "processing",
+        "completed",
+        "cancelled"
+      ]
+    },
+    "public.import_pending_status": {
+      "name": "import_pending_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "resolving",
+        "ingesting",
+        "linking",
+        "done",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.distribution_channel": {
+      "name": "distribution_channel",
+      "schema": "public",
+      "values": [
+        "direct",
+        "amazon_channel",
+        "apple_tv_channel"
+      ]
+    },
+    "public.offer_type": {
+      "name": "offer_type",
+      "schema": "public",
+      "values": [
+        "flatrate",
+        "rent",
+        "buy",
+        "ads",
+        "free"
+      ]
+    },
+    "public.eligibility_status": {
+      "name": "eligibility_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "eligible",
+        "ineligible",
+        "review"
+      ]
+    },
+    "public.evaluation_context": {
+      "name": "evaluation_context",
+      "schema": "public",
+      "values": [
+        "catalog",
+        "trending",
+        "homepage",
+        "now_playing",
+        "new_digital",
+        "search"
+      ]
+    },
+    "public.evaluation_run_status": {
+      "name": "evaluation_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "prepared",
+        "failed",
+        "cancelled",
+        "promoted",
+        "pending",
+        "completed",
+        "success"
+      ]
+    },
+    "public.review_report_reason": {
+      "name": "review_report_reason",
+      "schema": "public",
+      "values": [
+        "spam",
+        "harassment",
+        "hate_speech",
+        "misinformation",
+        "spoiler_unmarked",
+        "other"
+      ]
+    },
+    "public.review_report_status": {
+      "name": "review_report_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "reviewed",
+        "dismissed",
+        "actioned"
+      ]
+    },
+    "public.review_vote_type": {
+      "name": "review_vote_type",
+      "schema": "public",
+      "values": [
+        "like",
+        "dislike"
+      ]
+    },
+    "public.post_type": {
+      "name": "post_type",
+      "schema": "public",
+      "values": [
+        "update",
+        "explanation",
+        "fix",
+        "roadmap"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle_v2/meta/_journal.json
+++ b/apps/api/drizzle_v2/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1779347495966,
       "tag": "0028_tidy_havok",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1782220430204,
+      "tag": "0029_many_molecule_man",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -20,6 +20,7 @@ import { HomeModule } from './modules/home/home.module';
 import { IngestionModule } from './modules/ingestion/ingestion.module';
 import { InsightsModule } from './modules/insights/insights.module';
 import { JournalModule } from './modules/journal/journal.module';
+import { PersonModule } from './modules/person/person.module';
 import { ReviewsModule } from './modules/reviews/reviews.module';
 import { ClockModule } from './modules/shared/clock';
 import { StatsModule } from './modules/stats/stats.module';
@@ -156,6 +157,7 @@ const DURATION_RE = /^\d+\s*(ms|s|m|h|d)$/i;
     UserActionsModule,
     JournalModule,
     ReviewsModule,
+    PersonModule,
   ],
   controllers: [HealthController],
   providers: [

--- a/apps/api/src/database/schema.ts
+++ b/apps/api/src/database/schema.ts
@@ -5,6 +5,7 @@
 
 export * from './schema/shared';
 export * from './schema/media';
+export * from './schema/person';
 export * from './schema/users';
 export * from './schema/auth';
 export * from './schema/user-actions';

--- a/apps/api/src/database/schema/person.ts
+++ b/apps/api/src/database/schema/person.ts
@@ -1,0 +1,110 @@
+import { relations, sql } from 'drizzle-orm';
+import {
+  pgTable,
+  text,
+  integer,
+  doublePrecision,
+  timestamp,
+  uniqueIndex,
+  index,
+  pgEnum,
+  uuid,
+} from 'drizzle-orm/pg-core';
+
+import { mediaItems } from './media';
+
+// --- ENUMS ---
+
+/** Distinguishes acting roles (cast) from production roles (crew). */
+export const personCreditTypeEnum = pgEnum('person_credit_type', ['cast', 'crew']);
+
+// --- PERSONS ---
+
+/**
+ * PERSONS (Actors, directors, crew)
+ *
+ * Canonical key is `tmdbId`. Basic fields (name, profilePath) are populated
+ * during media ingest from the credits JSONB. The biography block is enriched
+ * lazily from TMDB /person/{id} on first request — `detailsFetchedAt` acts as
+ * the freshness marker (null = not yet enriched).
+ */
+export const persons = pgTable(
+  'persons',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    tmdbId: integer('tmdb_id').notNull().unique(),
+    slug: text('slug').notNull(),
+    name: text('name').notNull(),
+    profilePath: text('profile_path'),
+    knownForDepartment: text('known_for_department'),
+    popularity: doublePrecision('popularity').default(0),
+
+    // Enriched lazily from TMDB /person/{id}
+    biography: text('biography'),
+    birthday: timestamp('birthday'),
+    deathday: timestamp('deathday'),
+    placeOfBirth: text('place_of_birth'),
+    detailsFetchedAt: timestamp('details_fetched_at'),
+
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  },
+  (t) => ({
+    popularityIdx: index('persons_popularity_idx').on(t.popularity),
+    slugIdx: index('persons_slug_idx').on(t.slug),
+  }),
+);
+
+/**
+ * MEDIA CREDITS (normalized read-model)
+ *
+ * Reverse-lookup link between media items and persons. The source of truth for
+ * a title's credits remains `media_items.credits` (JSONB); this table exists so
+ * we can answer "all works of person X" with an index, mirroring `media_genres`.
+ */
+export const mediaCredits = pgTable(
+  'media_credits',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    mediaItemId: uuid('media_item_id')
+      .references(() => mediaItems.id, { onDelete: 'cascade' })
+      .notNull(),
+    personId: uuid('person_id')
+      .references(() => persons.id, { onDelete: 'cascade' })
+      .notNull(),
+    creditType: personCreditTypeEnum('credit_type').notNull(),
+    character: text('character'), // cast only
+    job: text('job'), // crew only (Director, Writer, …)
+    department: text('department'), // crew only (Directing, Writing, …)
+    order: integer('order').default(0).notNull(),
+  },
+  (t) => ({
+    // Idempotency: one row per (media, person, role, job). COALESCE keeps NULL jobs
+    // (cast) from defeating uniqueness so re-ingest overwrites instead of duplicating.
+    uniq: uniqueIndex('media_credits_uniq').on(
+      t.mediaItemId,
+      t.personId,
+      t.creditType,
+      sql`coalesce(${t.job}, '')`,
+    ),
+    personIdx: index('media_credits_person_idx').on(t.personId),
+    mediaItemIdx: index('media_credits_media_item_idx').on(t.mediaItemId),
+  }),
+);
+
+// --- RELATIONS ---
+
+export const personsRelations = relations(persons, ({ many }) => ({
+  credits: many(mediaCredits),
+}));
+
+export const mediaCreditsRelations = relations(mediaCredits, ({ one }) => ({
+  media: one(mediaItems, {
+    fields: [mediaCredits.mediaItemId],
+    references: [mediaItems.id],
+  }),
+  person: one(persons, {
+    fields: [mediaCredits.personId],
+    references: [persons.id],
+  }),
+}));

--- a/apps/api/src/modules/ingestion/application/pipelines/backfill-person-credits.pipeline.spec.ts
+++ b/apps/api/src/modules/ingestion/application/pipelines/backfill-person-credits.pipeline.spec.ts
@@ -1,0 +1,94 @@
+import { getQueueToken } from '@nestjs/bullmq';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { DATABASE_CONNECTION } from '@/database/database.module';
+
+import { PERSON_CREDITS_WRITER } from '../../../person/public';
+import { BACKFILL_QUEUE, IngestionJob } from '../../ingestion.constants';
+
+import { BackfillPersonCreditsPipeline } from './backfill-person-credits.pipeline';
+
+/**
+ * Lightweight Drizzle mock:
+ *   dispatcher:  db.select().from().where().orderBy().limit()
+ *   processItem: db.select().from().where().limit()
+ */
+function buildDbMock(selectBatches: Array<Array<Record<string, unknown>>>) {
+  let batchIndex = 0;
+  const limit = jest.fn().mockImplementation(() => {
+    const batch = selectBatches[batchIndex] ?? [];
+    batchIndex += 1;
+    return Promise.resolve(batch);
+  });
+  const orderBy = jest.fn().mockReturnValue({ limit });
+  const where = jest.fn().mockReturnValue({ orderBy, limit });
+  const from = jest.fn().mockReturnValue({ where });
+  const select = jest.fn().mockReturnValue({ from });
+  return { db: { select }, spies: { select, where, orderBy, limit } };
+}
+
+describe('BackfillPersonCreditsPipeline', () => {
+  let pipeline: BackfillPersonCreditsPipeline;
+  let queueAddBulk: jest.Mock;
+  let writeFromCredits: jest.Mock;
+
+  const setup = async (selectBatches: Array<Array<Record<string, unknown>>> = [[]]) => {
+    const { db } = buildDbMock(selectBatches);
+    queueAddBulk = jest.fn().mockResolvedValue([]);
+    writeFromCredits = jest.fn().mockResolvedValue(undefined);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BackfillPersonCreditsPipeline,
+        { provide: DATABASE_CONNECTION, useValue: db },
+        { provide: getQueueToken(BACKFILL_QUEUE), useValue: { addBulk: queueAddBulk } },
+        { provide: PERSON_CREDITS_WRITER, useValue: { writeFromCredits } },
+      ],
+    }).compile();
+
+    pipeline = module.get(BackfillPersonCreditsPipeline);
+  };
+
+  describe('dispatch', () => {
+    it('queues a per-item job for each media row, then stops on the empty batch', async () => {
+      await setup([[{ id: 'media-1' }, { id: 'media-2' }], []]);
+
+      await pipeline.dispatch();
+
+      expect(queueAddBulk).toHaveBeenCalledTimes(1);
+      const jobs = queueAddBulk.mock.calls[0][0];
+      expect(jobs).toHaveLength(2);
+      expect(jobs[0]).toMatchObject({
+        name: IngestionJob.BACKFILL_PERSON_CREDITS_ITEM,
+        data: { mediaItemId: 'media-1' },
+      });
+      expect(jobs[0].opts.jobId).toContain('backfill-person-credits_media-1_');
+    });
+
+    it('does not queue anything when there are no candidates', async () => {
+      await setup([[]]);
+      await pipeline.dispatch();
+      expect(queueAddBulk).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('processItem', () => {
+    it('loads the credits row and forwards it to the writer', async () => {
+      const credits = {
+        cast: [{ tmdbId: 1, name: 'A', character: 'X', profilePath: null, order: 0 }],
+        crew: [],
+      };
+      await setup([[{ credits }]]);
+
+      await pipeline.processItem('media-1', 'job-1');
+
+      expect(writeFromCredits).toHaveBeenCalledWith('media-1', credits);
+    });
+
+    it('is a no-op when the media item is missing', async () => {
+      await setup([[]]);
+      await pipeline.processItem('missing', 'job-2');
+      expect(writeFromCredits).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/modules/ingestion/application/pipelines/backfill-person-credits.pipeline.ts
+++ b/apps/api/src/modules/ingestion/application/pipelines/backfill-person-credits.pipeline.ts
@@ -1,0 +1,117 @@
+import { InjectQueue } from '@nestjs/bullmq';
+import { Inject, Injectable, Logger } from '@nestjs/common';
+
+import { Queue } from 'bullmq';
+import { and, gt, isNull, sql } from 'drizzle-orm';
+import { type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+
+import { formatUtcDayId } from '@/common/utils/date.util';
+import { withDbError } from '@/common/utils/db-error.utils';
+import { DATABASE_CONNECTION } from '@/database/database.module';
+import * as schema from '@/database/schema';
+
+import { type Credits } from '../../../ingestion/public';
+import { type IPersonCreditsWriter, PERSON_CREDITS_WRITER } from '../../../person/public';
+import { BACKFILL_QUEUE, IngestionJob, TMDB_BACKFILL_RUN_CAP } from '../../ingestion.constants';
+
+/** Batch size for backfill dispatcher pagination. */
+const BACKFILL_BATCH_SIZE = 100;
+
+/**
+ * Backfills the persons / media_credits read-model from existing
+ * `media_items.credits` JSONB.
+ *
+ * Without this, only titles synced after the feature shipped would have
+ * person credits. Reads no external APIs — pure DB work — so it is safe for the
+ * high-throughput backfill queue.
+ *
+ * 1. Dispatcher: finds media items whose credits contain cast/crew, queues item jobs.
+ * 2. Item job: re-reads the credits for one media item and writes the read-model.
+ */
+@Injectable()
+export class BackfillPersonCreditsPipeline {
+  private readonly logger = new Logger(BackfillPersonCreditsPipeline.name);
+
+  constructor(
+    @Inject(DATABASE_CONNECTION)
+    private readonly db: PostgresJsDatabase<typeof schema>,
+    @InjectQueue(BACKFILL_QUEUE)
+    private readonly queue: Queue,
+    @Inject(PERSON_CREDITS_WRITER)
+    private readonly personCreditsWriter: IPersonCreditsWriter,
+  ) {}
+
+  /** Predicate: credits JSONB has at least one cast or crew member. */
+  private hasCredits() {
+    return sql`(
+      jsonb_array_length(coalesce(${schema.mediaItems.credits} -> 'cast', '[]'::jsonb)) > 0
+      OR jsonb_array_length(coalesce(${schema.mediaItems.credits} -> 'crew', '[]'::jsonb)) > 0
+    )`;
+  }
+
+  /** Dispatcher: finds media with credits and queues per-item jobs. */
+  async dispatch(): Promise<void> {
+    this.logger.log('Starting person-credits backfill dispatcher...');
+
+    const day = formatUtcDayId();
+    let cursor: string | undefined;
+    let totalQueued = 0;
+
+    while (totalQueued < TMDB_BACKFILL_RUN_CAP) {
+      const conditions = [isNull(schema.mediaItems.deletedAt), this.hasCredits()];
+      if (cursor) conditions.push(gt(schema.mediaItems.id, cursor));
+
+      const remaining = TMDB_BACKFILL_RUN_CAP - totalQueued;
+      const batchSize = Math.min(BACKFILL_BATCH_SIZE, remaining);
+
+      const rows = await withDbError('find person-credits backfill candidates', this.logger, () =>
+        this.db
+          .select({ id: schema.mediaItems.id })
+          .from(schema.mediaItems)
+          .where(and(...conditions))
+          .orderBy(schema.mediaItems.id)
+          .limit(batchSize),
+      );
+
+      if (rows.length === 0) break;
+
+      const jobs = rows.map((r) => ({
+        name: IngestionJob.BACKFILL_PERSON_CREDITS_ITEM,
+        data: { mediaItemId: r.id },
+        opts: { jobId: `backfill-person-credits_${r.id}_${day}` },
+      }));
+
+      await this.queue.addBulk(jobs);
+      totalQueued += jobs.length;
+      cursor = rows[rows.length - 1].id;
+
+      this.logger.debug(`Queued ${jobs.length} person-credits jobs (total: ${totalQueued})`);
+    }
+
+    if (totalQueued >= TMDB_BACKFILL_RUN_CAP) {
+      this.logger.log(
+        `Person-credits backfill hit run cap (${TMDB_BACKFILL_RUN_CAP}); remaining items picked up next run`,
+      );
+    } else {
+      this.logger.log(`Person-credits backfill complete: queued=${totalQueued} items`);
+    }
+  }
+
+  /** Item job: re-reads credits for one media item and writes the read-model. */
+  async processItem(mediaItemId: string, jobId: string): Promise<void> {
+    const [row] = await withDbError('load credits for backfill', this.logger, () =>
+      this.db
+        .select({ credits: schema.mediaItems.credits })
+        .from(schema.mediaItems)
+        .where(sql`${schema.mediaItems.id} = ${mediaItemId}`)
+        .limit(1),
+    );
+
+    if (!row) {
+      this.logger.debug(`[${jobId}] media item ${mediaItemId} not found`);
+      return;
+    }
+
+    await this.personCreditsWriter.writeFromCredits(mediaItemId, row.credits as Credits | null);
+  }
+}

--- a/apps/api/src/modules/ingestion/application/services/sync-media.service.ts
+++ b/apps/api/src/modules/ingestion/application/services/sync-media.service.ts
@@ -10,6 +10,7 @@ import {
   classifyContent,
   EvaluationContext,
 } from '../../../catalog-policy/public';
+import { type IPersonCreditsWriter, PERSON_CREDITS_WRITER } from '../../../person/public';
 import { NormalizationService } from '../../../provider/public';
 import { CLOCK_PORT, type IClockPort } from '../../../shared/clock';
 import { ScoreCalculatorService, type ScoreInput } from '../../../shared/score-calculator';
@@ -75,6 +76,10 @@ export class SyncMediaService {
     @Optional()
     @Inject(CATALOG_POLICY_EVALUATOR)
     private readonly catalogEvaluator?: ICatalogPolicyEvaluator,
+
+    @Optional()
+    @Inject(PERSON_CREDITS_WRITER)
+    private readonly personCreditsWriter?: IPersonCreditsWriter,
   ) {}
 
   /**
@@ -175,6 +180,9 @@ export class SyncMediaService {
 
       // Step 9: Normalize watch providers
       await this.normalizeWatchProviders(classified, mediaItem, logPrefix);
+
+      // Step 9b: Populate persons / media_credits read-model from credits
+      await this.writePersonCredits(classified, mediaItem, logPrefix);
 
       // Step 10: Evaluate catalog eligibility (both catalog and trending contexts if applicable)
       const isTrending = trending !== undefined && trending.score > 0;
@@ -432,6 +440,24 @@ export class SyncMediaService {
     } catch (error) {
       // Best-effort: log warning but don't fail the sync
       this.logger.warn(`${logPrefix} Provider normalization failed: ${(error as Error).message}`);
+    }
+  }
+
+  /**
+   * Populates the persons / media_credits read-model from the synced credits.
+   * Best-effort: a failure here must not fail the whole sync.
+   */
+  private async writePersonCredits(
+    media: NormalizedMedia,
+    mediaItem: { id: string } | null,
+    logPrefix: string,
+  ): Promise<void> {
+    if (!this.personCreditsWriter || !mediaItem) return;
+
+    try {
+      await this.personCreditsWriter.writeFromCredits(mediaItem.id, media.credits ?? null);
+    } catch (error) {
+      this.logger.warn(`${logPrefix} Person credits write failed: ${(error as Error).message}`);
     }
   }
 

--- a/apps/api/src/modules/ingestion/application/workers/backfill.worker.spec.ts
+++ b/apps/api/src/modules/ingestion/application/workers/backfill.worker.spec.ts
@@ -9,6 +9,7 @@ import { IngestionJob } from '../../ingestion.constants';
 import { destroyTraktRateLimiter } from '../../../trakt/infrastructure/adapters/base-trakt-http';
 import { BackfillAltTitlesPipeline } from '../pipelines/backfill-alt-titles.pipeline';
 import { BackfillImdbPipeline } from '../pipelines/backfill-imdb.pipeline';
+import { BackfillPersonCreditsPipeline } from '../pipelines/backfill-person-credits.pipeline';
 
 import { BackfillWorker } from './backfill.worker';
 
@@ -22,8 +23,12 @@ describe('BackfillWorker', () => {
   let backfillImdbPipeline: any;
   let resolveImportDispatcherPipeline: any;
   let resolveImportItemPipeline: any;
+  let backfillPersonCreditsPipeline: any;
 
   beforeEach(async () => {
+    backfillPersonCreditsPipeline = {
+      processItem: jest.fn().mockResolvedValue(undefined),
+    };
     backfillAltTitlesPipeline = {
       processItem: jest.fn().mockResolvedValue(undefined),
     };
@@ -52,6 +57,10 @@ describe('BackfillWorker', () => {
         {
           provide: ResolveImportItemPipeline,
           useValue: resolveImportItemPipeline,
+        },
+        {
+          provide: BackfillPersonCreditsPipeline,
+          useValue: backfillPersonCreditsPipeline,
         },
       ],
     }).compile();
@@ -96,6 +105,23 @@ describe('BackfillWorker', () => {
       await worker.process(job);
 
       expect(backfillImdbPipeline.processItem).toHaveBeenCalledWith(100, 'imdb-1');
+    });
+  });
+
+  describe('process - BACKFILL_PERSON_CREDITS_ITEM', () => {
+    it('should route to backfillPersonCreditsPipeline.processItem()', async () => {
+      const job = {
+        name: IngestionJob.BACKFILL_PERSON_CREDITS_ITEM,
+        data: { mediaItemId: 'media-1' },
+        id: 'person-credits-1',
+      } as Job;
+
+      await worker.process(job);
+
+      expect(backfillPersonCreditsPipeline.processItem).toHaveBeenCalledWith(
+        'media-1',
+        'person-credits-1',
+      );
     });
   });
 

--- a/apps/api/src/modules/ingestion/application/workers/backfill.worker.ts
+++ b/apps/api/src/modules/ingestion/application/workers/backfill.worker.ts
@@ -11,6 +11,7 @@ import { ResolveImportItemPipeline } from '../../../user-media/public';
 import { BACKFILL_QUEUE, IngestionJob } from '../../ingestion.constants';
 import { BackfillAltTitlesPipeline } from '../pipelines/backfill-alt-titles.pipeline';
 import { BackfillImdbPipeline } from '../pipelines/backfill-imdb.pipeline';
+import { BackfillPersonCreditsPipeline } from '../pipelines/backfill-person-credits.pipeline';
 
 /**
  * High-throughput worker for backfill item jobs (TMDB-only, no Trakt).
@@ -34,6 +35,7 @@ export class BackfillWorker extends WorkerHost {
     private readonly backfillImdbPipeline: BackfillImdbPipeline,
     private readonly resolveImportDispatcherPipeline: ResolveImportDispatcherPipeline,
     private readonly resolveImportItemPipeline: ResolveImportItemPipeline,
+    private readonly backfillPersonCreditsPipeline: BackfillPersonCreditsPipeline,
   ) {
     super();
   }
@@ -64,6 +66,13 @@ export class BackfillWorker extends WorkerHost {
 
         case IngestionJob.BACKFILL_IMDB_ITEM:
           await this.backfillImdbPipeline.processItem(job.data.tmdbId!, job.id ?? 'unknown');
+          break;
+
+        case IngestionJob.BACKFILL_PERSON_CREDITS_ITEM:
+          await this.backfillPersonCreditsPipeline.processItem(
+            job.data.mediaItemId!,
+            job.id ?? 'unknown',
+          );
           break;
 
         case IngestionJob.RESOLVE_IMPORT_DISPATCHER:

--- a/apps/api/src/modules/ingestion/application/workers/sync.worker.spec.ts
+++ b/apps/api/src/modules/ingestion/application/workers/sync.worker.spec.ts
@@ -12,6 +12,7 @@ import { NewReleasesPipeline } from '../pipelines/new-releases.pipeline';
 import { BackfillAltTitlesPipeline } from '../pipelines/backfill-alt-titles.pipeline';
 import { BackfillImdbPipeline } from '../pipelines/backfill-imdb.pipeline';
 import { BackfillMdblistRatingsPipeline } from '../pipelines/backfill-mdblist-ratings.pipeline';
+import { BackfillPersonCreditsPipeline } from '../pipelines/backfill-person-credits.pipeline';
 import { destroyTraktRateLimiter } from '../../../trakt/infrastructure/adapters/base-trakt-http';
 
 afterAll(() => {
@@ -29,6 +30,7 @@ describe('SyncWorker', () => {
   let backfillImdbPipeline: any;
   let backfillAltTitlesPipeline: any;
   let backfillMdblistRatingsPipeline: any;
+  let backfillPersonCreditsPipeline: any;
 
   beforeEach(async () => {
     syncService = {
@@ -77,6 +79,11 @@ describe('SyncWorker', () => {
       processItem: jest.fn().mockResolvedValue(undefined),
     };
 
+    backfillPersonCreditsPipeline = {
+      dispatch: jest.fn().mockResolvedValue(undefined),
+      processItem: jest.fn().mockResolvedValue(undefined),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         SyncWorker,
@@ -89,6 +96,7 @@ describe('SyncWorker', () => {
         { provide: BackfillImdbPipeline, useValue: backfillImdbPipeline },
         { provide: BackfillAltTitlesPipeline, useValue: backfillAltTitlesPipeline },
         { provide: BackfillMdblistRatingsPipeline, useValue: backfillMdblistRatingsPipeline },
+        { provide: BackfillPersonCreditsPipeline, useValue: backfillPersonCreditsPipeline },
       ],
     }).compile();
 

--- a/apps/api/src/modules/ingestion/application/workers/sync.worker.ts
+++ b/apps/api/src/modules/ingestion/application/workers/sync.worker.ts
@@ -10,6 +10,7 @@ import { INGESTION_QUEUE, IngestionJob } from '../../ingestion.constants';
 import { BackfillAltTitlesPipeline } from '../pipelines/backfill-alt-titles.pipeline';
 import { BackfillImdbPipeline } from '../pipelines/backfill-imdb.pipeline';
 import { BackfillMdblistRatingsPipeline } from '../pipelines/backfill-mdblist-ratings.pipeline';
+import { BackfillPersonCreditsPipeline } from '../pipelines/backfill-person-credits.pipeline';
 import { NewReleasesPipeline } from '../pipelines/new-releases.pipeline';
 import { NowPlayingPipeline } from '../pipelines/now-playing.pipeline';
 import { SnapshotsPipeline } from '../pipelines/snapshots.pipeline';
@@ -47,6 +48,7 @@ export class SyncWorker extends WorkerHost {
     private readonly backfillImdbPipeline: BackfillImdbPipeline,
     private readonly backfillAltTitlesPipeline: BackfillAltTitlesPipeline,
     private readonly backfillMdblistRatingsPipeline: BackfillMdblistRatingsPipeline,
+    private readonly backfillPersonCreditsPipeline: BackfillPersonCreditsPipeline,
   ) {
     super();
   }
@@ -157,6 +159,11 @@ export class SyncWorker extends WorkerHost {
         // MDBList RT ratings backfill dispatcher (item jobs run on RatingsBackfillWorker)
         case IngestionJob.BACKFILL_MDBLIST_RATINGS_DISPATCHER:
           await this.backfillMdblistRatingsPipeline.dispatch();
+          break;
+
+        // Person-credits backfill dispatcher (item jobs run on BackfillWorker)
+        case IngestionJob.BACKFILL_PERSON_CREDITS_DISPATCHER:
+          await this.backfillPersonCreditsPipeline.dispatch();
           break;
 
         default:

--- a/apps/api/src/modules/ingestion/ingestion.constants.ts
+++ b/apps/api/src/modules/ingestion/ingestion.constants.ts
@@ -80,6 +80,11 @@ export enum IngestionJob {
   BACKFILL_MDBLIST_RATINGS_DISPATCHER = 'backfill-mdblist-ratings-dispatcher',
   /** Item job: fetches RT ratings (critics + audience) from MDBList. @queue ratings-backfill */
   BACKFILL_MDBLIST_RATINGS_ITEM = 'backfill-mdblist-ratings-item',
+
+  /** Dispatcher job: finds media with credits and queues per-item person-credits backfill. @queue backfill */
+  BACKFILL_PERSON_CREDITS_DISPATCHER = 'backfill-person-credits-dispatcher',
+  /** Item job: normalizes a media item's credits JSONB into persons/media_credits. @queue backfill */
+  BACKFILL_PERSON_CREDITS_ITEM = 'backfill-person-credits-item',
 }
 
 /**

--- a/apps/api/src/modules/ingestion/ingestion.module.ts
+++ b/apps/api/src/modules/ingestion/ingestion.module.ts
@@ -8,6 +8,7 @@ import schedulerConfig from '../../config/scheduler.config';
 import tvmazeConfig from '../../config/tvmaze.config';
 import { CatalogModule } from '../catalog/catalog.module';
 import { CatalogPolicyModule } from '../catalog-policy/catalog-policy.module';
+import { PersonModule } from '../person/person.module';
 import { ProviderModule } from '../provider/provider.module';
 import { ScoreCalculatorModule } from '../shared/score-calculator/score-calculator.module';
 import { StatsModule } from '../stats/stats.module';
@@ -19,6 +20,7 @@ import { UserMediaModule } from '../user-media/user-media.module';
 import { BackfillAltTitlesPipeline } from './application/pipelines/backfill-alt-titles.pipeline';
 import { BackfillImdbPipeline } from './application/pipelines/backfill-imdb.pipeline';
 import { BackfillMdblistRatingsPipeline } from './application/pipelines/backfill-mdblist-ratings.pipeline';
+import { BackfillPersonCreditsPipeline } from './application/pipelines/backfill-person-credits.pipeline';
 import { NewReleasesPipeline } from './application/pipelines/new-releases.pipeline';
 import { NowPlayingPipeline } from './application/pipelines/now-playing.pipeline';
 import { SnapshotsPipeline } from './application/pipelines/snapshots.pipeline';
@@ -53,6 +55,7 @@ import { IngestionController } from './presentation/controllers/ingestion.contro
   imports: [
     CatalogModule,
     CatalogPolicyModule,
+    PersonModule,
     ProviderModule,
     TmdbModule,
     TraktModule,
@@ -112,6 +115,7 @@ import { IngestionController } from './presentation/controllers/ingestion.contro
     BackfillImdbPipeline,
     BackfillAltTitlesPipeline,
     BackfillMdblistRatingsPipeline,
+    BackfillPersonCreditsPipeline,
   ],
   exports: [SyncMediaService, SnapshotsService],
 })

--- a/apps/api/src/modules/ingestion/presentation/controllers/ingestion.controller.ts
+++ b/apps/api/src/modules/ingestion/presentation/controllers/ingestion.controller.ts
@@ -551,4 +551,44 @@ export class IngestionController {
       force: isForce,
     };
   }
+
+  /**
+   * Queues a backfill job that populates the persons / media_credits read-model
+   * from existing media_items.credits JSONB. One-time operation; future syncs
+   * populate the read-model automatically.
+   */
+  @Post('backfill/person-credits')
+  @ApiOperation({
+    summary: 'Backfill person credits read-model from existing credits',
+    description:
+      'Finds media items whose credits JSONB contains cast/crew and queues per-item jobs ' +
+      'that upsert persons and rebuild media_credits rows. Pure DB work — no external API calls.',
+  })
+  @ApiQuery({
+    name: 'force',
+    required: false,
+    type: String,
+    description: 'Bypass daily deduplication',
+  })
+  @ApiOkResponse({ type: IngestionJobResponseDto, description: 'Backfill job queued' })
+  @HttpCode(HttpStatus.ACCEPTED)
+  async backfillPersonCredits(@Query('force') force?: string) {
+    const isForce = force === 'true';
+    const today = formatUtcDayId();
+    const window = isForce ? Date.now().toString() : today;
+    const jobId = `backfill_person_credits_${window}`;
+
+    const job = await this.ingestionQueue.add(
+      IngestionJob.BACKFILL_PERSON_CREDITS_DISPATCHER,
+      {},
+      { jobId },
+    );
+
+    return {
+      status: 'queued',
+      jobId: job.id,
+      jobType: IngestionJob.BACKFILL_PERSON_CREDITS_DISPATCHER,
+      force: isForce,
+    };
+  }
 }

--- a/apps/api/src/modules/person/application/services/person-credits-writer.service.spec.ts
+++ b/apps/api/src/modules/person/application/services/person-credits-writer.service.spec.ts
@@ -1,0 +1,141 @@
+import * as fc from 'fast-check';
+
+import { type Credits } from '../../../ingestion/public';
+import { PersonCreditType } from '../../domain/constants/person.constants';
+import {
+  type CreditSeed,
+  type IPersonRepository,
+  type PersonSeed,
+} from '../../domain/repositories/person.repository.interface';
+
+import { PersonCreditsWriterService } from './person-credits-writer.service';
+
+interface Captured {
+  mediaItemId: string;
+  persons: PersonSeed[];
+  credits: CreditSeed[];
+}
+
+function makeService(): { service: PersonCreditsWriterService; calls: Captured[] } {
+  const calls: Captured[] = [];
+  const repo: IPersonRepository = {
+    findByTmdbId: jest.fn(),
+    updateDetails: jest.fn(),
+    findEligibleCredits: jest.fn(),
+    writeMediaCredits: jest.fn(async (mediaItemId, persons, credits) => {
+      calls.push({ mediaItemId, persons, credits });
+    }),
+  };
+  return { service: new PersonCreditsWriterService(repo), calls };
+}
+
+describe('PersonCreditsWriterService', () => {
+  it('maps cast and crew into person + credit seeds', async () => {
+    const { service, calls } = makeService();
+    const credits: Credits = {
+      cast: [{ tmdbId: 1, name: 'Brad Pitt', character: 'Tyler', profilePath: '/b.jpg', order: 0 }],
+      crew: [
+        {
+          tmdbId: 2,
+          name: 'David Fincher',
+          job: 'Director',
+          department: 'Directing',
+          profilePath: '/d.jpg',
+        },
+      ],
+    };
+
+    await service.writeFromCredits('media-1', credits);
+
+    expect(calls).toHaveLength(1);
+    const { persons, credits: seeds } = calls[0];
+    expect(persons.map((p) => p.tmdbId).sort()).toEqual([1, 2]);
+    expect(seeds).toContainEqual(
+      expect.objectContaining({
+        personTmdbId: 1,
+        creditType: PersonCreditType.CAST,
+        character: 'Tyler',
+        job: null,
+        order: 0,
+      }),
+    );
+    expect(seeds).toContainEqual(
+      expect.objectContaining({
+        personTmdbId: 2,
+        creditType: PersonCreditType.CREW,
+        job: 'Director',
+        department: 'Directing',
+        character: null,
+      }),
+    );
+  });
+
+  it('clears credits for empty input', async () => {
+    const { service, calls } = makeService();
+    await service.writeFromCredits('media-1', { cast: [], crew: [] });
+    expect(calls[0]).toEqual({ mediaItemId: 'media-1', persons: [], credits: [] });
+  });
+
+  it('handles null credits as a clear', async () => {
+    const { service, calls } = makeService();
+    await service.writeFromCredits('media-1', null);
+    expect(calls[0]).toEqual({ mediaItemId: 'media-1', persons: [], credits: [] });
+  });
+
+  it('skips crew members without a job', async () => {
+    const { service, calls } = makeService();
+    await service.writeFromCredits('media-1', {
+      cast: [],
+      crew: [{ tmdbId: 5, name: 'Nobody', job: '', department: '', profilePath: null }],
+    });
+    expect(calls[0].credits).toHaveLength(0);
+  });
+
+  describe('property-based invariants', () => {
+    const castArb = fc.record({
+      tmdbId: fc.integer({ min: 1, max: 1000 }),
+      name: fc.string({ minLength: 1, maxLength: 20 }),
+      character: fc.string({ maxLength: 20 }),
+      profilePath: fc.option(fc.string(), { nil: null }),
+      order: fc.nat({ max: 50 }),
+    });
+    const crewArb = fc.record({
+      tmdbId: fc.integer({ min: 1, max: 1000 }),
+      name: fc.string({ minLength: 1, maxLength: 20 }),
+      job: fc.constantFrom('Director', 'Writer', 'Producer'),
+      department: fc.string({ minLength: 1, maxLength: 20 }),
+      profilePath: fc.option(fc.string(), { nil: null }),
+    });
+
+    it('person seeds are unique by tmdbId and cover every credited person', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.array(castArb, { maxLength: 15 }),
+          fc.array(crewArb, { maxLength: 15 }),
+          async (cast, crew) => {
+            const { service, calls } = makeService();
+            await service.writeFromCredits('m', { cast, crew });
+
+            const { persons, credits } = calls[0];
+            const seedIds = persons.map((p) => p.tmdbId);
+
+            // unique person seeds
+            expect(new Set(seedIds).size).toBe(seedIds.length);
+
+            // every credited tmdbId has exactly one seed
+            const creditedIds = new Set([
+              ...cast.map((c) => c.tmdbId),
+              ...crew.map((c) => c.tmdbId),
+            ]);
+            expect(new Set(seedIds)).toEqual(creditedIds);
+
+            // every credit seed references a known person
+            for (const c of credits) {
+              expect(creditedIds.has(c.personTmdbId)).toBe(true);
+            }
+          },
+        ),
+      );
+    });
+  });
+});

--- a/apps/api/src/modules/person/application/services/person-credits-writer.service.ts
+++ b/apps/api/src/modules/person/application/services/person-credits-writer.service.ts
@@ -1,0 +1,87 @@
+import { Inject, Injectable } from '@nestjs/common';
+
+import { generateSlug } from '../../../catalog/public';
+import { type Credits } from '../../../ingestion/public';
+import { PersonCreditType } from '../../domain/constants/person.constants';
+import { type IPersonCreditsWriter } from '../../domain/ports/person-credits-writer.port';
+import {
+  type CreditSeed,
+  type IPersonRepository,
+  type PersonSeed,
+  PERSON_REPOSITORY,
+} from '../../domain/repositories/person.repository.interface';
+
+/**
+ * Normalizes a media item's credits JSONB into the persons / media_credits
+ * read-model. Shared by the ingestion pipeline and the backfill job. Performs
+ * no external calls — the data is already in hand.
+ */
+@Injectable()
+export class PersonCreditsWriterService implements IPersonCreditsWriter {
+  constructor(
+    @Inject(PERSON_REPOSITORY)
+    private readonly personRepository: IPersonRepository,
+  ) {}
+
+  async writeFromCredits(mediaItemId: string, credits: Credits | null): Promise<void> {
+    const cast = credits?.cast ?? [];
+    const crew = credits?.crew ?? [];
+
+    if (cast.length === 0 && crew.length === 0) {
+      // Still clear any stale credits for this media item.
+      await this.personRepository.writeMediaCredits(mediaItemId, [], []);
+      return;
+    }
+
+    const seedsByTmdb = new Map<number, PersonSeed>();
+    const creditSeeds: CreditSeed[] = [];
+
+    for (const member of cast) {
+      if (!member.tmdbId) continue;
+      this.collectPerson(seedsByTmdb, member.tmdbId, member.name, member.profilePath);
+      creditSeeds.push({
+        personTmdbId: member.tmdbId,
+        creditType: PersonCreditType.CAST,
+        character: member.character || null,
+        job: null,
+        department: null,
+        order: member.order ?? 0,
+      });
+    }
+
+    for (const member of crew) {
+      if (!member.tmdbId || !member.job) continue;
+      this.collectPerson(seedsByTmdb, member.tmdbId, member.name, member.profilePath);
+      creditSeeds.push({
+        personTmdbId: member.tmdbId,
+        creditType: PersonCreditType.CREW,
+        character: null,
+        job: member.job,
+        department: member.department || null,
+        order: 0,
+      });
+    }
+
+    await this.personRepository.writeMediaCredits(
+      mediaItemId,
+      [...seedsByTmdb.values()],
+      creditSeeds,
+    );
+  }
+
+  private collectPerson(
+    seeds: Map<number, PersonSeed>,
+    tmdbId: number,
+    name: string,
+    profilePath: string | null,
+  ): void {
+    if (seeds.has(tmdbId)) return;
+    seeds.set(tmdbId, {
+      tmdbId,
+      slug: generateSlug(name, tmdbId),
+      name,
+      profilePath: profilePath ?? null,
+      knownForDepartment: null,
+    });
+  }
+}

--- a/apps/api/src/modules/person/application/services/person.service.spec.ts
+++ b/apps/api/src/modules/person/application/services/person.service.spec.ts
@@ -1,0 +1,115 @@
+import { type PersonDetails, type TmdbAdapter } from '../../../tmdb/public';
+import { type IClockPort } from '../../../shared/clock';
+import { PERSON_DETAILS_TTL_DAYS } from '../../domain/constants/person.constants';
+import { type Person } from '../../domain/entities/person.entity';
+import { PersonNotFoundError } from '../../domain/errors';
+import { type IPersonRepository } from '../../domain/repositories/person.repository.interface';
+
+import { PersonService } from './person.service';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function basePerson(overrides: Partial<Person> = {}): Person {
+  return {
+    id: 'uuid-1',
+    tmdbId: 287,
+    slug: 'brad-pitt',
+    name: 'Brad Pitt',
+    profilePath: '/b.jpg',
+    knownForDepartment: 'Acting',
+    popularity: 10,
+    biography: null,
+    birthday: null,
+    deathday: null,
+    placeOfBirth: null,
+    detailsFetchedAt: null,
+    ...overrides,
+  };
+}
+
+function setup(person: Person | null) {
+  const repo: jest.Mocked<IPersonRepository> = {
+    findByTmdbId: jest.fn().mockResolvedValue(person),
+    writeMediaCredits: jest.fn(),
+    updateDetails: jest.fn().mockResolvedValue(undefined),
+    findEligibleCredits: jest.fn().mockResolvedValue({ items: [], total: 0 }),
+  };
+  const now = new Date('2026-06-23T00:00:00Z');
+  const clock: IClockPort = { now: () => now };
+  const tmdb = { getPerson: jest.fn() } as unknown as jest.Mocked<TmdbAdapter>;
+  const service = new PersonService(repo, tmdb, clock);
+  return { service, repo, tmdb, now };
+}
+
+describe('PersonService', () => {
+  it('throws PersonNotFoundError when the person is absent', async () => {
+    const { service } = setup(null);
+    await expect(service.getByTmdbId(999)).rejects.toBeInstanceOf(PersonNotFoundError);
+  });
+
+  it('enriches biography on first read and persists it', async () => {
+    const { service, repo, tmdb } = setup(basePerson({ detailsFetchedAt: null }));
+    const details: PersonDetails = {
+      tmdbId: 287,
+      name: 'Brad Pitt',
+      biography: 'An American actor.',
+      birthday: new Date('1963-12-18'),
+      deathday: null,
+      placeOfBirth: 'Shawnee, Oklahoma, USA',
+      profilePath: '/new.jpg',
+      knownForDepartment: 'Acting',
+      popularity: 42,
+    };
+    tmdb.getPerson.mockResolvedValue(details);
+
+    const result = await service.getByTmdbId(287);
+
+    expect(tmdb.getPerson).toHaveBeenCalledWith(287);
+    expect(repo.updateDetails).toHaveBeenCalledWith(
+      'uuid-1',
+      expect.objectContaining({ biography: 'An American actor.', popularity: 42 }),
+    );
+    expect(result.biography).toBe('An American actor.');
+  });
+
+  it('does not re-fetch when details are fresh', async () => {
+    const fresh = new Date('2026-06-20T00:00:00Z'); // 3 days ago
+    const { service, tmdb, repo } = setup(
+      basePerson({ detailsFetchedAt: fresh, biography: 'cached' }),
+    );
+
+    const result = await service.getByTmdbId(287);
+
+    expect(tmdb.getPerson).not.toHaveBeenCalled();
+    expect(repo.updateDetails).not.toHaveBeenCalled();
+    expect(result.biography).toBe('cached');
+  });
+
+  it('re-fetches once details are older than the TTL', async () => {
+    const stale = new Date(
+      Date.parse('2026-06-23T00:00:00Z') - (PERSON_DETAILS_TTL_DAYS + 1) * MS_PER_DAY,
+    );
+    const { service, tmdb } = setup(basePerson({ detailsFetchedAt: stale }));
+    tmdb.getPerson.mockResolvedValue(null);
+
+    await service.getByTmdbId(287);
+
+    expect(tmdb.getPerson).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the un-enriched person when TMDB enrichment fails', async () => {
+    const { service, tmdb, repo } = setup(basePerson({ detailsFetchedAt: null }));
+    tmdb.getPerson.mockRejectedValue(new Error('TMDB down'));
+
+    const result = await service.getByTmdbId(287);
+
+    expect(result.tmdbId).toBe(287);
+    expect(repo.updateDetails).not.toHaveBeenCalled();
+  });
+
+  it('delegates credits listing to the repository', async () => {
+    const { service, repo } = setup(basePerson());
+    await service.getCredits(287, { limit: 20, offset: 0 });
+    expect(repo.findEligibleCredits).toHaveBeenCalledWith('uuid-1', { limit: 20, offset: 0 });
+  });
+});

--- a/apps/api/src/modules/person/application/services/person.service.ts
+++ b/apps/api/src/modules/person/application/services/person.service.ts
@@ -1,0 +1,105 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+
+import { MS_PER_DAY } from '../../../../common/constants';
+import { CLOCK_PORT, type IClockPort } from '../../../shared/clock';
+import { TmdbAdapter } from '../../../tmdb/public';
+import { PERSON_DETAILS_TTL_DAYS } from '../../domain/constants/person.constants';
+import { type Person, type PersonCreditsResult } from '../../domain/entities/person.entity';
+import { PersonNotFoundError } from '../../domain/errors';
+import {
+  type IPersonRepository,
+  type PersonCreditsQueryOptions,
+  PERSON_REPOSITORY,
+} from '../../domain/repositories/person.repository.interface';
+
+/**
+ * Read-side orchestration for the person page.
+ *
+ * The biography block is enriched lazily from TMDB on first request (and after
+ * the TTL lapses); the result is persisted so subsequent reads hit the DB only.
+ */
+@Injectable()
+export class PersonService {
+  private readonly logger = new Logger(PersonService.name);
+
+  constructor(
+    @Inject(PERSON_REPOSITORY)
+    private readonly personRepository: IPersonRepository,
+    private readonly tmdbAdapter: TmdbAdapter,
+    @Inject(CLOCK_PORT)
+    private readonly clock: IClockPort,
+  ) {}
+
+  /**
+   * Returns a person by TMDB id, enriching the biography block on demand.
+   * @throws {PersonNotFoundError} when the person is not in the catalog.
+   */
+  async getByTmdbId(tmdbId: number): Promise<Person> {
+    const person = await this.personRepository.findByTmdbId(tmdbId);
+    if (!person) throw new PersonNotFoundError(tmdbId);
+
+    if (!this.needsEnrichment(person)) return person;
+
+    return this.enrich(person);
+  }
+
+  /**
+   * Lists a person's catalog-eligible works.
+   * @throws {PersonNotFoundError} when the person is not in the catalog.
+   */
+  async getCredits(
+    tmdbId: number,
+    options: PersonCreditsQueryOptions,
+  ): Promise<PersonCreditsResult> {
+    const person = await this.personRepository.findByTmdbId(tmdbId);
+    if (!person) throw new PersonNotFoundError(tmdbId);
+
+    return this.personRepository.findEligibleCredits(person.id, options);
+  }
+
+  private needsEnrichment(person: Person): boolean {
+    if (!person.detailsFetchedAt) return true;
+    const ageMs = this.clock.now().getTime() - person.detailsFetchedAt.getTime();
+    return ageMs > PERSON_DETAILS_TTL_DAYS * MS_PER_DAY;
+  }
+
+  /** Best-effort TMDB enrichment — failures return the un-enriched person. */
+  private async enrich(person: Person): Promise<Person> {
+    try {
+      const details = await this.tmdbAdapter.getPerson(person.tmdbId);
+      if (!details) return person;
+
+      const now = this.clock.now();
+      const knownForDepartment = details.knownForDepartment ?? person.knownForDepartment;
+      const profilePath = details.profilePath ?? person.profilePath;
+
+      await this.personRepository.updateDetails(person.id, {
+        biography: details.biography,
+        birthday: details.birthday,
+        deathday: details.deathday,
+        placeOfBirth: details.placeOfBirth,
+        knownForDepartment,
+        popularity: details.popularity,
+        profilePath,
+        detailsFetchedAt: now,
+      });
+
+      return {
+        ...person,
+        biography: details.biography,
+        birthday: details.birthday,
+        deathday: details.deathday,
+        placeOfBirth: details.placeOfBirth,
+        knownForDepartment,
+        popularity: details.popularity,
+        profilePath,
+        detailsFetchedAt: now,
+      };
+    } catch (error) {
+      this.logger.warn(
+        `Person enrichment failed for tmdbId=${person.tmdbId}: ${(error as Error).message}`,
+      );
+      return person;
+    }
+  }
+}

--- a/apps/api/src/modules/person/domain/constants/person.constants.ts
+++ b/apps/api/src/modules/person/domain/constants/person.constants.ts
@@ -1,0 +1,20 @@
+/**
+ * Person module domain constants.
+ */
+
+/** Re-enrich biography/details from TMDB once they are older than this. */
+export const PERSON_DETAILS_TTL_DAYS = 30;
+
+/** Default page size for a person's credits list. */
+export const PERSON_CREDITS_DEFAULT_LIMIT = 20;
+
+/** Hard cap on a person's credits page size (mirrors catalog Max 50). */
+export const PERSON_CREDITS_MAX_LIMIT = 50;
+
+/** Credit role discriminator. */
+export const PersonCreditType = {
+  CAST: 'cast',
+  CREW: 'crew',
+} as const;
+
+export type PersonCreditTypeValue = (typeof PersonCreditType)[keyof typeof PersonCreditType];

--- a/apps/api/src/modules/person/domain/entities/person.entity.ts
+++ b/apps/api/src/modules/person/domain/entities/person.entity.ts
@@ -1,0 +1,48 @@
+import { type MediaType } from '../../../../common/enums/media-type.enum';
+
+/**
+ * A person (actor, director, crew member) as stored in the catalog.
+ */
+export interface Person {
+  id: string;
+  tmdbId: number;
+  slug: string;
+  name: string;
+  profilePath: string | null;
+  knownForDepartment: string | null;
+  popularity: number;
+  biography: string | null;
+  birthday: Date | null;
+  deathday: Date | null;
+  placeOfBirth: string | null;
+  /** null = biography never enriched from TMDB. */
+  detailsFetchedAt: Date | null;
+}
+
+/**
+ * One work in a person's filmography (one row per title), restricted to
+ * catalog-eligible media. A person may contribute as both cast and crew on the
+ * same title — those are merged here into a single entry.
+ */
+export interface PersonCreditItem {
+  mediaItemId: string;
+  type: MediaType;
+  tmdbId: number;
+  title: string;
+  slug: string;
+  posterPath: string | null;
+  releaseDate: Date | null;
+  ratingoScore: number | null;
+  /** Cast character on this title, if the person acted in it. */
+  character: string | null;
+  /** Crew jobs on this title (e.g. Director, Creator); empty if none. */
+  jobs: string[];
+}
+
+/**
+ * Paginated result of a person's catalog credits.
+ */
+export interface PersonCreditsResult {
+  items: PersonCreditItem[];
+  total: number;
+}

--- a/apps/api/src/modules/person/domain/errors/index.ts
+++ b/apps/api/src/modules/person/domain/errors/index.ts
@@ -1,0 +1,1 @@
+export { PersonDomainError, PersonNotFoundError } from './person.errors';

--- a/apps/api/src/modules/person/domain/errors/person.errors.ts
+++ b/apps/api/src/modules/person/domain/errors/person.errors.ts
@@ -1,0 +1,26 @@
+/**
+ * Person Domain Errors
+ *
+ * Pure domain errors mapped to HTTP responses in the presentation layer.
+ */
+
+/**
+ * Base class for person domain errors.
+ */
+export abstract class PersonDomainError extends Error {
+  abstract readonly code: string;
+}
+
+/**
+ * Thrown when a person is not found by TMDB id.
+ */
+export class PersonNotFoundError extends PersonDomainError {
+  readonly code = 'PERSON_NOT_FOUND';
+  readonly tmdbId: number;
+
+  constructor(tmdbId: number) {
+    super(`Person with TMDB id "${tmdbId}" not found`);
+    this.name = 'PersonNotFoundError';
+    this.tmdbId = tmdbId;
+  }
+}

--- a/apps/api/src/modules/person/domain/ports/person-credits-writer.port.ts
+++ b/apps/api/src/modules/person/domain/ports/person-credits-writer.port.ts
@@ -1,0 +1,12 @@
+import { type Credits } from '../../../ingestion/public';
+
+export const PERSON_CREDITS_WRITER = Symbol('PERSON_CREDITS_WRITER');
+
+/**
+ * Cross-module capability: normalize a media item's credits JSONB into the
+ * persons / media_credits read-model. Consumed by the ingestion pipeline and
+ * the backfill job.
+ */
+export interface IPersonCreditsWriter {
+  writeFromCredits(mediaItemId: string, credits: Credits | null): Promise<void>;
+}

--- a/apps/api/src/modules/person/domain/repositories/person.repository.interface.ts
+++ b/apps/api/src/modules/person/domain/repositories/person.repository.interface.ts
@@ -1,0 +1,72 @@
+import { type PersonCreditTypeValue } from '../constants/person.constants';
+import { type Person, type PersonCreditsResult } from '../entities/person.entity';
+
+export const PERSON_REPOSITORY = Symbol('PERSON_REPOSITORY');
+
+/**
+ * Minimal person identity extracted from credits during ingest.
+ */
+export interface PersonSeed {
+  tmdbId: number;
+  slug: string;
+  name: string;
+  profilePath: string | null;
+  knownForDepartment: string | null;
+}
+
+/**
+ * One normalized credit row to persist for a media item.
+ */
+export interface CreditSeed {
+  personTmdbId: number;
+  creditType: PersonCreditTypeValue;
+  character: string | null;
+  job: string | null;
+  department: string | null;
+  order: number;
+}
+
+/**
+ * Biography block enriched lazily from TMDB.
+ */
+export interface PersonDetailsUpdate {
+  biography: string | null;
+  birthday: Date | null;
+  deathday: Date | null;
+  placeOfBirth: string | null;
+  knownForDepartment: string | null;
+  popularity: number;
+  profilePath: string | null;
+  detailsFetchedAt: Date;
+}
+
+export interface PersonCreditsQueryOptions {
+  limit: number;
+  offset: number;
+  creditType?: PersonCreditTypeValue;
+}
+
+export interface IPersonRepository {
+  /** Look up a person by canonical TMDB id. */
+  findByTmdbId(tmdbId: number): Promise<Person | null>;
+
+  /**
+   * Idempotently persists a media item's credits: upserts persons (without
+   * touching the lazily-enriched biography block), then replaces all
+   * media_credits rows for the media item (delete-then-insert).
+   */
+  writeMediaCredits(
+    mediaItemId: string,
+    persons: PersonSeed[],
+    credits: CreditSeed[],
+  ): Promise<void>;
+
+  /** Persists the enriched biography block for a person. */
+  updateDetails(personId: string, details: PersonDetailsUpdate): Promise<void>;
+
+  /** Lists a person's catalog-eligible works. */
+  findEligibleCredits(
+    personId: string,
+    options: PersonCreditsQueryOptions,
+  ): Promise<PersonCreditsResult>;
+}

--- a/apps/api/src/modules/person/infrastructure/mappers/person.mapper.spec.ts
+++ b/apps/api/src/modules/person/infrastructure/mappers/person.mapper.spec.ts
@@ -1,0 +1,39 @@
+import { mapPerson, type PersonRow } from './person.mapper';
+
+const row: PersonRow = {
+  id: 'uuid-1',
+  tmdbId: 287,
+  slug: 'brad-pitt',
+  name: 'Brad Pitt',
+  profilePath: '/b.jpg',
+  knownForDepartment: 'Acting',
+  popularity: 12.5,
+  biography: 'Bio',
+  birthday: new Date('1963-12-18'),
+  deathday: null,
+  placeOfBirth: 'USA',
+  detailsFetchedAt: new Date('2026-06-23'),
+};
+
+describe('mapPerson', () => {
+  it('maps a row to the Person entity', () => {
+    expect(mapPerson(row)).toEqual({
+      id: 'uuid-1',
+      tmdbId: 287,
+      slug: 'brad-pitt',
+      name: 'Brad Pitt',
+      profilePath: '/b.jpg',
+      knownForDepartment: 'Acting',
+      popularity: 12.5,
+      biography: 'Bio',
+      birthday: new Date('1963-12-18'),
+      deathday: null,
+      placeOfBirth: 'USA',
+      detailsFetchedAt: new Date('2026-06-23'),
+    });
+  });
+
+  it('coerces null popularity to 0', () => {
+    expect(mapPerson({ ...row, popularity: null }).popularity).toBe(0);
+  });
+});

--- a/apps/api/src/modules/person/infrastructure/mappers/person.mapper.ts
+++ b/apps/api/src/modules/person/infrastructure/mappers/person.mapper.ts
@@ -1,0 +1,39 @@
+import { type Person } from '../../domain/entities/person.entity';
+
+/**
+ * Raw `persons` row shape (subset selected by the repository).
+ */
+export interface PersonRow {
+  id: string;
+  tmdbId: number;
+  slug: string;
+  name: string;
+  profilePath: string | null;
+  knownForDepartment: string | null;
+  popularity: number | null;
+  biography: string | null;
+  birthday: Date | null;
+  deathday: Date | null;
+  placeOfBirth: string | null;
+  detailsFetchedAt: Date | null;
+}
+
+/**
+ * Maps a raw persons row to the Person domain entity.
+ */
+export function mapPerson(row: PersonRow): Person {
+  return {
+    id: row.id,
+    tmdbId: row.tmdbId,
+    slug: row.slug,
+    name: row.name,
+    profilePath: row.profilePath,
+    knownForDepartment: row.knownForDepartment,
+    popularity: row.popularity ?? 0,
+    biography: row.biography,
+    birthday: row.birthday,
+    deathday: row.deathday,
+    placeOfBirth: row.placeOfBirth,
+    detailsFetchedAt: row.detailsFetchedAt,
+  };
+}

--- a/apps/api/src/modules/person/infrastructure/queries/person-credits.query.ts
+++ b/apps/api/src/modules/person/infrastructure/queries/person-credits.query.ts
@@ -1,0 +1,161 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+
+import { and, eq, isNull, sql, type SQL } from 'drizzle-orm';
+import { type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+
+import { IngestionStatus } from '../../../../common/enums/ingestion-status.enum';
+import { type MediaType } from '../../../../common/enums/media-type.enum';
+import { withDbError } from '../../../../common/utils/db-error.utils';
+import { DATABASE_CONNECTION } from '../../../../database/database.module';
+import * as schema from '../../../../database/schema';
+import { EligibilityStatus, EvaluationContext } from '../../../catalog-policy/public';
+import { type PersonCreditTypeValue } from '../../domain/constants/person.constants';
+import {
+  type PersonCreditItem,
+  type PersonCreditsResult,
+} from '../../domain/entities/person.entity';
+import { type PersonCreditsQueryOptions } from '../../domain/repositories/person.repository.interface';
+
+interface CreditRow {
+  mediaItemId: string;
+  type: MediaType;
+  tmdbId: number;
+  title: string;
+  slug: string;
+  posterPath: string | null;
+  releaseDate: Date | null;
+  ratingoScore: number | null;
+  character: string | null;
+  jobs: string[] | null;
+}
+
+/**
+ * Lists a person's works (one row per title), restricted to catalog-eligible
+ * media items.
+ *
+ * Reuses the catalog eligibility join (active policy + `context = catalog` +
+ * `status = eligible`) so the returned works always have a real catalog page.
+ * Cast and crew contributions on the same title are merged into one row.
+ */
+@Injectable()
+export class PersonCreditsQuery {
+  private readonly logger = new Logger(PersonCreditsQuery.name);
+
+  constructor(
+    @Inject(DATABASE_CONNECTION)
+    private readonly db: PostgresJsDatabase<typeof schema>,
+  ) {}
+
+  async execute(
+    personId: string,
+    options: PersonCreditsQueryOptions,
+  ): Promise<PersonCreditsResult> {
+    const { limit, offset, creditType } = options;
+
+    return withDbError('list person credits', this.logger, async () => {
+      const conditions = this.buildConditions(personId, creditType);
+
+      const rows = (await this.db
+        .select({
+          mediaItemId: schema.mediaItems.id,
+          type: schema.mediaItems.type,
+          tmdbId: schema.mediaItems.tmdbId,
+          title: schema.mediaItems.title,
+          slug: schema.mediaItems.slug,
+          posterPath: schema.mediaItems.posterPath,
+          releaseDate: schema.mediaItems.releaseDate,
+          ratingoScore: schema.mediaStats.ratingoScore,
+          // Merge a person's cast + crew contributions on the same title.
+          character: sql<
+            string | null
+          >`max(${schema.mediaCredits.character}) filter (where ${schema.mediaCredits.creditType} = 'cast')`,
+          jobs: sql<
+            string[]
+          >`coalesce(array_remove(array_agg(distinct ${schema.mediaCredits.job}) filter (where ${schema.mediaCredits.creditType} = 'crew'), null), '{}')`,
+        })
+        .from(schema.mediaCredits)
+        .innerJoin(schema.mediaItems, eq(schema.mediaCredits.mediaItemId, schema.mediaItems.id))
+        .innerJoin(schema.catalogPolicies, eq(schema.catalogPolicies.isActive, true))
+        .innerJoin(
+          schema.mediaCatalogEvaluations,
+          and(
+            eq(schema.mediaItems.id, schema.mediaCatalogEvaluations.mediaItemId),
+            eq(schema.mediaCatalogEvaluations.policyVersion, schema.catalogPolicies.version),
+            eq(schema.mediaCatalogEvaluations.context, EvaluationContext.CATALOG),
+            eq(schema.mediaCatalogEvaluations.status, EligibilityStatus.ELIGIBLE),
+          ),
+        )
+        .leftJoin(schema.mediaStats, eq(schema.mediaItems.id, schema.mediaStats.mediaItemId))
+        .where(and(...conditions))
+        .groupBy(
+          schema.mediaItems.id,
+          schema.mediaItems.type,
+          schema.mediaItems.tmdbId,
+          schema.mediaItems.title,
+          schema.mediaItems.slug,
+          schema.mediaItems.posterPath,
+          schema.mediaItems.releaseDate,
+          schema.mediaStats.ratingoScore,
+        )
+        .orderBy(
+          sql`${schema.mediaStats.ratingoScore} DESC NULLS LAST`,
+          sql`${schema.mediaItems.releaseDate} DESC NULLS LAST`,
+        )
+        .limit(limit)
+        .offset(offset)) as CreditRow[];
+
+      const total = await this.countTotal(conditions);
+
+      return { items: rows.map((r) => this.mapItem(r)), total };
+    });
+  }
+
+  private buildConditions(personId: string, creditType?: PersonCreditTypeValue): SQL[] {
+    const conditions: SQL[] = [
+      eq(schema.mediaCredits.personId, personId),
+      eq(schema.mediaItems.ingestionStatus, IngestionStatus.READY),
+      isNull(schema.mediaItems.deletedAt),
+    ];
+
+    if (creditType) {
+      conditions.push(eq(schema.mediaCredits.creditType, creditType));
+    }
+
+    return conditions;
+  }
+
+  private async countTotal(conditions: SQL[]): Promise<number> {
+    const [row] = await this.db
+      .select({ total: sql<number>`count(distinct ${schema.mediaItems.id})` })
+      .from(schema.mediaCredits)
+      .innerJoin(schema.mediaItems, eq(schema.mediaCredits.mediaItemId, schema.mediaItems.id))
+      .innerJoin(schema.catalogPolicies, eq(schema.catalogPolicies.isActive, true))
+      .innerJoin(
+        schema.mediaCatalogEvaluations,
+        and(
+          eq(schema.mediaItems.id, schema.mediaCatalogEvaluations.mediaItemId),
+          eq(schema.mediaCatalogEvaluations.policyVersion, schema.catalogPolicies.version),
+          eq(schema.mediaCatalogEvaluations.context, EvaluationContext.CATALOG),
+          eq(schema.mediaCatalogEvaluations.status, EligibilityStatus.ELIGIBLE),
+        ),
+      )
+      .where(and(...conditions));
+
+    return Number(row?.total ?? 0);
+  }
+
+  private mapItem(row: CreditRow): PersonCreditItem {
+    return {
+      mediaItemId: row.mediaItemId,
+      type: row.type,
+      tmdbId: row.tmdbId,
+      title: row.title,
+      slug: row.slug,
+      posterPath: row.posterPath,
+      releaseDate: row.releaseDate,
+      ratingoScore: row.ratingoScore,
+      character: row.character,
+      jobs: row.jobs ?? [],
+    };
+  }
+}

--- a/apps/api/src/modules/person/infrastructure/repositories/drizzle-person.repository.spec.ts
+++ b/apps/api/src/modules/person/infrastructure/repositories/drizzle-person.repository.spec.ts
@@ -1,0 +1,175 @@
+import * as schema from '@/database/schema';
+
+import { PersonCreditType } from '../../domain/constants/person.constants';
+import {
+  type CreditSeed,
+  type PersonSeed,
+} from '../../domain/repositories/person.repository.interface';
+import { type PersonCreditsQuery } from '../queries/person-credits.query';
+
+import { DrizzlePersonRepository } from './drizzle-person.repository';
+
+describe('DrizzlePersonRepository', () => {
+  describe('findByTmdbId', () => {
+    function dbReturning(rows: unknown[]) {
+      const limit = jest.fn().mockResolvedValue(rows);
+      const where = jest.fn().mockReturnValue({ limit });
+      const from = jest.fn().mockReturnValue({ where });
+      const select = jest.fn().mockReturnValue({ from });
+      return { select };
+    }
+
+    it('maps the row when found', async () => {
+      const row = {
+        id: 'uuid-1',
+        tmdbId: 287,
+        slug: 'brad-pitt',
+        name: 'Brad Pitt',
+        profilePath: '/b.jpg',
+        knownForDepartment: 'Acting',
+        popularity: 5,
+        biography: null,
+        birthday: null,
+        deathday: null,
+        placeOfBirth: null,
+        detailsFetchedAt: null,
+      };
+      const db = dbReturning([row]);
+      const repo = new DrizzlePersonRepository(db as never, {} as PersonCreditsQuery);
+
+      const result = await repo.findByTmdbId(287);
+      expect(result).toMatchObject({ id: 'uuid-1', tmdbId: 287, name: 'Brad Pitt' });
+    });
+
+    it('returns null when not found', async () => {
+      const db = dbReturning([]);
+      const repo = new DrizzlePersonRepository(db as never, {} as PersonCreditsQuery);
+      expect(await repo.findByTmdbId(999)).toBeNull();
+    });
+  });
+
+  describe('findEligibleCredits', () => {
+    it('delegates to PersonCreditsQuery', async () => {
+      const execute = jest.fn().mockResolvedValue({ items: [], total: 0 });
+      const repo = new DrizzlePersonRepository(
+        {} as never,
+        { execute } as unknown as PersonCreditsQuery,
+      );
+
+      await repo.findEligibleCredits('uuid-1', { limit: 10, offset: 0 });
+
+      expect(execute).toHaveBeenCalledWith('uuid-1', { limit: 10, offset: 0 });
+    });
+  });
+
+  describe('writeMediaCredits', () => {
+    /** Tx mock: insert().values()[.onConflictDoUpdate()], select().from().where(), delete().where() */
+    function buildTx(idRows: Array<{ id: string; tmdbId: number }>) {
+      const insertedByTable = new Map<unknown, unknown[]>();
+      let deleteCalled = false;
+
+      const tx = {
+        insert: (table: unknown) => ({
+          values: (vals: unknown[]) => {
+            insertedByTable.set(table, vals);
+            const p: Promise<void> & { onConflictDoUpdate?: () => Promise<void> } =
+              Promise.resolve();
+            p.onConflictDoUpdate = () => Promise.resolve();
+            return p;
+          },
+        }),
+        select: () => ({ from: () => ({ where: () => Promise.resolve(idRows) }) }),
+        delete: () => ({
+          where: () => {
+            deleteCalled = true;
+            return Promise.resolve();
+          },
+        }),
+      };
+
+      return { tx, insertedByTable, wasDeleteCalled: () => deleteCalled };
+    }
+
+    function makeRepo(idRows: Array<{ id: string; tmdbId: number }>) {
+      const ctx = buildTx(idRows);
+      const db = { transaction: (cb: (tx: unknown) => Promise<void>) => cb(ctx.tx) };
+      const repo = new DrizzlePersonRepository(db as never, {} as PersonCreditsQuery);
+      return { repo, ctx };
+    }
+
+    const persons: PersonSeed[] = [
+      { tmdbId: 1, slug: 'a', name: 'A', profilePath: null, knownForDepartment: null },
+      { tmdbId: 2, slug: 'b', name: 'B', profilePath: null, knownForDepartment: null },
+    ];
+
+    it('deletes existing credits then inserts rows for resolvable persons', async () => {
+      const { repo, ctx } = makeRepo([
+        { id: 'p1', tmdbId: 1 },
+        { id: 'p2', tmdbId: 2 },
+      ]);
+
+      const credits: CreditSeed[] = [
+        {
+          personTmdbId: 1,
+          creditType: PersonCreditType.CAST,
+          character: 'X',
+          job: null,
+          department: null,
+          order: 0,
+        },
+        {
+          personTmdbId: 2,
+          creditType: PersonCreditType.CREW,
+          character: null,
+          job: 'Director',
+          department: 'Directing',
+          order: 0,
+        },
+      ];
+
+      await repo.writeMediaCredits('media-1', persons, credits);
+
+      expect(ctx.wasDeleteCalled()).toBe(true);
+      const inserted = ctx.insertedByTable.get(schema.mediaCredits) as Array<{ personId: string }>;
+      expect(inserted).toHaveLength(2);
+      expect(inserted.map((r) => r.personId).sort()).toEqual(['p1', 'p2']);
+    });
+
+    it('skips credits whose person id could not be resolved', async () => {
+      const { repo, ctx } = makeRepo([{ id: 'p1', tmdbId: 1 }]); // tmdbId 2 unresolved
+
+      const credits: CreditSeed[] = [
+        {
+          personTmdbId: 1,
+          creditType: PersonCreditType.CAST,
+          character: 'X',
+          job: null,
+          department: null,
+          order: 0,
+        },
+        {
+          personTmdbId: 2,
+          creditType: PersonCreditType.CAST,
+          character: 'Y',
+          job: null,
+          department: null,
+          order: 1,
+        },
+      ];
+
+      await repo.writeMediaCredits('media-1', persons, credits);
+
+      const inserted = ctx.insertedByTable.get(schema.mediaCredits) as unknown[];
+      expect(inserted).toHaveLength(1);
+    });
+
+    it('still clears credits when there are no persons (empty media)', async () => {
+      const { repo, ctx } = makeRepo([]);
+
+      await repo.writeMediaCredits('media-1', [], []);
+
+      expect(ctx.wasDeleteCalled()).toBe(true);
+      expect(ctx.insertedByTable.get(schema.mediaCredits)).toBeUndefined();
+    });
+  });
+});

--- a/apps/api/src/modules/person/infrastructure/repositories/drizzle-person.repository.ts
+++ b/apps/api/src/modules/person/infrastructure/repositories/drizzle-person.repository.ts
@@ -1,0 +1,167 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+
+import { eq, inArray, sql } from 'drizzle-orm';
+import { type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+
+import { withDbError } from '../../../../common/utils/db-error.utils';
+import { DATABASE_CONNECTION } from '../../../../database/database.module';
+import * as schema from '../../../../database/schema';
+import { type Person, type PersonCreditsResult } from '../../domain/entities/person.entity';
+import {
+  type CreditSeed,
+  type IPersonRepository,
+  type PersonCreditsQueryOptions,
+  type PersonDetailsUpdate,
+  type PersonSeed,
+} from '../../domain/repositories/person.repository.interface';
+import { mapPerson, type PersonRow } from '../mappers/person.mapper';
+import { PersonCreditsQuery } from '../queries/person-credits.query';
+
+@Injectable()
+export class DrizzlePersonRepository implements IPersonRepository {
+  private readonly logger = new Logger(DrizzlePersonRepository.name);
+
+  constructor(
+    @Inject(DATABASE_CONNECTION)
+    private readonly db: PostgresJsDatabase<typeof schema>,
+    private readonly personCreditsQuery: PersonCreditsQuery,
+  ) {}
+
+  async findByTmdbId(tmdbId: number): Promise<Person | null> {
+    return withDbError(
+      'find person by tmdbId',
+      this.logger,
+      async () => {
+        const [row] = await this.db
+          .select()
+          .from(schema.persons)
+          .where(eq(schema.persons.tmdbId, tmdbId))
+          .limit(1);
+
+        return row ? mapPerson(row as PersonRow) : null;
+      },
+      { tmdbId },
+    );
+  }
+
+  async writeMediaCredits(
+    mediaItemId: string,
+    persons: PersonSeed[],
+    credits: CreditSeed[],
+  ): Promise<void> {
+    return withDbError(
+      'write media credits',
+      this.logger,
+      async () => {
+        await this.db.transaction(async (tx) => {
+          // 1. Upsert persons by tmdbId. Biography block is left untouched —
+          //    it is enriched lazily on the person page, not during ingest.
+          if (persons.length > 0) {
+            await tx
+              .insert(schema.persons)
+              .values(
+                persons.map((p) => ({
+                  tmdbId: p.tmdbId,
+                  slug: p.slug,
+                  name: p.name,
+                  profilePath: p.profilePath,
+                  knownForDepartment: p.knownForDepartment,
+                })),
+              )
+              .onConflictDoUpdate({
+                target: schema.persons.tmdbId,
+                // Refresh identity fields, but never clobber lazily-enriched data
+                // with the always-null seed values. COALESCE keeps the existing
+                // value when the incoming credit field is null; knownForDepartment
+                // is enriched-only, so it is left untouched here.
+                set: {
+                  slug: sqlExcluded('slug'),
+                  name: sqlExcluded('name'),
+                  profilePath: sql`coalesce(excluded.profile_path, ${schema.persons.profilePath})`,
+                  updatedAt: new Date(),
+                },
+              });
+          }
+
+          // 2. Resolve tmdbId -> person uuid for this media's credits.
+          const tmdbIds = [...new Set(credits.map((c) => c.personTmdbId))];
+          const idRows = tmdbIds.length
+            ? await tx
+                .select({ id: schema.persons.id, tmdbId: schema.persons.tmdbId })
+                .from(schema.persons)
+                .where(inArrayTmdb(tmdbIds))
+            : [];
+          const idByTmdb = new Map(idRows.map((r) => [r.tmdbId, r.id]));
+
+          // 3. Replace credits for this media item (delete-then-insert = idempotent).
+          await tx
+            .delete(schema.mediaCredits)
+            .where(eq(schema.mediaCredits.mediaItemId, mediaItemId));
+
+          const rows = credits
+            .map((c) => {
+              const personId = idByTmdb.get(c.personTmdbId);
+              if (!personId) return null;
+              return {
+                mediaItemId,
+                personId,
+                creditType: c.creditType,
+                character: c.character,
+                job: c.job,
+                department: c.department,
+                order: c.order,
+              };
+            })
+            .filter((r): r is NonNullable<typeof r> => r !== null);
+
+          if (rows.length > 0) {
+            await tx.insert(schema.mediaCredits).values(rows);
+          }
+        });
+      },
+      { mediaItemId },
+    );
+  }
+
+  async updateDetails(personId: string, details: PersonDetailsUpdate): Promise<void> {
+    return withDbError(
+      'update person details',
+      this.logger,
+      async () => {
+        await this.db
+          .update(schema.persons)
+          .set({
+            biography: details.biography,
+            birthday: details.birthday,
+            deathday: details.deathday,
+            placeOfBirth: details.placeOfBirth,
+            knownForDepartment: details.knownForDepartment,
+            popularity: details.popularity,
+            profilePath: details.profilePath,
+            detailsFetchedAt: details.detailsFetchedAt,
+            updatedAt: new Date(),
+          })
+          .where(eq(schema.persons.id, personId));
+      },
+      { personId },
+    );
+  }
+
+  async findEligibleCredits(
+    personId: string,
+    options: PersonCreditsQueryOptions,
+  ): Promise<PersonCreditsResult> {
+    return this.personCreditsQuery.execute(personId, options);
+  }
+}
+
+// --- local SQL helpers ---
+
+/** Reference the conflicting INSERT row's column in an upsert SET clause. */
+function sqlExcluded(column: string) {
+  return sql.raw(`excluded.${column}`);
+}
+
+function inArrayTmdb(tmdbIds: number[]) {
+  return inArray(schema.persons.tmdbId, tmdbIds);
+}

--- a/apps/api/src/modules/person/person.module.ts
+++ b/apps/api/src/modules/person/person.module.ts
@@ -1,0 +1,25 @@
+import { Module } from '@nestjs/common';
+
+import { TmdbModule } from '../tmdb/tmdb.module';
+
+import { PersonCreditsWriterService } from './application/services/person-credits-writer.service';
+import { PersonService } from './application/services/person.service';
+import { PERSON_CREDITS_WRITER } from './domain/ports/person-credits-writer.port';
+import { PERSON_REPOSITORY } from './domain/repositories/person.repository.interface';
+import { PersonCreditsQuery } from './infrastructure/queries/person-credits.query';
+import { DrizzlePersonRepository } from './infrastructure/repositories/drizzle-person.repository';
+import { PersonController } from './presentation/controllers/person.controller';
+
+@Module({
+  imports: [TmdbModule],
+  controllers: [PersonController],
+  providers: [
+    PersonCreditsQuery,
+    { provide: PERSON_REPOSITORY, useClass: DrizzlePersonRepository },
+    PersonService,
+    PersonCreditsWriterService,
+    { provide: PERSON_CREDITS_WRITER, useExisting: PersonCreditsWriterService },
+  ],
+  exports: [PERSON_CREDITS_WRITER],
+})
+export class PersonModule {}

--- a/apps/api/src/modules/person/presentation/controllers/person.controller.spec.ts
+++ b/apps/api/src/modules/person/presentation/controllers/person.controller.spec.ts
@@ -1,0 +1,71 @@
+import { MediaType } from '../../../../common/enums/media-type.enum';
+import { type PersonService } from '../../application/services/person.service';
+import { type Person, type PersonCreditItem } from '../../domain/entities/person.entity';
+
+import { PersonController } from './person.controller';
+
+function makeController(service: Partial<PersonService>): PersonController {
+  return new PersonController(service as PersonService);
+}
+
+const person: Person = {
+  id: 'uuid-1',
+  tmdbId: 287,
+  slug: 'brad-pitt',
+  name: 'Brad Pitt',
+  profilePath: '/b.jpg',
+  knownForDepartment: 'Acting',
+  popularity: 10,
+  biography: 'Bio',
+  birthday: new Date('1963-12-18'),
+  deathday: null,
+  placeOfBirth: 'USA',
+  detailsFetchedAt: new Date('2026-06-23'),
+};
+
+const creditItem: PersonCreditItem = {
+  mediaItemId: 'm-1',
+  type: MediaType.MOVIE,
+  tmdbId: 550,
+  title: 'Fight Club',
+  slug: 'fight-club',
+  posterPath: '/p.jpg',
+  releaseDate: new Date('1999-10-15'),
+  ratingoScore: 0.9,
+  character: 'Tyler Durden',
+  jobs: [],
+};
+
+describe('PersonController', () => {
+  it('returns mapped person details with a profile image', async () => {
+    const controller = makeController({ getByTmdbId: jest.fn().mockResolvedValue(person) });
+
+    const result = await controller.getPerson(287);
+
+    expect(result.tmdbId).toBe(287);
+    expect(result.name).toBe('Brad Pitt');
+    expect(result.profile?.medium).toContain('/b.jpg');
+    expect(result.biography).toBe('Bio');
+  });
+
+  it('returns credits with correct pagination meta', async () => {
+    const getCredits = jest.fn().mockResolvedValue({ items: [creditItem], total: 5 });
+    const controller = makeController({ getCredits });
+
+    const result = await controller.getPersonCredits(287, { limit: 1, offset: 0 });
+
+    expect(getCredits).toHaveBeenCalledWith(287, { limit: 1, offset: 0, creditType: undefined });
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0]).toMatchObject({ id: 'm-1', character: 'Tyler Durden' });
+    expect(result.meta).toEqual({ count: 1, total: 5, limit: 1, offset: 0, hasMore: true });
+  });
+
+  it('reports hasMore=false on the last page', async () => {
+    const getCredits = jest.fn().mockResolvedValue({ items: [creditItem], total: 3 });
+    const controller = makeController({ getCredits });
+
+    const result = await controller.getPersonCredits(287, { limit: 10, offset: 2 });
+
+    expect(result.meta.hasMore).toBe(false);
+  });
+});

--- a/apps/api/src/modules/person/presentation/controllers/person.controller.ts
+++ b/apps/api/src/modules/person/presentation/controllers/person.controller.ts
@@ -1,0 +1,63 @@
+import { Controller, Get, Param, ParseIntPipe, Query, UseFilters } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+
+import { PersonService } from '../../application/services/person.service';
+import {
+  PaginatedPersonCreditsResponseDto,
+  PersonCreditsQueryDto,
+  PersonResponseDto,
+} from '../dtos';
+import { PersonDomainExceptionFilter } from '../filters/person-domain-exception.filter';
+import { toPersonCreditItemDto, toPersonResponseDto } from '../mappers/person-response.mapper';
+
+@ApiTags('Public: Persons')
+@UseFilters(PersonDomainExceptionFilter)
+@Controller('persons')
+export class PersonController {
+  constructor(private readonly personService: PersonService) {}
+
+  @Get(':tmdbId')
+  @ApiOperation({
+    summary: 'Get person details by TMDB id',
+    description:
+      'Returns photo, biography and vital data for an actor/crew member. ' +
+      'Biography is enriched from TMDB lazily on first request.',
+  })
+  @ApiParam({ name: 'tmdbId', type: Number, example: 287 })
+  @ApiOkResponse({ type: PersonResponseDto })
+  async getPerson(@Param('tmdbId', ParseIntPipe) tmdbId: number): Promise<PersonResponseDto> {
+    const person = await this.personService.getByTmdbId(tmdbId);
+    return toPersonResponseDto(person);
+  }
+
+  @Get(':tmdbId/credits')
+  @ApiOperation({
+    summary: "Get a person's catalog works",
+    description:
+      "Lists the person's works that exist in the Ratingo catalog (eligible titles only), " +
+      'sorted by Ratingo score then release date. Filter with creditType=cast|crew.',
+  })
+  @ApiParam({ name: 'tmdbId', type: Number, example: 287 })
+  @ApiOkResponse({ type: PaginatedPersonCreditsResponseDto })
+  async getPersonCredits(
+    @Param('tmdbId', ParseIntPipe) tmdbId: number,
+    @Query() query: PersonCreditsQueryDto,
+  ): Promise<PaginatedPersonCreditsResponseDto> {
+    const { items, total } = await this.personService.getCredits(tmdbId, {
+      limit: query.limit,
+      offset: query.offset,
+      creditType: query.creditType,
+    });
+
+    return {
+      data: items.map(toPersonCreditItemDto),
+      meta: {
+        count: items.length,
+        total,
+        limit: query.limit,
+        offset: query.offset,
+        hasMore: query.offset + items.length < total,
+      },
+    };
+  }
+}

--- a/apps/api/src/modules/person/presentation/dtos/index.ts
+++ b/apps/api/src/modules/person/presentation/dtos/index.ts
@@ -1,0 +1,6 @@
+export { PersonResponseDto } from './person-response.dto';
+export {
+  PersonCreditItemDto,
+  PaginatedPersonCreditsResponseDto,
+} from './person-credits-response.dto';
+export { PersonCreditsQueryDto } from './person-credits-query.dto';

--- a/apps/api/src/modules/person/presentation/dtos/person-credits-query.dto.spec.ts
+++ b/apps/api/src/modules/person/presentation/dtos/person-credits-query.dto.spec.ts
@@ -1,0 +1,49 @@
+import { plainToInstance } from 'class-transformer';
+import { validateSync } from 'class-validator';
+
+import { PERSON_CREDITS_MAX_LIMIT } from '../../domain/constants/person.constants';
+
+import { PersonCreditsQueryDto } from './person-credits-query.dto';
+
+function validate(input: Record<string, unknown>) {
+  const dto = plainToInstance(PersonCreditsQueryDto, input, {
+    enableImplicitConversion: true,
+  });
+  return { dto, errors: validateSync(dto, { whitelist: true }) };
+}
+
+describe('PersonCreditsQueryDto', () => {
+  it('accepts an empty query and applies defaults', () => {
+    const { dto, errors } = validate({});
+    expect(errors).toHaveLength(0);
+    expect(dto.limit).toBeGreaterThan(0);
+    expect(dto.offset).toBe(0);
+  });
+
+  it('coerces numeric strings', () => {
+    const { dto, errors } = validate({ limit: '10', offset: '5' });
+    expect(errors).toHaveLength(0);
+    expect(dto.limit).toBe(10);
+    expect(dto.offset).toBe(5);
+  });
+
+  it('rejects a limit above the max', () => {
+    const { errors } = validate({ limit: PERSON_CREDITS_MAX_LIMIT + 1 });
+    expect(errors.some((e) => e.property === 'limit')).toBe(true);
+  });
+
+  it('rejects a negative offset', () => {
+    const { errors } = validate({ offset: -1 });
+    expect(errors.some((e) => e.property === 'offset')).toBe(true);
+  });
+
+  it('accepts valid creditType values', () => {
+    expect(validate({ creditType: 'cast' }).errors).toHaveLength(0);
+    expect(validate({ creditType: 'crew' }).errors).toHaveLength(0);
+  });
+
+  it('rejects an unknown creditType', () => {
+    const { errors } = validate({ creditType: 'producer' });
+    expect(errors.some((e) => e.property === 'creditType')).toBe(true);
+  });
+});

--- a/apps/api/src/modules/person/presentation/dtos/person-credits-query.dto.ts
+++ b/apps/api/src/modules/person/presentation/dtos/person-credits-query.dto.ts
@@ -1,0 +1,39 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+import { Type } from 'class-transformer';
+import { IsIn, IsInt, IsOptional, Max, Min } from 'class-validator';
+
+import {
+  PERSON_CREDITS_DEFAULT_LIMIT,
+  PERSON_CREDITS_MAX_LIMIT,
+  PersonCreditType,
+  type PersonCreditTypeValue,
+} from '../../domain/constants/person.constants';
+
+const CREDIT_TYPE_VALUES = Object.values(PersonCreditType);
+
+export class PersonCreditsQueryDto {
+  @ApiPropertyOptional({
+    default: PERSON_CREDITS_DEFAULT_LIMIT,
+    minimum: 1,
+    maximum: PERSON_CREDITS_MAX_LIMIT,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(PERSON_CREDITS_MAX_LIMIT)
+  @Type(() => Number)
+  limit: number = PERSON_CREDITS_DEFAULT_LIMIT;
+
+  @ApiPropertyOptional({ default: 0, minimum: 0 })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Type(() => Number)
+  offset: number = 0;
+
+  @ApiPropertyOptional({ enum: PersonCreditType, description: 'Filter by cast or crew' })
+  @IsOptional()
+  @IsIn(CREDIT_TYPE_VALUES)
+  creditType?: PersonCreditTypeValue;
+}

--- a/apps/api/src/modules/person/presentation/dtos/person-credits-response.dto.ts
+++ b/apps/api/src/modules/person/presentation/dtos/person-credits-response.dto.ts
@@ -1,0 +1,53 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { ImageDto } from '../../../../common/dtos/image.dto';
+import { OffsetPaginationMetaDto } from '../../../../common/dtos/pagination.dto';
+import { MediaType } from '../../../../common/enums/media-type.enum';
+
+export class PersonCreditItemDto {
+  @ApiProperty({ example: '123e4567-e89b-12d3-a456-426614174000' })
+  id: string;
+
+  @ApiProperty({ enum: MediaType, example: MediaType.MOVIE })
+  type: MediaType;
+
+  @ApiProperty({ example: 550 })
+  tmdbId: number;
+
+  @ApiProperty({ example: 'Fight Club' })
+  title: string;
+
+  @ApiProperty({ example: 'fight-club' })
+  slug: string;
+
+  @ApiProperty({ type: ImageDto, required: false, nullable: true })
+  poster?: ImageDto | null;
+
+  @ApiProperty({ type: Date, required: false, nullable: true })
+  releaseDate: Date | null;
+
+  @ApiProperty({ example: 0.87, required: false, nullable: true })
+  ratingoScore: number | null;
+
+  @ApiProperty({
+    example: 'Tyler Durden',
+    nullable: true,
+    description: 'Cast character on this title, if the person acted in it',
+  })
+  character: string | null;
+
+  @ApiProperty({
+    type: [String],
+    example: ['Director'],
+    description: 'Crew jobs on this title (e.g. Director, Creator); empty if none',
+  })
+  jobs: string[];
+}
+
+export class PaginatedPersonCreditsResponseDto {
+  @ApiProperty({ type: [PersonCreditItemDto] })
+  data: PersonCreditItemDto[];
+
+  @ApiProperty({ type: OffsetPaginationMetaDto })
+  meta: OffsetPaginationMetaDto;
+}

--- a/apps/api/src/modules/person/presentation/dtos/person-response.dto.ts
+++ b/apps/api/src/modules/person/presentation/dtos/person-response.dto.ts
@@ -1,0 +1,39 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { ImageDto } from '../../../../common/dtos/image.dto';
+
+export class PersonResponseDto {
+  @ApiProperty({ example: 287 })
+  tmdbId: number;
+
+  @ApiProperty({ example: 'brad-pitt' })
+  slug: string;
+
+  @ApiProperty({ example: 'Brad Pitt' })
+  name: string;
+
+  @ApiProperty({ type: ImageDto, required: false, nullable: true })
+  profile?: ImageDto | null;
+
+  @ApiProperty({ example: 'Acting', required: false, nullable: true })
+  knownForDepartment?: string | null;
+
+  @ApiProperty({
+    example: 'An American actor and film producer...',
+    required: false,
+    nullable: true,
+  })
+  biography?: string | null;
+
+  @ApiProperty({ type: Date, required: false, nullable: true })
+  birthday?: Date | null;
+
+  @ApiProperty({ type: Date, required: false, nullable: true })
+  deathday?: Date | null;
+
+  @ApiProperty({ example: 'Shawnee, Oklahoma, USA', required: false, nullable: true })
+  placeOfBirth?: string | null;
+
+  @ApiProperty({ example: 12.34 })
+  popularity: number;
+}

--- a/apps/api/src/modules/person/presentation/filters/person-domain-exception.filter.spec.ts
+++ b/apps/api/src/modules/person/presentation/filters/person-domain-exception.filter.spec.ts
@@ -1,0 +1,44 @@
+import { type ArgumentsHost, HttpStatus } from '@nestjs/common';
+
+import { PersonDomainError, PersonNotFoundError } from '../../domain/errors';
+
+import { PersonDomainExceptionFilter } from './person-domain-exception.filter';
+
+function makeHost(): { host: ArgumentsHost; status: jest.Mock; send: jest.Mock } {
+  const send = jest.fn();
+  const status = jest.fn().mockReturnValue({ send });
+  const host = {
+    switchToHttp: () => ({ getResponse: () => ({ status }) }),
+  } as unknown as ArgumentsHost;
+  return { host, status, send };
+}
+
+class UnknownPersonError extends PersonDomainError {
+  readonly code = 'PERSON_UNKNOWN';
+  constructor() {
+    super('boom');
+  }
+}
+
+describe('PersonDomainExceptionFilter', () => {
+  const filter = new PersonDomainExceptionFilter();
+
+  it('maps PersonNotFoundError to 404 with tmdbId detail', () => {
+    const { host, status, send } = makeHost();
+
+    filter.catch(new PersonNotFoundError(287), host);
+
+    expect(status).toHaveBeenCalledWith(HttpStatus.NOT_FOUND);
+    const body = send.mock.calls[0][0];
+    expect(body.error.code).toBe('PERSON_NOT_FOUND');
+    expect(body.error.details).toMatchObject({ tmdbId: 287 });
+  });
+
+  it('maps unknown person errors to 500', () => {
+    const { host, status } = makeHost();
+
+    filter.catch(new UnknownPersonError(), host);
+
+    expect(status).toHaveBeenCalledWith(HttpStatus.INTERNAL_SERVER_ERROR);
+  });
+});

--- a/apps/api/src/modules/person/presentation/filters/person-domain-exception.filter.ts
+++ b/apps/api/src/modules/person/presentation/filters/person-domain-exception.filter.ts
@@ -1,0 +1,54 @@
+/**
+ * Person Domain Exception Filter
+ *
+ * Maps person domain errors to HTTP responses.
+ */
+
+import {
+  type ArgumentsHost,
+  Catch,
+  type ExceptionFilter,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+
+import { type FastifyReply } from 'fastify';
+
+import { type ErrorResponseDto } from '../../../../common/dtos/error-response.dto';
+import { ErrorResponseBuilder } from '../../../../common/utils/error-response.builder';
+import { PersonDomainError, PersonNotFoundError } from '../../domain/errors';
+
+@Catch(PersonDomainError)
+export class PersonDomainExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(PersonDomainExceptionFilter.name);
+
+  catch(exception: PersonDomainError, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<FastifyReply>();
+
+    const { statusCode, body } = this.buildResponse(exception);
+
+    this.logger.warn(`Person domain error: ${exception.code} - ${exception.message}`);
+
+    void response.status(statusCode).send(body);
+  }
+
+  private buildResponse(exception: PersonDomainError): {
+    statusCode: number;
+    body: ErrorResponseDto;
+  } {
+    if (exception instanceof PersonNotFoundError) {
+      return {
+        statusCode: HttpStatus.NOT_FOUND,
+        body: ErrorResponseBuilder.build(exception, HttpStatus.NOT_FOUND, {
+          tmdbId: exception.tmdbId,
+        }),
+      };
+    }
+
+    return {
+      statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+      body: ErrorResponseBuilder.build(exception, HttpStatus.INTERNAL_SERVER_ERROR),
+    };
+  }
+}

--- a/apps/api/src/modules/person/presentation/mappers/person-response.mapper.spec.ts
+++ b/apps/api/src/modules/person/presentation/mappers/person-response.mapper.spec.ts
@@ -1,0 +1,74 @@
+import { MediaType } from '../../../../common/enums/media-type.enum';
+import { type Person, type PersonCreditItem } from '../../domain/entities/person.entity';
+
+import { toPersonCreditItemDto, toPersonResponseDto } from './person-response.mapper';
+
+const person: Person = {
+  id: 'uuid-1',
+  tmdbId: 287,
+  slug: 'brad-pitt',
+  name: 'Brad Pitt',
+  profilePath: '/b.jpg',
+  knownForDepartment: 'Acting',
+  popularity: 10,
+  biography: 'Bio',
+  birthday: new Date('1963-12-18'),
+  deathday: null,
+  placeOfBirth: 'USA',
+  detailsFetchedAt: new Date('2026-06-23'),
+};
+
+describe('toPersonResponseDto', () => {
+  it('maps a person and builds the profile image set', () => {
+    const dto = toPersonResponseDto(person);
+    expect(dto).toMatchObject({
+      tmdbId: 287,
+      slug: 'brad-pitt',
+      name: 'Brad Pitt',
+      knownForDepartment: 'Acting',
+      biography: 'Bio',
+      placeOfBirth: 'USA',
+      popularity: 10,
+    });
+    expect(dto.profile?.small).toContain('/b.jpg');
+    expect(dto.profile?.original).toContain('/b.jpg');
+  });
+
+  it('returns null profile when there is no profile path', () => {
+    expect(toPersonResponseDto({ ...person, profilePath: null }).profile).toBeNull();
+  });
+});
+
+describe('toPersonCreditItemDto', () => {
+  const credit: PersonCreditItem = {
+    mediaItemId: 'm-1',
+    type: MediaType.MOVIE,
+    tmdbId: 550,
+    title: 'Fight Club',
+    slug: 'fight-club',
+    posterPath: '/p.jpg',
+    releaseDate: new Date('1999-10-15'),
+    ratingoScore: 0.9,
+    character: 'Tyler Durden',
+    jobs: ['Director'],
+  };
+
+  it('maps a credit item and exposes mediaItemId as id', () => {
+    const dto = toPersonCreditItemDto(credit);
+    expect(dto).toMatchObject({
+      id: 'm-1',
+      type: MediaType.MOVIE,
+      tmdbId: 550,
+      title: 'Fight Club',
+      slug: 'fight-club',
+      character: 'Tyler Durden',
+      jobs: ['Director'],
+      ratingoScore: 0.9,
+    });
+    expect(dto.poster?.medium).toContain('/p.jpg');
+  });
+
+  it('returns null poster when there is no poster path', () => {
+    expect(toPersonCreditItemDto({ ...credit, posterPath: null }).poster).toBeNull();
+  });
+});

--- a/apps/api/src/modules/person/presentation/mappers/person-response.mapper.ts
+++ b/apps/api/src/modules/person/presentation/mappers/person-response.mapper.ts
@@ -1,0 +1,40 @@
+import { ImageMapper } from '../../../../common/mappers/image.mapper';
+import { type Person, type PersonCreditItem } from '../../domain/entities/person.entity';
+import { type PersonCreditItemDto } from '../dtos/person-credits-response.dto';
+import { type PersonResponseDto } from '../dtos/person-response.dto';
+
+/**
+ * Maps a Person domain entity to its API response shape.
+ */
+export function toPersonResponseDto(person: Person): PersonResponseDto {
+  return {
+    tmdbId: person.tmdbId,
+    slug: person.slug,
+    name: person.name,
+    profile: ImageMapper.toPoster(person.profilePath),
+    knownForDepartment: person.knownForDepartment,
+    biography: person.biography,
+    birthday: person.birthday,
+    deathday: person.deathday,
+    placeOfBirth: person.placeOfBirth,
+    popularity: person.popularity,
+  };
+}
+
+/**
+ * Maps a person credit item to its API response shape.
+ */
+export function toPersonCreditItemDto(item: PersonCreditItem): PersonCreditItemDto {
+  return {
+    id: item.mediaItemId,
+    type: item.type,
+    tmdbId: item.tmdbId,
+    title: item.title,
+    slug: item.slug,
+    poster: ImageMapper.toPoster(item.posterPath),
+    releaseDate: item.releaseDate,
+    ratingoScore: item.ratingoScore,
+    character: item.character,
+    jobs: item.jobs,
+  };
+}

--- a/apps/api/src/modules/person/public/index.ts
+++ b/apps/api/src/modules/person/public/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Public API for the person module.
+ *
+ * Only tokens + types are exported — never implementations.
+ */
+
+export {
+  PERSON_CREDITS_WRITER,
+  type IPersonCreditsWriter,
+} from '../domain/ports/person-credits-writer.port';

--- a/apps/api/src/modules/tmdb/mappers/tmdb-person.mapper.spec.ts
+++ b/apps/api/src/modules/tmdb/mappers/tmdb-person.mapper.spec.ts
@@ -1,0 +1,42 @@
+import { type TmdbPersonResponse } from '../types/tmdb-api.types';
+
+import { TmdbMapper } from './tmdb.mapper';
+
+describe('TmdbMapper.toPersonDetails', () => {
+  const raw: TmdbPersonResponse = {
+    id: 287,
+    name: 'Brad Pitt',
+    biography: '  An American actor.  ',
+    birthday: '1963-12-18',
+    deathday: null,
+    place_of_birth: 'Shawnee, Oklahoma, USA',
+    profile_path: '/b.jpg',
+    known_for_department: 'Acting',
+    popularity: 42.5,
+  };
+
+  it('maps a full person response and trims biography', () => {
+    const result = TmdbMapper.toPersonDetails(raw);
+    expect(result).toEqual({
+      tmdbId: 287,
+      name: 'Brad Pitt',
+      biography: 'An American actor.',
+      birthday: new Date('1963-12-18'),
+      deathday: null,
+      placeOfBirth: 'Shawnee, Oklahoma, USA',
+      profilePath: '/b.jpg',
+      knownForDepartment: 'Acting',
+      popularity: 42.5,
+    });
+  });
+
+  it('returns null for missing identity', () => {
+    expect(TmdbMapper.toPersonDetails(null)).toBeNull();
+    expect(TmdbMapper.toPersonDetails({ ...raw, name: '' } as TmdbPersonResponse)).toBeNull();
+  });
+
+  it('normalizes empty biography to null', () => {
+    const result = TmdbMapper.toPersonDetails({ ...raw, biography: '   ' });
+    expect(result?.biography).toBeNull();
+  });
+});

--- a/apps/api/src/modules/tmdb/mappers/tmdb.mapper.ts
+++ b/apps/api/src/modules/tmdb/mappers/tmdb.mapper.ts
@@ -15,6 +15,7 @@ import {
   type WatchProvider,
 } from '../../ingestion/public';
 import { ALT_TITLE_COUNTRIES, MAX_ALT_TITLES } from '../constants/alt-title.constants';
+import type { PersonDetails } from '../types/person.types';
 import {
   type TmdbMediaResponse,
   type TmdbMovieResponse,
@@ -26,6 +27,7 @@ import {
   type TmdbVideo,
   type TmdbWatchProvider,
   type TmdbSeason,
+  type TmdbPersonResponse,
 } from '../types/tmdb-api.types';
 import {
   normalizeOriginCountries,
@@ -44,6 +46,26 @@ const DEFAULT_ORDER_FALLBACK = 999;
  * Handles type-specific mapping (Movie vs Show) and slug generation.
  */
 export class TmdbMapper {
+  /**
+   * Converts a raw TMDB /person/{id} response into normalized person details.
+   * Returns null if the response has no usable identity (missing id/name).
+   */
+  static toPersonDetails(data: TmdbPersonResponse | null): PersonDetails | null {
+    if (!data?.id || !data.name) return null;
+
+    return {
+      tmdbId: data.id,
+      name: data.name,
+      biography: data.biography?.trim() || null,
+      birthday: data.birthday ? new Date(data.birthday) : null,
+      deathday: data.deathday ? new Date(data.deathday) : null,
+      placeOfBirth: data.place_of_birth || null,
+      profilePath: data.profile_path || null,
+      knownForDepartment: data.known_for_department || null,
+      popularity: data.popularity ?? 0,
+    };
+  }
+
   /**
    * Converts raw TMDB API response to our Domain Model.
    * Returns null only if title is missing (essential for identification).

--- a/apps/api/src/modules/tmdb/public/index.ts
+++ b/apps/api/src/modules/tmdb/public/index.ts
@@ -13,3 +13,4 @@
 
 export { ALT_TITLE_COUNTRIES, MAX_ALT_TITLES } from '../constants/alt-title.constants';
 export { TmdbAdapter } from '../tmdb.adapter';
+export type { PersonDetails } from '../types/person.types';

--- a/apps/api/src/modules/tmdb/tmdb.adapter.spec.ts
+++ b/apps/api/src/modules/tmdb/tmdb.adapter.spec.ts
@@ -11,11 +11,16 @@ global.fetch = mockFetch;
 // Mock TmdbMapper - can be configured per test
 const mockToDomain = jest.fn();
 
-jest.mock('./mappers/tmdb.mapper', () => ({
-  TmdbMapper: {
-    toDomain: (data: any, type: any) => mockToDomain(data, type),
-  },
-}));
+jest.mock('./mappers/tmdb.mapper', () => {
+  const actual = jest.requireActual('./mappers/tmdb.mapper');
+  return {
+    TmdbMapper: {
+      toDomain: (data: any, type: any) => mockToDomain(data, type),
+      // Use the real person mapper so getPerson tests exercise actual mapping.
+      toPersonDetails: actual.TmdbMapper.toPersonDetails,
+    },
+  };
+});
 
 // Mock ResilientHttpClient to disable retries in tests
 jest.mock('@/common/http/resilient-http.client', () => {
@@ -714,6 +719,53 @@ describe('TmdbAdapter', () => {
       mockFetch.mockRejectedValue(new Error('Network error'));
 
       await expect(adapter.getMovie(550)).rejects.toThrow('Failed to communicate with TMDB');
+    });
+  });
+
+  describe('getPerson', () => {
+    it('fetches and maps person details', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            id: 287,
+            name: 'Brad Pitt',
+            biography: 'An American actor.',
+            birthday: '1963-12-18',
+            deathday: null,
+            place_of_birth: 'Shawnee, Oklahoma, USA',
+            profile_path: '/b.jpg',
+            known_for_department: 'Acting',
+            popularity: 42,
+          }),
+      });
+
+      const result = await adapter.getPerson(287);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/person/287'),
+        expect.anything(),
+      );
+      expect(result).toMatchObject({
+        tmdbId: 287,
+        name: 'Brad Pitt',
+        biography: 'An American actor.',
+        knownForDepartment: 'Acting',
+        popularity: 42,
+      });
+      expect(result?.birthday).toEqual(new Date('1963-12-18'));
+    });
+
+    it('returns null when the person is not found (404)', async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' });
+
+      expect(await adapter.getPerson(999999)).toBeNull();
+    });
+
+    it('throws on non-404 errors', async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 500, statusText: 'Server Error' });
+
+      await expect(adapter.getPerson(287)).rejects.toThrow(TmdbApiException);
     });
   });
 });

--- a/apps/api/src/modules/tmdb/tmdb.adapter.ts
+++ b/apps/api/src/modules/tmdb/tmdb.adapter.ts
@@ -22,10 +22,12 @@ import {
 } from '../ingestion/public';
 
 import { TmdbMapper } from './mappers/tmdb.mapper';
+import type { PersonDetails } from './types/person.types';
 import type {
   TmdbAlternativeTitle,
   TmdbMediaResponse,
   TmdbMovieResponse,
+  TmdbPersonResponse,
   TmdbSeasonDetailResponse,
 } from './types/tmdb-api.types';
 
@@ -208,6 +210,24 @@ export class TmdbAdapter implements MetadataProviderPort {
         return null;
       }
       this.logger.error(`TMDB getShow error for ${tmdbId}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Fetches person details (biography, photo, vital dates) from TMDB.
+   * Returns null if the person is not found (404).
+   */
+  public async getPerson(tmdbId: number): Promise<PersonDetails | null> {
+    try {
+      const data = await this.fetch<TmdbPersonResponse>(`/person/${tmdbId}`);
+      return TmdbMapper.toPersonDetails(data);
+    } catch (error) {
+      if (error instanceof TmdbApiException && error.details?.statusCode === HttpStatus.NOT_FOUND) {
+        this.logger.warn(`TMDB person ${tmdbId} not found (404)`);
+        return null;
+      }
+      this.logger.error(`TMDB getPerson error for ${tmdbId}:`, error);
       throw error;
     }
   }

--- a/apps/api/src/modules/tmdb/types/person.types.ts
+++ b/apps/api/src/modules/tmdb/types/person.types.ts
@@ -1,0 +1,17 @@
+/**
+ * Normalized person details returned by TmdbAdapter.getPerson().
+ *
+ * This is the boundary type consumed by the person module — raw TMDB shapes
+ * stay internal to the tmdb module.
+ */
+export interface PersonDetails {
+  tmdbId: number;
+  name: string;
+  biography: string | null;
+  birthday: Date | null;
+  deathday: Date | null;
+  placeOfBirth: string | null;
+  profilePath: string | null;
+  knownForDepartment: string | null;
+  popularity: number;
+}

--- a/apps/api/src/modules/tmdb/types/tmdb-api.types.ts
+++ b/apps/api/src/modules/tmdb/types/tmdb-api.types.ts
@@ -235,3 +235,18 @@ export interface TmdbSeasonDetailResponse {
  * Union type for TMDB API responses
  */
 export type TmdbMediaResponse = TmdbMovieResponse | TmdbShowResponse;
+
+/**
+ * TMDB person detail response (/person/{id})
+ */
+export interface TmdbPersonResponse {
+  id: number;
+  name: string;
+  biography: string | null;
+  birthday: string | null; // YYYY-MM-DD
+  deathday: string | null; // YYYY-MM-DD
+  place_of_birth: string | null;
+  profile_path: string | null;
+  known_for_department: string | null;
+  popularity: number;
+}

--- a/packages/api-contract/openapi.json
+++ b/packages/api-contract/openapi.json
@@ -6515,6 +6515,99 @@
         ]
       }
     },
+    "/api/ingestion/backfill/person-credits": {
+      "post": {
+        "operationId": "IngestionController_backfillPersonCredits",
+        "summary": "Backfill person credits read-model from existing credits",
+        "description": "Finds media items whose credits JSONB contains cast/crew and queues per-item jobs that upsert persons and rebuild media_credits rows. Pure DB work — no external API calls.",
+        "parameters": [
+          {
+            "name": "force",
+            "required": false,
+            "in": "query",
+            "description": "Bypass daily deduplication",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Backfill job queued",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/IngestionJobResponseDto"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation failed or malformed input",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid access token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Admin role required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Admin: Ingestion"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
     "/api/admin/catalog-policies": {
       "get": {
         "operationId": "PolicyController_getPolicies",
@@ -8385,6 +8478,196 @@
           {
             "bearer": []
           }
+        ]
+      }
+    },
+    "/api/persons/{tmdbId}": {
+      "get": {
+        "operationId": "PersonController_getPerson",
+        "summary": "Get person details by TMDB id",
+        "description": "Returns photo, biography and vital data for an actor/crew member. Biography is enriched from TMDB lazily on first request.",
+        "parameters": [
+          {
+            "name": "tmdbId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "example": 287,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/PersonResponseDto"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation failed or malformed input",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Public: Persons"
+        ]
+      }
+    },
+    "/api/persons/{tmdbId}/credits": {
+      "get": {
+        "operationId": "PersonController_getPersonCredits",
+        "summary": "Get a person's catalog works",
+        "description": "Lists the person's works that exist in the Ratingo catalog (eligible titles only), sorted by Ratingo score then release date. Filter with creditType=cast|crew.",
+        "parameters": [
+          {
+            "name": "tmdbId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "example": 287,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "minimum": 1,
+              "maximum": 50,
+              "default": 20,
+              "type": "number"
+            }
+          },
+          {
+            "name": "offset",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "minimum": 0,
+              "default": 0,
+              "type": "number"
+            }
+          },
+          {
+            "name": "creditType",
+            "required": false,
+            "in": "query",
+            "description": "Filter by cast or crew",
+            "schema": {
+              "enum": [
+                "cast",
+                "crew"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/PaginatedPersonCreditsResponseDto"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation failed or malformed input",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Public: Persons"
         ]
       }
     },
@@ -18586,6 +18869,156 @@
           "tmdbProviderId",
           "region",
           "found"
+        ]
+      },
+      "PersonResponseDto": {
+        "type": "object",
+        "properties": {
+          "tmdbId": {
+            "type": "number",
+            "example": 287
+          },
+          "slug": {
+            "type": "string",
+            "example": "brad-pitt"
+          },
+          "name": {
+            "type": "string",
+            "example": "Brad Pitt"
+          },
+          "profile": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ImageDto"
+              }
+            ]
+          },
+          "knownForDepartment": {
+            "type": "string",
+            "example": "Acting",
+            "nullable": true
+          },
+          "biography": {
+            "type": "string",
+            "example": "An American actor and film producer...",
+            "nullable": true
+          },
+          "birthday": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          },
+          "deathday": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          },
+          "placeOfBirth": {
+            "type": "string",
+            "example": "Shawnee, Oklahoma, USA",
+            "nullable": true
+          },
+          "popularity": {
+            "type": "number",
+            "example": 12.34
+          }
+        },
+        "required": [
+          "tmdbId",
+          "slug",
+          "name",
+          "popularity"
+        ]
+      },
+      "PersonCreditItemDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "movie",
+              "show"
+            ],
+            "example": "movie"
+          },
+          "tmdbId": {
+            "type": "number",
+            "example": 550
+          },
+          "title": {
+            "type": "string",
+            "example": "Fight Club"
+          },
+          "slug": {
+            "type": "string",
+            "example": "fight-club"
+          },
+          "poster": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ImageDto"
+              }
+            ]
+          },
+          "releaseDate": {
+            "format": "date-time",
+            "type": "string",
+            "nullable": true
+          },
+          "ratingoScore": {
+            "type": "number",
+            "example": 0.87,
+            "nullable": true
+          },
+          "character": {
+            "type": "string",
+            "example": "Tyler Durden",
+            "nullable": true,
+            "description": "Cast character on this title, if the person acted in it"
+          },
+          "jobs": {
+            "example": [
+              "Director"
+            ],
+            "description": "Crew jobs on this title (e.g. Director, Creator); empty if none",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "tmdbId",
+          "title",
+          "slug",
+          "character",
+          "jobs"
+        ]
+      },
+      "PaginatedPersonCreditsResponseDto": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PersonCreditItemDto"
+            }
+          },
+          "meta": {
+            "$ref": "#/components/schemas/OffsetPaginationMetaDto"
+          }
+        },
+        "required": [
+          "data",
+          "meta"
         ]
       },
       "HeroShowProgressDto": {

--- a/packages/api-contract/src/api-types.ts
+++ b/packages/api-contract/src/api-types.ts
@@ -1168,6 +1168,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/ingestion/backfill/person-credits": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Backfill person credits read-model from existing credits
+         * @description Finds media items whose credits JSONB contains cast/crew and queues per-item jobs that upsert persons and rebuild media_credits rows. Pure DB work — no external API calls.
+         */
+        post: operations["IngestionController_backfillPersonCredits"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/admin/catalog-policies": {
         parameters: {
             query?: never;
@@ -1492,6 +1512,46 @@ export interface paths {
          * @description Tests how a TMDB provider ID would be resolved to canonical provider. Useful for debugging mapping issues.
          */
         get: operations["ProvidersController_resolveProvider"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/persons/{tmdbId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get person details by TMDB id
+         * @description Returns photo, biography and vital data for an actor/crew member. Biography is enriched from TMDB lazily on first request.
+         */
+        get: operations["PersonController_getPerson"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/persons/{tmdbId}/credits": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get a person's catalog works
+         * @description Lists the person's works that exist in the Ratingo catalog (eligible titles only), sorted by Ratingo score then release date. Filter with creditType=cast|crew.
+         */
+        get: operations["PersonController_getPersonCredits"];
         put?: never;
         post?: never;
         delete?: never;
@@ -5156,6 +5216,63 @@ export interface components {
              * @example region
              */
             source?: string;
+        };
+        PersonResponseDto: {
+            /** @example 287 */
+            tmdbId: number;
+            /** @example brad-pitt */
+            slug: string;
+            /** @example Brad Pitt */
+            name: string;
+            profile?: components["schemas"]["ImageDto"] | null;
+            /** @example Acting */
+            knownForDepartment?: string | null;
+            /** @example An American actor and film producer... */
+            biography?: string | null;
+            /** Format: date-time */
+            birthday?: string | null;
+            /** Format: date-time */
+            deathday?: string | null;
+            /** @example Shawnee, Oklahoma, USA */
+            placeOfBirth?: string | null;
+            /** @example 12.34 */
+            popularity: number;
+        };
+        PersonCreditItemDto: {
+            /** @example 123e4567-e89b-12d3-a456-426614174000 */
+            id: string;
+            /**
+             * @example movie
+             * @enum {string}
+             */
+            type: "movie" | "show";
+            /** @example 550 */
+            tmdbId: number;
+            /** @example Fight Club */
+            title: string;
+            /** @example fight-club */
+            slug: string;
+            poster?: components["schemas"]["ImageDto"] | null;
+            /** Format: date-time */
+            releaseDate?: string | null;
+            /** @example 0.87 */
+            ratingoScore?: number | null;
+            /**
+             * @description Cast character on this title, if the person acted in it
+             * @example Tyler Durden
+             */
+            character: string | null;
+            /**
+             * @description Crew jobs on this title (e.g. Director, Creator); empty if none
+             * @example [
+             *       "Director"
+             *     ]
+             */
+            jobs: string[];
+        };
+        PaginatedPersonCreditsResponseDto: {
+            data: components["schemas"]["PersonCreditItemDto"][];
+            meta: components["schemas"]["OffsetPaginationMetaDto"];
         };
         HeroShowProgressDto: {
             /** @example 5 */
@@ -9963,6 +10080,69 @@ export interface operations {
             };
         };
     };
+    IngestionController_backfillPersonCredits: {
+        parameters: {
+            query?: {
+                /** @description Bypass daily deduplication */
+                force?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Backfill job queued */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {boolean} */
+                        success: true;
+                        data: components["schemas"]["IngestionJobResponseDto"];
+                    };
+                };
+            };
+            /** @description Validation failed or malformed input */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Missing or invalid access token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Admin role required */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
     PolicyController_getPolicies: {
         parameters: {
             query?: never;
@@ -11209,6 +11389,115 @@ export interface operations {
             };
             /** @description Admin role required */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    PersonController_getPerson: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                tmdbId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {boolean} */
+                        success: true;
+                        data: components["schemas"]["PersonResponseDto"];
+                    };
+                };
+            };
+            /** @description Validation failed or malformed input */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    PersonController_getPersonCredits: {
+        parameters: {
+            query?: {
+                limit?: number;
+                offset?: number;
+                /** @description Filter by cast or crew */
+                creditType?: "cast" | "crew";
+            };
+            header?: never;
+            path: {
+                tmdbId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {boolean} */
+                        success: true;
+                        data: components["schemas"]["PaginatedPersonCreditsResponseDto"];
+                    };
+                };
+            };
+            /** @description Validation failed or malformed input */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Resource not found */
+            404: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
Закриває #87 — клік на актора відкриває сторінку з фото, короткою біографією та списком робіт («Відомий за…»). Це бекенд-частина.

## Що додано

**Новий модуль `person`** (4-шарова чиста архітектура) з двома публічними ендпоінтами:
- `GET /persons/:tmdbId` — фото + біографія + дата/місце народження.
- `GET /persons/:tmdbId/credits` — роботи з нашого каталогу, **один рядок на тайтл** (cast/crew змержені в `character` + `jobs[]`), пагінація, фільтр `creditType=cast|crew`.

**Нормалізований read-model:** таблиці `persons` + `media_credits` (міграція `0029`), за патерном `genres`/`seasons`.

**Наповнення:**
- під час інжесту (`PersonCreditsWriterService`, best-effort крок у `SyncMediaService`);
- разова backfill-джоба по наявних `media_items.credits` (`POST /ingestion/backfill/person-credits`).

**Біографія/фото** підтягуються ліниво з TMDB `/person/{id}` на першому запиті й персистяться (`detailsFetchedAt` як кеш + TTL); додано `TmdbAdapter.getPerson`.

**Видимість:** список робіт перевикористовує eligibility-join каталогу (активна політика + `context=catalog` + `eligible` + `ready`), тож кожна робота має реальну сторінку.

**Контракти:** перегенеровано OpenAPI + типи (`packages/api-contract`).

## Тести / перевірка
- Unit на всіх шарах (вкл. property-based на маппінг credits), 294 suites / 3980 тестів зелені; lint/tsc чисто.
- Перевірено **e2e наживо** проти реального сервера + БД (бекфіл наповнив ~1.5k персон; ендпоінти повертають коректні дані, 404/400, lazy-enrich персиститься).

## Нотатки
- Показуємо лише роботи з нашого каталогу (не всю фільмографію TMDB) — свідоме рішення.
- Crew під час інжесту обмежений режисером/творцем, cast — топ-10 (наявне обмеження мапера); за потреби розширюється окремо.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added person profiles API with biographical details and enrichment support
  * Added person credits/filmography endpoint with pagination and cast/crew filtering
  * Added backfill capability for normalizing existing cast and crew data

* **Chores**
  * Database migration for person profiles and credits normalization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->